### PR TITLE
Regard the BlockJustification as a part of L2Msg

### DIFF
--- a/arbos/arbostypes/incomingmessage.go
+++ b/arbos/arbostypes/incomingmessage.go
@@ -41,13 +41,12 @@ type EspressoBlockJustification struct {
 }
 
 type L1IncomingMessageHeader struct {
-	Kind               uint8                       `json:"kind"`
-	Poster             common.Address              `json:"sender"`
-	BlockNumber        uint64                      `json:"blockNumber"`
-	Timestamp          uint64                      `json:"timestamp"`
-	RequestId          *common.Hash                `json:"requestId" rlp:"nilList"`
-	L1BaseFee          *big.Int                    `json:"baseFeeL1"`
-	BlockJustification *EspressoBlockJustification `json:"justification,omitempty" rlp:"optional"`
+	Kind        uint8          `json:"kind"`
+	Poster      common.Address `json:"sender"`
+	BlockNumber uint64         `json:"blockNumber"`
+	Timestamp   uint64         `json:"timestamp"`
+	RequestId   *common.Hash   `json:"requestId" rlp:"nilList"`
+	L1BaseFee   *big.Int       `json:"baseFeeL1"`
 }
 
 func (h L1IncomingMessageHeader) SeqNum() (uint64, error) {
@@ -235,7 +234,6 @@ func ParseIncomingL1Message(rd io.Reader, batchFetcher FallibleBatchFetcher) (*L
 			timestamp,
 			&requestId,
 			baseFeeL1.Big(),
-			nil,
 		},
 		data,
 		nil,

--- a/arbos/parse_l2_test.go
+++ b/arbos/parse_l2_test.go
@@ -1,0 +1,44 @@
+package arbos
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/offchainlabs/nitro/arbos/arbostypes"
+	"github.com/offchainlabs/nitro/arbos/espresso"
+)
+
+func TestEspressoParsing(t *testing.T) {
+	expectTxes := []espresso.Bytes{
+		[]byte{1, 2, 3},
+		[]byte{4},
+	}
+	expectHeader := &arbostypes.L1IncomingMessageHeader{
+		Kind:        arbostypes.L1MessageType_L2Message,
+		BlockNumber: 1,
+	}
+	expectJst := &arbostypes.EspressoBlockJustification{
+		Header: espresso.Header{
+			TransactionsRoot: espresso.NmtRoot{Root: []byte{7, 8, 9}},
+			Metadata: espresso.Metadata{
+				L1Head:    1,
+				Timestamp: 2,
+			},
+		},
+		Proof: []byte{9},
+	}
+	msg, err := MessageFromEspresso(expectHeader, expectTxes, expectJst)
+	Require(t, err)
+
+	actualTxes, actualJst, err := ParseEspressoMsg(&msg)
+	Require(t, err)
+
+	if !reflect.DeepEqual(actualTxes, expectTxes) {
+		Fail(t)
+	}
+
+	if !reflect.DeepEqual(actualJst, expectJst) {
+		Fail(t)
+	}
+
+}

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -250,22 +250,20 @@ func main() {
 		// TODO test: https://github.com/EspressoSystems/espresso-sequencer/issues/772
 		if chainConfig.Espresso {
 			hotShotCommitment := getHotShotCommitment(seqNum)
-			jst := message.Message.Header.BlockJustification
+			txs, jst, err := arbos.ParseEspressoMsg(message.Message)
+			if err != nil {
+				panic(err)
+			}
 			if jst == nil {
 				panic("batch missing espresso justification")
-
 			}
 			hotshotHeader := jst.Header
 			if *hotShotCommitment != hotshotHeader.Commit() {
 				panic("invalid hotshot header")
 			}
 			var roots = []*espresso.NmtRoot{&hotshotHeader.TransactionsRoot}
-			var proofs = []*espresso.NmtProof{&message.Message.Header.BlockJustification.Proof}
+			var proofs = []*espresso.NmtProof{&jst.Proof}
 
-			txs, err := arbos.ParseEspressoTransactions(message.Message)
-			if err != nil {
-				panic(err)
-			}
 			err = espresso.ValidateBatchTransactions(chainConfig.ChainID.Uint64(), roots, proofs, txs)
 			if err != nil {
 				panic(err)

--- a/execution/gethexec/espresso_sequencer.go
+++ b/execution/gethexec/espresso_sequencer.go
@@ -85,13 +85,14 @@ func (s *EspressoSequencer) createBlock(ctx context.Context) (returnValue bool) 
 		Timestamp:   header.Timestamp,
 		RequestId:   nil,
 		L1BaseFee:   nil,
-		BlockJustification: &arbostypes.EspressoBlockJustification{
-			Header: header,
-			Proof:  arbTxns.Proof,
-		},
 	}
 
-	_, err = s.execEngine.SequenceTransactionsEspresso(arbHeader, arbTxns.Transactions)
+	jst := &arbostypes.EspressoBlockJustification{
+		Header: header,
+		Proof:  arbTxns.Proof,
+	}
+
+	_, err = s.execEngine.SequenceTransactionsEspresso(arbHeader, arbTxns.Transactions, jst)
 	if err != nil {
 		log.Error("Sequencing error for block number", "block_num", nextSeqBlockNum, "err", err)
 		return false


### PR DESCRIPTION
In this PR:
- As comments in #14 suggest, use a total different way from what the nitro does to serialize the `message`
- As [here](https://github.com/EspressoSystems/espresso-sequencer/issues/781) suggests, regard the BlockJustification as a part of L2Msg to let it be serialized with the batch data
- Move the `MessageFromEspresso` to arbos folder and add a test for serializing and parsing