### PR TITLE
Backport stale l1 sequencing fix

### DIFF
--- a/execution/gethexec/espresso_sequencer.go
+++ b/execution/gethexec/espresso_sequencer.go
@@ -67,6 +67,7 @@ func (s *EspressoSequencer) createBlock(ctx context.Context) (returnValue bool) 
 			log.Warn("Unable to fetch the latest hotshot block")
 			return false
 		}
+                log.Info("Starting sequencing at the latest hotshot block", "block number", latestBlock)
 		s.hotShotState.nextSeqBlockNum = latestBlock
 	}
 	nextSeqBlockNum := s.hotShotState.nextSeqBlockNum

--- a/execution/gethexec/espresso_sequencer.go
+++ b/execution/gethexec/espresso_sequencer.go
@@ -67,7 +67,7 @@ func (s *EspressoSequencer) createBlock(ctx context.Context) (returnValue bool) 
 			log.Warn("Unable to fetch the latest hotshot block")
 			return false
 		}
-                log.Info("Starting sequencing at the latest hotshot block", "block number", latestBlock)
+		log.Info("Starting sequencing at the latest hotshot block", "block number", latestBlock)
 		s.hotShotState.nextSeqBlockNum = latestBlock
 	}
 	nextSeqBlockNum := s.hotShotState.nextSeqBlockNum

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -70,6 +70,7 @@ type SequencerConfig struct {
 	Espresso          bool   `koanf:"espresso"`
 	HotShotUrl        string `koanf:"hotshot-url"`
 	EspressoNamespace uint64 `koanf:"espresso-namespace"`
+	StartHotShotBlock uint64 `koanf:"start-hotshot-block"`
 }
 
 func (c *SequencerConfig) Validate() error {
@@ -134,6 +135,7 @@ func SequencerConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".espresso", DefaultSequencerConfig.Espresso, "if true, transactions will be fetched from the espresso sequencer network")
 	f.String(prefix+".hotshot-url", DefaultSequencerConfig.HotShotUrl, "")
 	f.Uint64(prefix+".espresso-namespace", DefaultSequencerConfig.EspressoNamespace, "espresso namespace that corresponds the L2 chain")
+	f.Uint64(prefix+".start-hotshot-block", DefaultSequencerConfig.StartHotShotBlock, "the starting block number of hotshot")
 }
 
 type txQueueItem struct {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/VictoriaMetrics/fastcache => ./fastcache
 replace github.com/ethereum/go-ethereum => ./go-ethereum
 
 require (
-	github.com/EspressoSystems/espresso-sequencer-go v0.0.3-0.20240105024202-f902ae6fac1d
+	github.com/EspressoSystems/espresso-sequencer-go v0.0.3
 	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible
 	github.com/Shopify/toxiproxy v2.1.4+incompatible
 	github.com/alicebob/miniredis/v2 v2.21.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,9 @@ replace github.com/VictoriaMetrics/fastcache => ./fastcache
 replace github.com/ethereum/go-ethereum => ./go-ethereum
 
 require (
-	github.com/EspressoSystems/espresso-sequencer-go v0.0.2
+	github.com/EspressoSystems/espresso-sequencer-go v0.0.3-0.20240105024202-f902ae6fac1d
+	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible
+	github.com/Shopify/toxiproxy v2.1.4+incompatible
 	github.com/alicebob/miniredis/v2 v2.21.0
 	github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156
 	github.com/andybalholm/brotli v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -51,22 +51,8 @@ github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53/go.mod h1:+3
 github.com/CloudyKit/jet/v3 v3.0.0/go.mod h1:HKQPgSJmdK8hdoAbKUUWajkHyHo4RaU5rMdUywE7VMo=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/EspressoSystems/espresso-sequencer-go v0.0.1 h1:8Es2XVLJQoHvq9m4A7MfB3s33cZZmmiM/QhjZ9iiSxw=
-github.com/EspressoSystems/espresso-sequencer-go v0.0.1/go.mod h1:T3MyQRnfbCSTBhAAG2WASmVPCwWkl0/sPKKY5Z1ewtg=
-github.com/EspressoSystems/espresso-sequencer-go v0.0.2-0.20231213053144-08be545d123d h1:Wm6b/DCFgzDpdHFgQlK1o/Reh3QUF4zysyFOnZuw8gc=
-github.com/EspressoSystems/espresso-sequencer-go v0.0.2-0.20231213053144-08be545d123d/go.mod h1:T3MyQRnfbCSTBhAAG2WASmVPCwWkl0/sPKKY5Z1ewtg=
-github.com/EspressoSystems/espresso-sequencer-go v0.0.2-0.20231213105430-bd56e55d8fc1 h1:a5+pAL15/3NusnwDHF6IOjaIsWV7bz+h2K4A+ZpA5iQ=
-github.com/EspressoSystems/espresso-sequencer-go v0.0.2-0.20231213105430-bd56e55d8fc1/go.mod h1:T3MyQRnfbCSTBhAAG2WASmVPCwWkl0/sPKKY5Z1ewtg=
-github.com/EspressoSystems/espresso-sequencer-go v0.0.2-0.20231213110302-957677ce40da h1:egY08eRaMEzNElOXzx/2qQrJnnHQlhzwgQrixp+ytug=
-github.com/EspressoSystems/espresso-sequencer-go v0.0.2-0.20231213110302-957677ce40da/go.mod h1:T3MyQRnfbCSTBhAAG2WASmVPCwWkl0/sPKKY5Z1ewtg=
-github.com/EspressoSystems/espresso-sequencer-go v0.0.2-0.20231213111252-435e29faf79c h1:PXvV3sz52ZkCRZOipbUP+FF+uesCqhp+NsXFoV4iauk=
-github.com/EspressoSystems/espresso-sequencer-go v0.0.2-0.20231213111252-435e29faf79c/go.mod h1:T3MyQRnfbCSTBhAAG2WASmVPCwWkl0/sPKKY5Z1ewtg=
-github.com/EspressoSystems/espresso-sequencer-go v0.0.2-0.20231213134923-6fd0cb5f60f1 h1:YLH6GyJRWk8+9rnvCkNA5iEMTSagEYKt04+605vdejU=
-github.com/EspressoSystems/espresso-sequencer-go v0.0.2-0.20231213134923-6fd0cb5f60f1/go.mod h1:T3MyQRnfbCSTBhAAG2WASmVPCwWkl0/sPKKY5Z1ewtg=
-github.com/EspressoSystems/espresso-sequencer-go v0.0.2 h1:OI3HHqXwrltl/YjQb4ZOKyK+M5t/+2Tqp9aTMssPDPc=
-github.com/EspressoSystems/espresso-sequencer-go v0.0.2/go.mod h1:T3MyQRnfbCSTBhAAG2WASmVPCwWkl0/sPKKY5Z1ewtg=
-github.com/EspressoSystems/espresso-sequencer-go v0.0.3-0.20240105024202-f902ae6fac1d h1:dUF1d3om9y3xIwMQznFv+kh0UbeMwr2YPVPLviubIY8=
-github.com/EspressoSystems/espresso-sequencer-go v0.0.3-0.20240105024202-f902ae6fac1d/go.mod h1:T3MyQRnfbCSTBhAAG2WASmVPCwWkl0/sPKKY5Z1ewtg=
+github.com/EspressoSystems/espresso-sequencer-go v0.0.3 h1:A227KQpb46Lfccz+b/OGEfA2+pjrHN8f6+XzxBVUVmw=
+github.com/EspressoSystems/espresso-sequencer-go v0.0.3/go.mod h1:T3MyQRnfbCSTBhAAG2WASmVPCwWkl0/sPKKY5Z1ewtg=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
@@ -247,7 +233,6 @@ github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811 h1:ytcWPaNPhNoG
 github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811/go.mod h1:Nb5lgvnQ2+oGlE/EyZy4+2/CxRh9KfvCXnag1vtpxVM=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=
 github.com/cockroachdb/redact v1.1.3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
-github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2/go.mod h1:8BT+cPK6xvFOcRlk0R8eg+OTkcqI6baNH4xAkpiYVvQ=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codeclysm/extract/v3 v3.0.2 h1:sB4LcE3Php7LkhZwN0n2p8GCwZe92PEQutdbGURf5xc=
 github.com/codeclysm/extract/v3 v3.0.2/go.mod h1:NKsw+hqua9H+Rlwy/w/3Qgt9jDonYEgB6wJu+25eOKw=
@@ -286,7 +271,6 @@ github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c/go.mod h1:6Uh
 github.com/deckarep/golang-set/v2 v2.1.0 h1:g47V4Or+DUdzbs8FxCCmgb6VYd+ptPAngjM6dtGktsI=
 github.com/deckarep/golang-set/v2 v2.1.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
-github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 h1:HbphB4TFFXpv7MNrT52FGrrgVXF1owhMVTHFZIlnvd4=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0/go.mod h1:DZGJHZMqrU4JJqFAWUS2UO1+lbSKsdiOoYi9Zzey7Fc=
 github.com/decred/dcrd/lru v1.0.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0tEMk218=
@@ -402,7 +386,6 @@ github.com/go-ldap/ldap v3.0.2+incompatible/go.mod h1:qfd9rJvER9Q0/D/Sqn1DfHRoBp
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
-github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -895,7 +878,6 @@ github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
-github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
@@ -1273,7 +1255,6 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
-github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=
 github.com/mr-tron/base58 v1.1.0/go.mod h1:xcD2VGqlgYjBdcBLw+TuYLr8afG+Hj8g2eTVqeSzSU8=
 github.com/mr-tron/base58 v1.1.1/go.mod h1:xcD2VGqlgYjBdcBLw+TuYLr8afG+Hj8g2eTVqeSzSU8=
@@ -1415,7 +1396,6 @@ github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAv
 github.com/pelletier/go-toml/v2 v2.0.5 h1:ipoSadvV8oGUjnUbMub59IDPPwfxF694nG/jwbMiyQg=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9 h1:1/WtZae0yGtPq+TI6+Tv1WTxkukpXeMlviSxvL7SRgk=
-github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9/go.mod h1:x3N5drFsm2uilKKuuYo6LdyD8vZAW55sH/9w+pbo1sw=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
@@ -1650,7 +1630,6 @@ github.com/wealdtech/go-merkletree v1.0.0/go.mod h1:cdil512d/8ZC7Kx3bfrDvGMQXB25
 github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc h1:BCPnHtcboadS0DvysUuJXZ4lWVv5Bh5i7+tbIyi+ck4=
 github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc/go.mod h1:r45hJU7yEoA81k6MWNhpMj/kms0n14dkzkxYHoB96UM=
 github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11 h1:5HZfQkwe0mIfyDmc1Em5GqlNRzcdtlv4HTNmdpt7XH0=
-github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11/go.mod h1:Wlo/SzPmxVp6vXpGt/zaXhHH0fn4IxgqZc82aKg6bpQ=
 github.com/whyrusleeping/cbor-gen v0.0.0-20200123233031-1cdf64d27158/go.mod h1:Xj/M2wWU+QdTdRbu/L/1dIZY8/Wb2K9pAhtroQuxJJI=
 github.com/whyrusleeping/cbor-gen v0.0.0-20230126041949-52956bd4c9aa h1:EyA027ZAkuaCLoxVX4r1TZMPy1d31fM6hbfQ4OU4I5o=
 github.com/whyrusleeping/cbor-gen v0.0.0-20230126041949-52956bd4c9aa/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/EspressoSystems/espresso-sequencer-go v0.0.2-0.20231213134923-6fd0cb5
 github.com/EspressoSystems/espresso-sequencer-go v0.0.2-0.20231213134923-6fd0cb5f60f1/go.mod h1:T3MyQRnfbCSTBhAAG2WASmVPCwWkl0/sPKKY5Z1ewtg=
 github.com/EspressoSystems/espresso-sequencer-go v0.0.2 h1:OI3HHqXwrltl/YjQb4ZOKyK+M5t/+2Tqp9aTMssPDPc=
 github.com/EspressoSystems/espresso-sequencer-go v0.0.2/go.mod h1:T3MyQRnfbCSTBhAAG2WASmVPCwWkl0/sPKKY5Z1ewtg=
+github.com/EspressoSystems/espresso-sequencer-go v0.0.3-0.20240105024202-f902ae6fac1d h1:dUF1d3om9y3xIwMQznFv+kh0UbeMwr2YPVPLviubIY8=
+github.com/EspressoSystems/espresso-sequencer-go v0.0.3-0.20240105024202-f902ae6fac1d/go.mod h1:T3MyQRnfbCSTBhAAG2WASmVPCwWkl0/sPKKY5Z1ewtg=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=

--- a/system_tests/espresso_test.go
+++ b/system_tests/espresso_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
@@ -76,6 +77,14 @@ func userTxs(t *testing.T, l2Info *BlockchainTestInfo) [][]byte {
 
 func createMockHotShot(ctx context.Context, t *testing.T, l2Info *BlockchainTestInfo) func() {
 	httpmock.Activate()
+
+	httpmock.RegisterResponder(
+		"GET",
+		`=~http://127.0.0.1:50000/status/latest_block_height`,
+		func(r *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(200, strconv.Itoa(startHotShotBlock)), nil
+		},
+	)
 
 	httpmock.RegisterResponder(
 		"GET",
@@ -257,12 +266,6 @@ func TestEspresso(t *testing.T) {
 		cnt := node.ConsensusNode.BlockValidator.Validated(t)
 		expected := arbutil.MessageIndex(expectedMsgCnt)
 		return cnt >= expected
-	})
-	Require(t, err)
-
-	// To reproduce the bug.
-	err = waitFor(t, ctx, func() bool {
-		return false
 	})
 	Require(t, err)
 

--- a/system_tests/espresso_test.go
+++ b/system_tests/espresso_test.go
@@ -22,7 +22,8 @@ import (
 var (
 	validationPort     = 54320
 	broadcastPort      = 9642
-	startHotShotBlock  = 1
+	staleBlocks        = 10
+	startHotShotBlock  = staleBlocks + 1
 	maxHotShotBlock    = 100
 	malformedBlockNum  = 5
 	firstGoodBlockNum  = 15
@@ -82,13 +83,17 @@ func createMockHotShot(ctx context.Context, t *testing.T, l2Info *BlockchainTest
 		func(req *http.Request) (*http.Response, error) {
 			log.Info("GET", "url", req.URL)
 			block := uint64(httpmock.MustGetSubmatchAsUint(req, 1))
+			timestamp := uint64(time.Now().Unix())
+			if block < uint64(staleBlocks) {
+				timestamp = 0
+			}
 			header := espressoTypes.Header{
 				// Since we don't realize the validation of espresso yet,
 				// mock a simple nmt root here
 				Height:           block,
 				TransactionsRoot: espressoTypes.NmtRoot{Root: []byte{}},
 				L1Head:           0, // Currently not used
-				Timestamp:        uint64(time.Now().Unix()),
+				Timestamp:        timestamp,
 			}
 			return httpmock.NewJsonResponse(200, header)
 		})
@@ -252,6 +257,12 @@ func TestEspresso(t *testing.T) {
 		cnt := node.ConsensusNode.BlockValidator.Validated(t)
 		expected := arbutil.MessageIndex(expectedMsgCnt)
 		return cnt >= expected
+	})
+	Require(t, err)
+
+	// To reproduce the bug.
+	err = waitFor(t, ctx, func() bool {
+		return false
 	})
 	Require(t, err)
 


### PR DESCRIPTION
Backports this fix: https://github.com/EspressoSystems/nitro-espresso-integration/pull/55