### PR TITLE
Validation pipeline updates: Associate hotshot commitments with Arb messages correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -369,6 +369,9 @@ generate-hotshot-binding:
 	abigen --abi ./arbos/espresso/hotshot/HotShot.abi.json --pkg hotshot --out ./arbos/espresso/hotshot/hotshot.go
 	rm ./arbos/espresso/hotshot/HotShot.abi.json
 
+local-sequencer:
+	./target/bin/nitro --conf.file ./config/sequencer_config.json --node.feed.output.enable --node.feed.output.port 9642  --http.api net,web3,eth,txpool,debug --node.seq-coordinator.my-url  ws://localhost:8548 --graphql.enable --execution.sequencer.espresso --execution.sequencer.hotshot-url "http://localhost:50000" --execution.rpc.espresso --execution.rpc.hotshot-url "http://localhost:50000" --execution.rpc.espresso-namespace 1 --execution.sequencer.espresso-namespace 1
+
 # Makefile settings
 
 always:              # use this to force other rules to always build

--- a/Makefile
+++ b/Makefile
@@ -372,6 +372,9 @@ generate-hotshot-binding:
 local-sequencer:
 	./target/bin/nitro --conf.file ./config/sequencer_config.json --node.feed.output.enable --node.feed.output.port 9642  --http.api net,web3,eth,txpool,debug --node.seq-coordinator.my-url  ws://localhost:8548 --graphql.enable --execution.sequencer.espresso --execution.sequencer.hotshot-url "http://localhost:50000" --execution.rpc.espresso --execution.rpc.hotshot-url "http://localhost:50000" --execution.rpc.espresso-namespace 1 --execution.sequencer.espresso-namespace 1
 
+local-validator:
+	./target/bin/nitro --conf.file ./config/validator_config.json --http.port 8247 --http.api net,web3,arb,debug --ws.port 8548
+
 # Makefile settings
 
 always:              # use this to force other rules to always build

--- a/arbitrator/jit/src/machine.rs
+++ b/arbitrator/jit/src/machine.rs
@@ -185,7 +185,7 @@ impl From<RuntimeError> for Escape {
 
 pub type WasmEnvMut<'a> = FunctionEnvMut<'a, WasmEnv>;
 pub type Inbox = BTreeMap<u64, Vec<u8>>;
-pub type HotShotCommitmentMap = BTreeMap<u64, [u8; 32]>;
+pub type HotShotCommitmentMap = BTreeMap<(u64, u64), [u8; 32]>;
 pub type Preimages = BTreeMap<PreimageType, BTreeMap<[u8; 32], Vec<u8>>>;
 
 #[derive(Default)]

--- a/arbitrator/jit/src/wavmio.rs
+++ b/arbitrator/jit/src/wavmio.rs
@@ -302,7 +302,6 @@ fn ready_hostio(env: &mut WasmEnv) -> MaybeEscape {
     let last_block_hash = socket::read_bytes32(stream)?;
     let last_send_root = socket::read_bytes32(stream)?;
     let hotshot_comm = socket::read_bytes32(stream)?;
-    // Debug step: panic here, if the commitment gets read here, try making it a global somehow
 
     env.small_globals = [inbox_position, position_within_message];
     env.large_globals = [last_block_hash, last_send_root];

--- a/arbitrator/jit/src/wavmio.rs
+++ b/arbitrator/jit/src/wavmio.rs
@@ -302,6 +302,7 @@ fn ready_hostio(env: &mut WasmEnv) -> MaybeEscape {
     let last_block_hash = socket::read_bytes32(stream)?;
     let last_send_root = socket::read_bytes32(stream)?;
     let hotshot_comm = socket::read_bytes32(stream)?;
+    // Debug step: panic here, if the commitment gets read here, try making it a global somehow
 
     env.small_globals = [inbox_position, position_within_message];
     env.large_globals = [last_block_hash, last_send_root];

--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -623,16 +623,13 @@ func (t *InboxTracker) AddSequencerBatches(ctx context.Context, client arbutil.L
 		}
 		messages = append(messages, *msg)
 		// Update the count of l2 sequenced messages
+		// Note that since it is possible for this method to see duplicate batches,
+		// We use a boolean map to make sure that we increment the espresso batch count
+		// For every unique batch
 		msgKind := msg.Message.Header.Kind
-		log.Info("message kind", "msg knid", msgKind)
-		log.Info("batch seq number", "number", batchSeqNum)
-		log.Info("current bathc message count", "count", batchSeqNum)
 		if msgKind == 3 && !sequencerBatchDetected[batchSeqNum] {
 			t.espressoBatchNum += 1
-			log.Info("Detected espresso batch, incrementing count to", "count", t.espressoBatchNum)
 			sequencerBatchDetected[batchSeqNum] = true
-		} else {
-			log.Info("Batch does not contain justification")
 		}
 		batchMessageCounts[batchSeqNum] = currentpos
 		currentpos += 1

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -47,8 +47,8 @@ func getBlockHeaderByHash(hash common.Hash) *types.Header {
 	return header
 }
 
-func getHotShotCommitment(seqNum uint64) *espresso.Commitment {
-	headerBytes := espresso.Commitment(wavmio.ReadHotShotCommitment(seqNum))
+func getHotShotCommitment(pos uint64, posInBatch uint64) *espresso.Commitment {
+	headerBytes := espresso.Commitment(wavmio.ReadHotShotCommitment(pos, posInBatch))
 	log.Info("HotShot commitment", "commit", headerBytes)
 	return &headerBytes
 }

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -255,8 +255,8 @@ func main() {
 				panic("batch missing espresso justification")
 			}
 			hotshotHeader := jst.Header
-			debugComm := espresso.Commitment(wavmio.ReadHotShotCommitment(inboxPos, posInInbox))
-			if !debugComm.Equals(hotshotHeader.Commit()) {
+			commitment := espresso.Commitment(wavmio.ReadHotShotCommitment(inboxPos, posInInbox))
+			if !commitment.Equals(hotshotHeader.Commit()) {
 				panic(fmt.Sprintf("invalid hotshot header jst header: %v, provided %v. seqNum %v posInInbox %v", hotshotHeader.Commit(), debugComm, inboxPos, posInInbox))
 			}
 			var roots = []*espresso.NmtRoot{&hotshotHeader.TransactionsRoot}

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -257,7 +257,7 @@ func main() {
 			hotshotHeader := jst.Header
 			commitment := espresso.Commitment(wavmio.ReadHotShotCommitment(inboxPos, posInInbox))
 			if !commitment.Equals(hotshotHeader.Commit()) {
-				panic(fmt.Sprintf("invalid hotshot header jst header: %v, provided %v. seqNum %v posInInbox %v", hotshotHeader.Commit(), debugComm, inboxPos, posInInbox))
+				panic(fmt.Sprintf("invalid hotshot header jst header: %v, provided %v. seqNum %v posInInbox %v", hotshotHeader.Commit(), commitment, inboxPos, posInInbox))
 			}
 			var roots = []*espresso.NmtRoot{&hotshotHeader.TransactionsRoot}
 			var proofs = []*espresso.NmtProof{&jst.Proof}

--- a/execution/gethexec/espresso_sequencer.go
+++ b/execution/gethexec/espresso_sequencer.go
@@ -73,11 +73,6 @@ func (s *EspressoSequencer) createBlock(ctx context.Context) (returnValue bool) 
 
 	}
 
-	if len(arbTxns.Transactions) == 0 {
-		s.hotShotState.advance()
-		return true
-	}
-
 	arbHeader := &arbostypes.L1IncomingMessageHeader{
 		Kind:        arbostypes.L1MessageType_L2Message,
 		Poster:      l1pricing.BatchPosterAddress,

--- a/staker/stateless_block_validator.go
+++ b/staker/stateless_block_validator.go
@@ -58,6 +58,7 @@ type InboxTrackerInterface interface {
 	GetDelayedMessageBytes(uint64) ([]byte, error)
 	GetBatchMessageCount(seqNum uint64) (arbutil.MessageIndex, error)
 	GetBatchAcc(seqNum uint64) (common.Hash, error)
+	GetSequencerBatchCount() uint64
 	GetBatchCount() (uint64, error)
 }
 
@@ -306,7 +307,7 @@ func (v *StatelessBlockValidator) ValidationEntryRecord(ctx context.Context, e *
 		if usingEspresso {
 			// TODO: Use the inbox tracker to fetch the correct HotShot index
 			// https://github.com/EspressoSystems/espresso-sequencer/issues/782
-			batchNum := batch.Number
+			batchNum := v.inboxTracker.GetSequencerBatchCount()
 			hotShotCommitment, err := v.hotShotReader.L1HotShotCommitmentFromHeight(batchNum)
 			if err != nil {
 				return fmt.Errorf("error attempting to fetch HotShot commitment for block %d: %w", batchNum, err)

--- a/staker/stateless_block_validator.go
+++ b/staker/stateless_block_validator.go
@@ -304,7 +304,8 @@ func (v *StatelessBlockValidator) ValidationEntryRecord(ctx context.Context, e *
 		e.DelayedMsg = delayedMsg
 	}
 	for i, batch := range e.BatchInfo {
-		if usingEspresso {
+		// Only fetch commitments for L2 message batches
+		if usingEspresso && e.msg.Message.Header.Kind == 3 {
 			hotShotIndex := v.inboxTracker.GetSequencerBatchCount()
 			hotShotCommitment, err := v.hotShotReader.L1HotShotCommitmentFromHeight(hotShotIndex)
 			if err != nil {

--- a/staker/stateless_block_validator.go
+++ b/staker/stateless_block_validator.go
@@ -305,15 +305,13 @@ func (v *StatelessBlockValidator) ValidationEntryRecord(ctx context.Context, e *
 	}
 	for i, batch := range e.BatchInfo {
 		if usingEspresso {
-			// TODO: Use the inbox tracker to fetch the correct HotShot index
-			// https://github.com/EspressoSystems/espresso-sequencer/issues/782
-			batchNum := v.inboxTracker.GetSequencerBatchCount()
-			hotShotCommitment, err := v.hotShotReader.L1HotShotCommitmentFromHeight(batchNum)
+			hotShotIndex := v.inboxTracker.GetSequencerBatchCount()
+			hotShotCommitment, err := v.hotShotReader.L1HotShotCommitmentFromHeight(hotShotIndex)
 			if err != nil {
-				return fmt.Errorf("error attempting to fetch HotShot commitment for block %d: %w", batchNum, err)
+				return fmt.Errorf("error attempting to fetch HotShot commitment for height %d: %w", hotShotIndex, err)
 
 			}
-			log.Info("fetched HotShot commitment", "batchNum", batchNum, "commitment", hotShotCommitment)
+			log.Info("fetched HotShot commitment", "index", hotShotIndex, "commitment", hotShotCommitment)
 			e.BatchInfo[i].HotShotCommitment = *hotShotCommitment
 		}
 		if len(batch.Data) <= 40 {

--- a/staker/stateless_block_validator.go
+++ b/staker/stateless_block_validator.go
@@ -47,8 +47,6 @@ type StatelessBlockValidator struct {
 	moduleMutex           sync.Mutex
 	currentWasmModuleRoot common.Hash
 	pendingWasmModuleRoot common.Hash
-
-	testIndex uint64
 }
 
 type BlockValidatorRegistrer interface {
@@ -308,7 +306,7 @@ func (v *StatelessBlockValidator) ValidationEntryRecord(ctx context.Context, e *
 		e.DelayedMsg = delayedMsg
 	}
 
-	if usingEspresso && e.msg.Message.Header.Kind == 3 {
+	if usingEspresso && e.msg.Message.Header.Kind == arbostypes.L1MessageType_L2Message {
 		hotShotIndex := v.inboxTracker.MessageIndexToHotShotIndex(e.Pos)
 		hotShotCommitment, err := v.hotShotReader.L1HotShotCommitmentFromHeight(hotShotIndex)
 		if err != nil {

--- a/staker/stateless_block_validator.go
+++ b/staker/stateless_block_validator.go
@@ -315,8 +315,6 @@ func (v *StatelessBlockValidator) ValidationEntryRecord(ctx context.Context, e *
 			return fmt.Errorf("error attempting to fetch HotShot commitment for height %d: %w", hotShotIndex, err)
 
 		}
-		log.Info("fetched HotShot commitment", "batch", hotShotIndex, "msg index", e.Pos, "commitment", hotShotCommitment)
-		log.Info("batches", "start batch", e.Start.Batch, "pos in batch", e.Start.PosInBatch, "end", e.End.Batch, "pos in batch", e.End.PosInBatch)
 		e.HotShotCommitment = *hotShotCommitment
 	}
 

--- a/system_tests/espresso_test.go
+++ b/system_tests/espresso_test.go
@@ -19,19 +19,19 @@ import (
 )
 
 var (
-	validationPort    = 54320
-	broadcastPort     = 9642
-	maxHotShotBlock   = 100
-	malformedBlockNum = 5
-	firstGoodBlockNum = 15
-	seconGoodBlockNum = 25
+	validationPort     = 54320
+	broadcastPort      = 9642
+	maxHotShotBlock    = 100
+	malformedBlockNum  = 5
+	firstGoodBlockNum  = 15
+	secondGoodBlockNum = 25
 )
 
 func espresso_block_txs_generators(t *testing.T, l2Info *BlockchainTestInfo) map[int][][]byte {
 	return map[int][][]byte{
 		malformedBlockNum: onlyMalformedTxs(t),
 		firstGoodBlockNum: userTxs(t, l2Info),
-		seconGoodBlockNum: func(t *testing.T) [][]byte {
+		secondGoodBlockNum: func(t *testing.T) [][]byte {
 			// Contains malformed txes, valid transactions and invalid transactions
 			r := [][]byte{}
 			r = append(r, onlyMalformedTxs(t)...)
@@ -275,6 +275,6 @@ func TestEspresso(t *testing.T) {
 	Require(t, err)
 
 	if len(block3.Body().Transactions) != 3 {
-		Fatal(t, "block", seconGoodBlockNum, " should contain 2 valid transactions")
+		Fatal(t, "block", secondGoodBlockNum, " should contain 2 valid transactions")
 	}
 }

--- a/validator/server_api/json.go
+++ b/validator/server_api/json.go
@@ -14,19 +14,19 @@ import (
 )
 
 type BatchInfoJson struct {
-	HotShotCommitment espresso.Commitment
-	Number            uint64
-	DataB64           string
+	Number  uint64
+	DataB64 string
 }
 
 type ValidationInputJson struct {
-	Id            uint64
-	HasDelayedMsg bool
-	DelayedMsgNr  uint64
-	PreimagesB64  map[arbutil.PreimageType]*jsonapi.PreimagesMapJson
-	BatchInfo     []BatchInfoJson
-	DelayedMsgB64 string
-	StartState    validator.GoGlobalState
+	Id                uint64
+	HasDelayedMsg     bool
+	DelayedMsgNr      uint64
+	PreimagesB64      map[arbutil.PreimageType]*jsonapi.PreimagesMapJson
+	BatchInfo         []BatchInfoJson
+	HotShotCommitment espresso.Commitment
+	DelayedMsgB64     string
+	StartState        validator.GoGlobalState
 }
 
 func ValidationInputToJson(entry *validator.ValidationInput) *ValidationInputJson {
@@ -35,16 +35,17 @@ func ValidationInputToJson(entry *validator.ValidationInput) *ValidationInputJso
 		jsonPreimagesMap[ty] = jsonapi.NewPreimagesMapJson(preimages)
 	}
 	res := &ValidationInputJson{
-		Id:            entry.Id,
-		HasDelayedMsg: entry.HasDelayedMsg,
-		DelayedMsgNr:  entry.DelayedMsgNr,
-		DelayedMsgB64: base64.StdEncoding.EncodeToString(entry.DelayedMsg),
-		StartState:    entry.StartState,
-		PreimagesB64:  jsonPreimagesMap,
+		Id:                entry.Id,
+		HasDelayedMsg:     entry.HasDelayedMsg,
+		DelayedMsgNr:      entry.DelayedMsgNr,
+		DelayedMsgB64:     base64.StdEncoding.EncodeToString(entry.DelayedMsg),
+		StartState:        entry.StartState,
+		HotShotCommitment: entry.HotShotCommitment,
+		PreimagesB64:      jsonPreimagesMap,
 	}
 	for _, binfo := range entry.BatchInfo {
 		encData := base64.StdEncoding.EncodeToString(binfo.Data)
-		res.BatchInfo = append(res.BatchInfo, BatchInfoJson{Number: binfo.Number, DataB64: encData, HotShotCommitment: binfo.HotShotCommitment})
+		res.BatchInfo = append(res.BatchInfo, BatchInfoJson{Number: binfo.Number, DataB64: encData})
 	}
 	return res
 }
@@ -55,11 +56,12 @@ func ValidationInputFromJson(entry *ValidationInputJson) (*validator.ValidationI
 		preimages[ty] = jsonPreimages.Map
 	}
 	valInput := &validator.ValidationInput{
-		Id:            entry.Id,
-		HasDelayedMsg: entry.HasDelayedMsg,
-		DelayedMsgNr:  entry.DelayedMsgNr,
-		StartState:    entry.StartState,
-		Preimages:     preimages,
+		Id:                entry.Id,
+		HasDelayedMsg:     entry.HasDelayedMsg,
+		DelayedMsgNr:      entry.DelayedMsgNr,
+		StartState:        entry.StartState,
+		HotShotCommitment: entry.HotShotCommitment,
+		Preimages:         preimages,
 	}
 	delayed, err := base64.StdEncoding.DecodeString(entry.DelayedMsgB64)
 	if err != nil {
@@ -72,9 +74,8 @@ func ValidationInputFromJson(entry *ValidationInputJson) (*validator.ValidationI
 			return nil, err
 		}
 		decInfo := validator.BatchInfo{
-			Number:            binfo.Number,
-			Data:              data,
-			HotShotCommitment: binfo.HotShotCommitment,
+			Number: binfo.Number,
+			Data:   data,
 		}
 		valInput.BatchInfo = append(valInput.BatchInfo, decInfo)
 	}

--- a/validator/server_jit/jit_machine.go
+++ b/validator/server_jit/jit_machine.go
@@ -139,6 +139,10 @@ func (machine *JitMachine) prove(
 	if err := writeExact(entry.StartState.SendRoot[:]); err != nil {
 		return state, err
 	}
+	log.Info("validating with hotshot commitment", "commitment", entry.HotShotCommitment)
+	if err := writeExact(entry.HotShotCommitment[:]); err != nil {
+		return state, err
+	}
 
 	const successByte = 0x0
 	const failureByte = 0x1
@@ -149,9 +153,10 @@ func (machine *JitMachine) prove(
 	another := []byte{anotherByte}
 	ready := []byte{readyByte}
 
+	log.Info("here are the indices", "validation id", entry.Id, "inbox position", entry.StartState.Batch, "pos in batch", entry.StartState.PosInBatch)
+
 	// send inbox
 	for _, batch := range entry.BatchInfo {
-		log.Info("validating with hotshot commitment", "commitment", batch.HotShotCommitment)
 		if err := writeExact(another); err != nil {
 			return state, err
 		}
@@ -159,9 +164,6 @@ func (machine *JitMachine) prove(
 			return state, err
 		}
 		if err := writeBytes(batch.Data); err != nil {
-			return state, err
-		}
-		if err := writeExact(batch.HotShotCommitment[:]); err != nil {
 			return state, err
 		}
 	}

--- a/validator/server_jit/jit_machine.go
+++ b/validator/server_jit/jit_machine.go
@@ -139,7 +139,6 @@ func (machine *JitMachine) prove(
 	if err := writeExact(entry.StartState.SendRoot[:]); err != nil {
 		return state, err
 	}
-	log.Info("validating with hotshot commitment", "commitment", entry.HotShotCommitment)
 	if err := writeExact(entry.HotShotCommitment[:]); err != nil {
 		return state, err
 	}
@@ -152,8 +151,6 @@ func (machine *JitMachine) prove(
 	success := []byte{successByte}
 	another := []byte{anotherByte}
 	ready := []byte{readyByte}
-
-	log.Info("here are the indices", "validation id", entry.Id, "inbox position", entry.StartState.Batch, "pos in batch", entry.StartState.PosInBatch)
 
 	// send inbox
 	for _, batch := range entry.BatchInfo {

--- a/validator/validation_entry.go
+++ b/validator/validation_entry.go
@@ -7,17 +7,17 @@ import (
 )
 
 type BatchInfo struct {
-	Number            uint64
-	HotShotCommitment espresso.Commitment
-	Data              []byte
+	Number uint64
+	Data   []byte
 }
 
 type ValidationInput struct {
-	Id            uint64
-	HasDelayedMsg bool
-	DelayedMsgNr  uint64
-	Preimages     map[arbutil.PreimageType]map[common.Hash][]byte
-	BatchInfo     []BatchInfo
-	DelayedMsg    []byte
-	StartState    GoGlobalState
+	Id                uint64
+	HasDelayedMsg     bool
+	DelayedMsgNr      uint64
+	Preimages         map[arbutil.PreimageType]map[common.Hash][]byte
+	BatchInfo         []BatchInfo
+	DelayedMsg        []byte
+	StartState        GoGlobalState
+	HotShotCommitment espresso.Commitment
 }

--- a/wavmio/higher.go
+++ b/wavmio/higher.go
@@ -53,8 +53,8 @@ func ReadInboxMessage(msgNum uint64) []byte {
 	})
 }
 
-func ReadHotShotCommitment(seqNum uint64) (commitment [32]byte) {
-	readHotShotCommitment(seqNum, commitment[:])
+func ReadHotShotCommitment(pos uint64, posInBatch uint64) (commitment [32]byte) {
+	readHotShotCommitment(seqNum, posInBatch, commitment[:])
 	return
 }
 

--- a/wavmio/higher.go
+++ b/wavmio/higher.go
@@ -53,8 +53,8 @@ func ReadInboxMessage(msgNum uint64) []byte {
 	})
 }
 
-func ReadHotShotCommitment(pos uint64, posInBatch uint64) (commitment [32]byte) {
-	readHotShotCommitment(seqNum, posInBatch, commitment[:])
+func ReadHotShotCommitment(inboxPos uint64, posInInbox uint64) (commitment [32]byte) {
+	readHotShotCommitment(inboxPos, posInInbox, commitment[:])
 	return
 }
 

--- a/wavmio/raw.go
+++ b/wavmio/raw.go
@@ -11,6 +11,6 @@ func setGlobalStateBytes32(idx uint64, val []byte)
 func getGlobalStateU64(idx uint64) uint64
 func setGlobalStateU64(idx uint64, val uint64)
 func readInboxMessage(msgNum uint64, offset uint32, output []byte) uint32
-func readHotShotCommitment(seqNum uint64, output []byte) uint32
+func readHotShotCommitment(inboxPos uint64, posInInbox uint64, output []byte) uint32
 func readDelayedInboxMessage(seqNum uint64, offset uint32, output []byte) uint32
 func resolveTypedPreimage(ty uint8, hash []byte, offset uint32, output []byte) uint32

--- a/wavmio/stub.go
+++ b/wavmio/stub.go
@@ -118,10 +118,7 @@ func GetLastBlockHash() (hash common.Hash) {
 	return lastBlockHash
 }
 
-func ReadHotShotCommitment(seqNum uint64) [32]byte {
-	if seqNum != seqMsgPos {
-		panic(fmt.Sprintf("hotshot header position should be consistent with the sequencer inbox position %d", seqNum))
-	}
+func ReadHotShotCommitment(pos uint64, posInBatch uint64) [32]byte {
 	return hotShotHeader
 
 }

--- a/wavmio/stub.go
+++ b/wavmio/stub.go
@@ -118,7 +118,7 @@ func GetLastBlockHash() (hash common.Hash) {
 	return lastBlockHash
 }
 
-func ReadHotShotCommitment(pos uint64, posInBatch uint64) [32]byte {
+func ReadHotShotCommitment(inboxPos uint64, posInInbox uint64) [32]byte {
 	return hotShotHeader
 
 }


### PR DESCRIPTION
Added an InboxTracker method that fetches the correct HotShot index corresponding to an arbitrum message. I also reworked the validation pipeline a bit. HotShotCommitments are now indexed by a `(inboxPosition, positionInInboxMsg`) tuple (there can be multiple arbitrum messages per inbox message). 

Locally, the commitments match up for me when I attempt to [run the validator](https://www.notion.so/espressosys/Arbitrum-Integration-Scratchpad-6a2d5143ee81460a95379f2236b5b6fb?pvs=4#3ebd19116c9649ecb03a32d507acf082) (at least it did at one point, I am now getting consistent wasm root mismatch errors, which may be unrelated). 
