### PR TITLE
Validation: Ensure that HotShot indices are consecutive

### DIFF
--- a/staker/block_validator.go
+++ b/staker/block_validator.go
@@ -505,6 +505,28 @@ func (v *BlockValidator) createNextValidationEntry(ctx context.Context) (bool, e
 		if err != nil {
 			return false, err
 		}
+		// Check that Espresso block numbers increase consecutively. This ensures that the sequenced L2 chain does not skip an Espresso block.
+		var prevEspressoMsg *arbostypes.L1IncomingMessage
+		for i := pos - 1; i != 0; i-- {
+			msg, err := v.streamer.GetMessage(i)
+			if err != nil {
+				return false, err
+			}
+			if msg.Message.Header.Kind == arbostypes.L1MessageType_L2Message {
+				prevEspressoMsg = msg.Message
+				break
+			}
+		}
+		if prevEspressoMsg != nil {
+			_, prevJst, err := arbos.ParseEspressoMsg(prevEspressoMsg)
+			if err != nil {
+				return false, err
+			}
+			if prevJst.EspressoBlockNumber+1 != jst.EspressoBlockNumber {
+				return false, fmt.Errorf("l2 chain appears to have skipped an espresso block, last espresso block number: %d, current: %d", prevJst.EspressoBlockNumber, jst.EspressoBlockNumber)
+			}
+		}
+
 		fetchedCommitment, err := v.hotShotReader.L1HotShotCommitmentFromHeight(jst.EspressoBlockNumber)
 		if err != nil {
 			return false, err

--- a/staker/stateless_block_validator.go
+++ b/staker/stateless_block_validator.go
@@ -369,14 +369,12 @@ func (v *StatelessBlockValidator) CreateReadyValidationEntry(ctx context.Context
 		return nil, err
 	}
 	var prevDelayed uint64
-	var prevMessage *arbostypes.MessageWithMetadata
 	if pos > 0 {
 		prev, err := v.streamer.GetMessage(pos - 1)
 		if err != nil {
 			return nil, err
 		}
 		prevDelayed = prev.DelayedMessagesRead
-		prevMessage = prev
 	}
 	prevResult, err := v.streamer.ResultAtCount(pos)
 	if err != nil {
@@ -399,16 +397,6 @@ func (v *StatelessBlockValidator) CreateReadyValidationEntry(ctx context.Context
 		_, jst, err := arbos.ParseEspressoMsg(msg.Message)
 		if err != nil {
 			return nil, err
-		}
-		// Check that Espresso block numbers increase consecutively. This ensures that the sequenced L2 chain does not skip an Espresso block.
-		if pos > 0 && prevMessage.Message.Header.Kind == arbostypes.L1MessageType_L2Message {
-			_, prevJst, err := arbos.ParseEspressoMsg(prevMessage.Message)
-			if err != nil {
-				return nil, err
-			}
-			if prevJst.EspressoBlockNumber+1 != jst.EspressoBlockNumber {
-				return nil, fmt.Errorf("l2 chain appears to have skipped an espresso block, last espresso block number: %d, current: %d", prevJst.EspressoBlockNumber, jst.EspressoBlockNumber)
-			}
 		}
 		fetchedCommitment, err := v.hotShotReader.L1HotShotCommitmentFromHeight(jst.EspressoBlockNumber)
 		if err != nil {

--- a/staker/stateless_block_validator.go
+++ b/staker/stateless_block_validator.go
@@ -369,12 +369,14 @@ func (v *StatelessBlockValidator) CreateReadyValidationEntry(ctx context.Context
 		return nil, err
 	}
 	var prevDelayed uint64
+	var prevMessage *arbostypes.MessageWithMetadata
 	if pos > 0 {
 		prev, err := v.streamer.GetMessage(pos - 1)
 		if err != nil {
 			return nil, err
 		}
 		prevDelayed = prev.DelayedMessagesRead
+		prevMessage = prev
 	}
 	prevResult, err := v.streamer.ResultAtCount(pos)
 	if err != nil {
@@ -391,12 +393,23 @@ func (v *StatelessBlockValidator) CreateReadyValidationEntry(ctx context.Context
 		return nil, err
 	}
 	var comm espressoTypes.Commitment
+	// Note: this code path is not used in the staker validation pipeline, return to this
+	// when we look into fraud proofs
 	if v.config.Espresso && msg.Message.Header.Kind == arbostypes.L1MessageType_L2Message {
 		_, jst, err := arbos.ParseEspressoMsg(msg.Message)
 		if err != nil {
 			return nil, err
 		}
-		log.Info("block num %d", jst.EspressoBlockNumber)
+		// Check that Espresso block numbers increase consecutively. This ensures that the sequenced L2 chain does not skip an Espresso block.
+		if pos > 0 && prevMessage.Message.Header.Kind == arbostypes.L1MessageType_L2Message {
+			_, prevJst, err := arbos.ParseEspressoMsg(prevMessage.Message)
+			if err != nil {
+				return nil, err
+			}
+			if prevJst.EspressoBlockNumber+1 != jst.EspressoBlockNumber {
+				return nil, fmt.Errorf("l2 chain appears to have skipped an espresso block, last espresso block number: %d, current: %d", prevJst.EspressoBlockNumber, jst.EspressoBlockNumber)
+			}
+		}
 		fetchedCommitment, err := v.hotShotReader.L1HotShotCommitmentFromHeight(jst.EspressoBlockNumber)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
To prevent censorship of HotShot blocks, ensure that all HotShot blocks are accounted for by ensuring that Arb messages corresponding to hotshot blocks have a consecutively increasing height. 

close #38 