### PR TITLE
Update sequencer CLI arguments

### DIFF
--- a/system_tests/espresso-e2e/docker-compose.yaml
+++ b/system_tests/espresso-e2e/docker-compose.yaml
@@ -44,7 +44,7 @@ services:
     ports:
       - "$ESPRESSO_SEQUENCER_API_PORT:$ESPRESSO_SEQUENCER_API_PORT"
     # Run the API server (with options taken from the environment) and the optional submission API
-    command: sequencer -- http -- query-fs -- submit -- status
+    command: sequencer -- http -- query -- submit -- status
     environment:
       - ESPRESSO_SEQUENCER_ORCHESTRATOR_URL
       - ESPRESSO_SEQUENCER_DA_SERVER_URL
@@ -70,7 +70,7 @@ services:
     ports:
       - "$ESPRESSO_SEQUENCER1_API_PORT:$ESPRESSO_SEQUENCER_API_PORT"
     # Run the API server (with options taken from the environment)
-    command: sequencer -- http -- query-fs
+    command: sequencer -- http
     environment:
       - ESPRESSO_SEQUENCER_ORCHESTRATOR_URL
       - ESPRESSO_SEQUENCER_DA_SERVER_URL


### PR DESCRIPTION
https://github.com/EspressoSystems/espresso-sequencer/pull/893

The second node doesn't need to run a query service, so remove it.