### PR TITLE
Keep all transactions in Batch

### DIFF
--- a/execution/gethexec/block_recorder.go
+++ b/execution/gethexec/block_recorder.go
@@ -140,7 +140,6 @@ func (r *BlockRecorder) RecordBlockCreation(
 			msg.Message,
 			msg.DelayedMessagesRead,
 			prevHeader,
-			nil,
 			recordingdb,
 			chaincontext,
 			chainConfig,

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -17,7 +17,6 @@ import (
 	"github.com/offchainlabs/nitro/arbos"
 	"github.com/offchainlabs/nitro/arbos/arbosState"
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
-	"github.com/offchainlabs/nitro/arbos/espresso"
 	"github.com/offchainlabs/nitro/arbos/l1pricing"
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/execution"
@@ -498,17 +497,11 @@ func (s *ExecutionEngine) createBlockFromNextMessage(msg *arbostypes.MessageWith
 	}
 	statedb.StartPrefetcher("TransactionStreamer")
 	defer statedb.StopPrefetcher()
-	jst := msg.Message.Header.BlockJustification
-	var hotShotCommitment espresso.Commitment
-	if jst != nil {
-		hotShotCommitment = jst.Header.Commit()
-	}
 
 	block, receipts, err := arbos.ProduceBlock(
 		msg.Message,
 		msg.DelayedMessagesRead,
 		currentHeader,
-		&hotShotCommitment,
 		statedb,
 		s.bc,
 		s.bc.Config(),

--- a/system_tests/state_fuzz_test.go
+++ b/system_tests/state_fuzz_test.go
@@ -56,7 +56,7 @@ func BuildBlock(
 		return seqBatch, nil
 	}
 	block, _, err := arbos.ProduceBlock(
-		l1Message, delayedMessagesRead, lastBlockHeader, nil, statedb, chainContext, chainConfig, batchFetcher,
+		l1Message, delayedMessagesRead, lastBlockHeader, statedb, chainContext, chainConfig, batchFetcher,
 	)
 	return block, err
 }


### PR DESCRIPTION
Regarding https://github.com/EspressoSystems/espresso-sequencer/issues/763

@sveitser's attempt at summarizing the change:

The main ideas

1. Arbitrum sequencer now builds a batch (aka an `L1IncomingMessage` with `L2msg` of kind `L2MessageKind_Batch`) with all the transactions instead of filtering out invalid ones.
2. A new kind of L2 message `L2MessageKind_EspressoTx = 10` is used for espresso transactions so that they can be parsed differently than `L2MessageKind_SignedTx`.

During replay the messages from the sequencer to the L1 inbox are read into the wasm VM. Since all transactions are contained in the message they are now available in the wasm VM and we can validate that the transactions sequenced by hotshot are the same as the ones sent to the inbox.

During sequencing and validation the same code is used to produce blocks. Therefore a honest sequencer and validator should still produce the same results.

@ImJeremyHe's complements:
I'd like to highlight a couple of aspects in the L2's block validation process.

- instead of validating transaction root, receipt root, or block hash separately, Arbitrum validates a block by reproducing it with the same input and comparing through the block hash.
-  `message` is a critical factor in this process, as it provides the necessary data for accurate block reproduction.
- `ProduceBlockAdvanced` will execute the user transactions and filter out all the invalid transactions even though a noop-hooks is set.
- `ProduceBlock` parses the transactions from the messages and then executes the `ProduceBlockAdvanced`.
- A user tx can yield other txs and they will be packed in the same block
- `message` is built from all the *valid user* transactions (making a smaller size).
- Based on the above two points, using the message and `ProduceBlockAdvanced` function can create the same block for validators.

For Arbitrum sequencer:
User Txs ->`ProduceBlockAdvanced`(Get a block here) -> User Valid Txs. -> Message -> Append the block

For Validators:
Message -> `ProduceBlock` -> User Valid Txs -> `ProduceBlockAdvancd`(Get a block here) -> Validate

In this change:
For sequencer:
Raw data from HotShot -> Message -> `ProduceBlock` -> User Txs (exclude the malformed txs here) -> `ProduceBlockAdvanced`(Get a block here) -> Append the block

For validators:
Message -> Validate The Message(todo, check the commitment) -> `ProduceBlock` -> User Txs (exclude the malformed txs here) -> `ProduceBlockAdvanced` -> Validate

A little trick here is that we don't attempt to make the `message` as smaller as it could. We just make the `message` contains all the information from HotShot and that's why we get the `message` at first while arbitrum get the message after creating a block.