### PR TITLE
Nix build on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,9 @@ clean:
 	rm -f arbitrator/wasm-libraries/soft-float/SoftFloat/build/Wasm-Clang/*.a
 	@rm -rf contracts/build contracts/cache solgen/go/
 	@rm -f .make/*
+	# Ensure lib64 is a symlink to lib
+	mkdir -p $(output_root)/lib
+	ln -s lib $(output_root)/lib64
 
 docker:
 	docker build -t nitro-node-slim --target nitro-node-slim .

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
           # Prevent cargo aliases from using programs in `~/.cargo` to avoid conflicts
           # with rustup installations.
           export CARGO_HOME=$HOME/.cargo-nix
+          export DOCKER_BUILDKIT=1
 
           # Create a target directory and ensure lib64 is a symlink to lib.
           # Individual build steps may target either directory and later


### PR DESCRIPTION
- Workaround issue with target/lib64 symlink.
- Disable stack protector.
- Use clang to build everything (I hope).
- Install a `cc` with nix to avoid falling back to the system installed
  version.

Close https://github.com/EspressoSystems/espresso-sequencer/issues/727