### PR TITLE
Staker e2e test

### DIFF
--- a/.github/workflows/espresso-e2e.yml
+++ b/.github/workflows/espresso-e2e.yml
@@ -28,6 +28,16 @@ jobs:
           sudo apt update && sudo apt install -y wabt gotestsum
           cmake build-essential bison golang clang make wabt
 
+      - name: free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+
       - name: Setup nodejs
         uses: actions/setup-node@v3
         with:

--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -177,13 +177,18 @@ func ProduceBlock(
 	}
 
 	var height uint64
-	if message.Header.Kind == arbostypes.L1MessageType_L2Message &&
-		chainConfig.ArbitrumChainParams.EnableEspresso {
-		_, jst, err := ParseEspressoMsg(message)
-		if err != nil {
-			return nil, nil, err
+	if chainConfig.ArbitrumChainParams.EnableEspresso {
+		if message.Header.Kind == arbostypes.L1MessageType_L2Message {
+			// creating a block with espresso message
+			_, jst, err := ParseEspressoMsg(message)
+			if err != nil {
+				return nil, nil, err
+			}
+			height = jst.Header.Height
+		} else {
+			lastInfo := types.DeserializeHeaderExtraInformation(lastBlockHeader)
+			height = lastInfo.HotShotHeight
 		}
-		height = jst.Header.Height
 	}
 
 	hooks := NoopSequencingHooks()

--- a/staker/block_challenge_backend.go
+++ b/staker/block_challenge_backend.go
@@ -73,14 +73,6 @@ func NewBlockChallengeBackend(
 	}, nil
 }
 
-func (b *BlockChallengeBackend) SetDebugEspressoIncorrectHeight(h uint64) {
-	b.debugEspressoIncorrectHeight = h
-}
-
-func (b *BlockChallengeBackend) EspressoDebugging(curr uint64) bool {
-	return b.debugEspressoIncorrectHeight > 0 && curr > b.debugEspressoIncorrectHeight
-}
-
 func (b *BlockChallengeBackend) findBatchAfterMessageCount(msgCount arbutil.MessageIndex) (uint64, error) {
 	if msgCount == 0 {
 		return 0, nil
@@ -240,4 +232,14 @@ func (b *BlockChallengeBackend) IssueExecChallenge(
 		globalStateHashes,
 		big.NewInt(int64(numsteps)),
 	)
+}
+
+// This method should be only used in tests.
+func (b *BlockChallengeBackend) DebugEspresso_SetIncorrectHeight(h uint64) {
+	b.debugEspressoIncorrectHeight = h
+}
+
+// This method is to create a conditional branch to help mocking a challenge.
+func (b *BlockChallengeBackend) EspressoDebugging(curr uint64) bool {
+	return b.debugEspressoIncorrectHeight > 0 && curr > b.debugEspressoIncorrectHeight
 }

--- a/staker/challenge_manager.go
+++ b/staker/challenge_manager.go
@@ -133,7 +133,9 @@ func NewChallengeManager(
 	if err != nil {
 		return nil, fmt.Errorf("error creating block challenge backend for challenge %v: %w", challengeIndex, err)
 	}
-	backend.SetDebugEspressoIncorrectHeight(val.GetDebugEspressoIncorrectHeight())
+	if val.debugEspressoIncorrectHeight > 0 {
+		backend.DebugEspresso_SetIncorrectHeight(val.debugEspressoIncorrectHeight)
+	}
 	return &ChallengeManager{
 		challengeCore: &challengeCore{
 			con:                  con,

--- a/staker/challenge_manager.go
+++ b/staker/challenge_manager.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/big"
 
+	espressoTypes "github.com/EspressoSystems/espresso-sequencer-go/types"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
@@ -132,6 +133,7 @@ func NewChallengeManager(
 	if err != nil {
 		return nil, fmt.Errorf("error creating block challenge backend for challenge %v: %w", challengeIndex, err)
 	}
+	backend.SetDebugEspressoIncorrectHeight(val.GetDebugEspressoIncorrectHeight())
 	return &ChallengeManager{
 		challengeCore: &challengeCore{
 			con:                  con,
@@ -467,6 +469,10 @@ func (m *ChallengeManager) createExecutionBackend(ctx context.Context, step uint
 	if err != nil {
 		return fmt.Errorf("error creating validation entry for challenge %v msg %v for execution challenge: %w", m.challengeIndex, initialCount, err)
 	}
+	if m.blockChallengeBackend.EspressoDebugging(entry.End.HotShotHeight) {
+		entry.End.BlockHash = mockHash(entry.End.HotShotHeight)
+		entry.HotShotCommitment = espressoTypes.Commitment{}
+	}
 	input, err := entry.ToInput()
 	if err != nil {
 		return fmt.Errorf("error getting validation entry input of challenge %v msg %v: %w", m.challengeIndex, initialCount, err)
@@ -493,6 +499,10 @@ func (m *ChallengeManager) createExecutionBackend(ctx context.Context, step uint
 	machineStepCount, computedState, computedStatus, err := backend.GetFinalState(ctx)
 	if err != nil {
 		return fmt.Errorf("error getting execution challenge final state: %w", err)
+	}
+	if m.blockChallengeBackend.EspressoDebugging(computedState.HotShotHeight) {
+		computedState.BlockHash = mockHash(computedState.HotShotHeight)
+		computedStatus = expectedStatus
 	}
 	if expectedStatus != computedStatus {
 		return fmt.Errorf("after msg %v expected status %v but got %v", initialCount, expectedStatus, computedStatus)

--- a/staker/stateless_block_validator.go
+++ b/staker/stateless_block_validator.go
@@ -59,23 +59,6 @@ type StatelessBlockValidator struct {
 	debugEspressoIncorrectHeight uint64
 }
 
-// This should be only used in tests
-func (s *StatelessBlockValidator) SetHotShotReader(reader HotShotReaderInterface, t *testing.T) {
-	s.hotShotReader = reader
-}
-
-func (s *StatelessBlockValidator) SetDebugEspressoIncorrectHeight(h uint64, t *testing.T) {
-	s.debugEspressoIncorrectHeight = h
-}
-
-func (s *StatelessBlockValidator) EspressoDebugging(curr uint64) bool {
-	return s.debugEspressoIncorrectHeight > 0 && curr >= s.debugEspressoIncorrectHeight
-}
-
-func (s *StatelessBlockValidator) GetDebugEspressoIncorrectHeight() uint64 {
-	return s.debugEspressoIncorrectHeight
-}
-
 type BlockValidatorRegistrer interface {
 	SetBlockValidator(*BlockValidator)
 }
@@ -534,4 +517,19 @@ func (v *StatelessBlockValidator) Stop() {
 	for _, spawner := range v.validationSpawners {
 		spawner.Stop()
 	}
+}
+
+// This method should be only used in tests.
+func (s *StatelessBlockValidator) DebugEspresso_SetHotShotReader(reader HotShotReaderInterface, t *testing.T) {
+	s.hotShotReader = reader
+}
+
+// This method should be only used in tests.
+func (s *StatelessBlockValidator) DebugEspresso_SetIncorrectHeight(h uint64, t *testing.T) {
+	s.debugEspressoIncorrectHeight = h
+}
+
+// This method is to create a conditional branch to help mocking a challenge.
+func (s *StatelessBlockValidator) EspressoDebugging(curr uint64) bool {
+	return s.debugEspressoIncorrectHeight > 0 && curr >= s.debugEspressoIncorrectHeight
 }

--- a/system_tests/das_test.go
+++ b/system_tests/das_test.go
@@ -112,7 +112,7 @@ func TestDASRekey(t *testing.T) {
 	l1info, l1client, _, l1stack := createTestL1BlockChain(t, nil)
 	defer requireClose(t, l1stack)
 	feedErrChan := make(chan error, 10)
-	addresses, initMessage := DeployOnTestL1(t, ctx, l1info, l1client, chainConfig)
+	addresses, initMessage := DeployOnTestL1(t, ctx, l1info, l1client, chainConfig, common.Address{})
 
 	// Setup DAS servers
 	dasDataDir := t.TempDir()
@@ -247,7 +247,7 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 	l1Reader.Start(ctx)
 	defer l1Reader.StopAndWait()
 	feedErrChan := make(chan error, 10)
-	addresses, initMessage := DeployOnTestL1(t, ctx, l1info, l1client, chainConfig)
+	addresses, initMessage := DeployOnTestL1(t, ctx, l1info, l1client, chainConfig, common.Address{})
 
 	keyDir, fileDataDir, dbDataDir := t.TempDir(), t.TempDir(), t.TempDir()
 	pubkey, _, err := das.GenerateAndStoreKeys(keyDir)

--- a/system_tests/espresso_e2e_test.go
+++ b/system_tests/espresso_e2e_test.go
@@ -160,8 +160,8 @@ func createStaker(ctx context.Context, t *testing.T, builder *NodeBuilder, incor
 	Require(t, err)
 
 	if incorrectHeight > 0 {
-		l2Node.StatelessBlockValidator.SetDebugEspressoIncorrectHeight(incorrectHeight, t)
-		l2Node.BlockValidator.SetDebugEspressoIncorrectHeight(incorrectHeight, t)
+		l2Node.StatelessBlockValidator.DebugEspresso_SetIncorrectHeight(incorrectHeight, t)
+		l2Node.BlockValidator.DebugEspresso_SetIncorrectHeight(incorrectHeight, t)
 	}
 
 	err = wallet.Initialize(ctx)
@@ -286,13 +286,7 @@ func TestEspressoE2E(t *testing.T) {
 	if len(commitmentBytes) != 32 {
 		t.Fatal("failed to read hotshot via hostio contract, length is not 32")
 	}
-	empty := true
-	for _, i := range commitmentBytes {
-		if i != 0 {
-			empty = false
-			break
-		}
-	}
+	empty := actualCommitment.Cmp(big.NewInt(0)) == 0
 	if empty {
 		t.Fatal("failed to read hotshot via hostio contract, empty")
 	}

--- a/system_tests/espresso_e2e_test.go
+++ b/system_tests/espresso_e2e_test.go
@@ -5,13 +5,28 @@ import (
 	"fmt"
 	"math/big"
 	"os/exec"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/offchainlabs/nitro/arbnode"
+	"github.com/offchainlabs/nitro/arbnode/dataposter/storage"
 	"github.com/offchainlabs/nitro/arbutil"
+	"github.com/offchainlabs/nitro/solgen/go/ospgen"
+	"github.com/offchainlabs/nitro/solgen/go/rollupgen"
+	"github.com/offchainlabs/nitro/solgen/go/upgrade_executorgen"
+	"github.com/offchainlabs/nitro/staker"
+	"github.com/offchainlabs/nitro/staker/validatorwallet"
 )
 
 var workingDir = "./espresso-e2e"
+var hotShotAddress = "0x217788c286797d56cd59af5e493f3699c39cbbe8"
+var hostIoAddress = "0xF34C2fac45527E55ED122f80a969e79A40547e6D"
 
 func runEspresso(t *testing.T, ctx context.Context) func() {
 	shutdown := func() {
@@ -46,7 +61,7 @@ func runEspresso(t *testing.T, ctx context.Context) func() {
 	return shutdown
 }
 
-func createL1ValidatorPosterNode(ctx context.Context, t *testing.T) (*TestClient, func()) {
+func createL1ValidatorPosterNode(ctx context.Context, t *testing.T) (*NodeBuilder, func()) {
 	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
 	builder.l1StackConfig.HTTPPort = 8545
 	builder.l1StackConfig.WSPort = 8546
@@ -60,31 +75,128 @@ func createL1ValidatorPosterNode(ctx context.Context, t *testing.T) (*TestClient
 
 	builder.nodeConfig.Feed.Input.URL = []string{fmt.Sprintf("ws://127.0.0.1:%d", broadcastPort)}
 	builder.nodeConfig.BatchPoster.Enable = true
+	builder.nodeConfig.BatchPoster.MaxSize = 41
+	builder.nodeConfig.BatchPoster.MaxDelay = -1000 * time.Hour
 	builder.nodeConfig.BlockValidator.Enable = true
-	builder.nodeConfig.BlockValidator.ValidationServer.URL = fmt.Sprintf("ws://127.0.0.1:%d", validationPort)
-	builder.nodeConfig.BlockValidator.HotShotAddress = "0x217788c286797d56cd59af5e493f3699c39cbbe8"
+	builder.nodeConfig.BlockValidator.ValidationServer.URL = fmt.Sprintf("ws://127.0.0.1:%d", arbValidationPort)
+	builder.nodeConfig.BlockValidator.HotShotAddress = hotShotAddress
 	builder.nodeConfig.BlockValidator.Espresso = true
+
 	cleanup := builder.Build(t)
 
+	// Fund the commitment task
 	mnemonic := "indoor dish desk flag debris potato excuse depart ticket judge file exit"
 	err := builder.L1Info.GenerateAccountWithMnemonic("CommitmentTask", mnemonic, 5)
-	if err != nil {
-		panic(err)
-	}
+	Require(t, err)
 	builder.L1.TransferBalance(t, "Faucet", "CommitmentTask", big.NewInt(9e18), builder.L1Info)
 
-	return builder.L2, cleanup
+	// Fund the stakers
+	builder.L1Info.GenerateAccount("Staker1")
+	builder.L1.TransferBalance(t, "Faucet", "Staker1", big.NewInt(9e18), builder.L1Info)
+	builder.L1Info.GenerateAccount("Staker2")
+	builder.L1.TransferBalance(t, "Faucet", "Staker2", big.NewInt(9e18), builder.L1Info)
+
+	// Update the rollup
+	deployAuth := builder.L1Info.GetDefaultTransactOpts("RollupOwner", ctx)
+	upgradeExecutor, err := upgrade_executorgen.NewUpgradeExecutor(builder.L2.ConsensusNode.DeployInfo.UpgradeExecutor, builder.L1.Client)
+	Require(t, err)
+	rollupABI, err := abi.JSON(strings.NewReader(rollupgen.RollupAdminLogicABI))
+	Require(t, err)
+
+	setMinAssertPeriodCalldata, err := rollupABI.Pack("setMinimumAssertionPeriod", big.NewInt(0))
+	Require(t, err, "unable to generate setMinimumAssertionPeriod calldata")
+	tx, err := upgradeExecutor.ExecuteCall(&deployAuth, builder.L2.ConsensusNode.DeployInfo.Rollup, setMinAssertPeriodCalldata)
+	Require(t, err, "unable to set minimum assertion period")
+	_, err = builder.L1.EnsureTxSucceeded(tx)
+	Require(t, err)
+
+	// Add the stakers into the validator whitelist
+	staker1Addr := builder.L1Info.GetAddress("Staker1")
+	staker2Addr := builder.L1Info.GetAddress("Staker2")
+	setValidatorCalldata, err := rollupABI.Pack("setValidator", []common.Address{staker1Addr, staker2Addr}, []bool{true, true})
+	Require(t, err, "unable to generate setValidator calldata")
+	tx, err = upgradeExecutor.ExecuteCall(&deployAuth, builder.L2.ConsensusNode.DeployInfo.Rollup, setValidatorCalldata)
+	Require(t, err, "unable to set validators")
+	_, err = builder.L1.EnsureTxSucceeded(tx)
+	Require(t, err)
+
+	return builder, cleanup
+}
+
+func createStaker(ctx context.Context, t *testing.T, builder *NodeBuilder, incorrectHeight uint64) (*staker.Staker, *staker.BlockValidator, func()) {
+	config := arbnode.ConfigDefaultL1Test()
+	config.Sequencer = false
+	config.DelayedSequencer.Enable = false
+	config.BatchPoster.Enable = false
+	config.Staker.Enable = false
+	config.BlockValidator.Enable = true
+	config.BlockValidator.HotShotAddress = hotShotAddress
+	config.BlockValidator.Espresso = true
+	config.BlockValidator.ValidationServer.URL = fmt.Sprintf("ws://127.0.0.1:%d", arbValidationPort)
+	testClient, cleanup := builder.Build2ndNode(t, &SecondNodeParams{nodeConfig: config})
+	l2Node := testClient.ConsensusNode
+
+	var auth bind.TransactOpts
+	if incorrectHeight > 0 {
+		auth = builder.L1Info.GetDefaultTransactOpts("Staker2", ctx)
+	} else {
+		auth = builder.L1Info.GetDefaultTransactOpts("Staker1", ctx)
+	}
+
+	cfg := arbnode.ConfigDefaultL1NonSequencerTest()
+	parentChainID, err := builder.L1.Client.ChainID(ctx)
+	Require(t, err)
+	dp, err := arbnode.StakerDataposter(
+		ctx,
+		rawdb.NewTable(l2Node.ArbDB, storage.StakerPrefix),
+		l2Node.L1Reader,
+		&auth,
+		NewFetcherFromConfig(cfg),
+		nil,
+		parentChainID,
+	)
+	Require(t, err)
+	wallet, err := validatorwallet.NewEOA(dp, l2Node.DeployInfo.Rollup, l2Node.L1Reader.Client(), func() uint64 { return 50000 })
+	Require(t, err)
+
+	if incorrectHeight > 0 {
+		l2Node.StatelessBlockValidator.SetDebugEspressoIncorrectHeight(incorrectHeight, t)
+		l2Node.BlockValidator.SetDebugEspressoIncorrectHeight(incorrectHeight, t)
+	}
+
+	err = wallet.Initialize(ctx)
+	Require(t, err)
+	valConfig := staker.TestL1ValidatorConfig
+	valConfig.Strategy = "MakeNodes"
+	valConfig.StartValidationFromStaked = false
+	staker, err := staker.NewStaker(
+		l2Node.L1Reader,
+		wallet,
+		bind.CallOpts{},
+		valConfig,
+		l2Node.BlockValidator,
+		l2Node.StatelessBlockValidator,
+		nil,
+		nil,
+		l2Node.DeployInfo.ValidatorUtils,
+		nil,
+	)
+	Require(t, err)
+	err = staker.Initialize(ctx)
+	Require(t, err)
+	return staker, l2Node.BlockValidator, cleanup
 }
 
 func TestEspressoE2E(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	cleanValNode := createValidationNode(ctx, t)
+	cleanValNode := createValidationNode(ctx, t, false)
 	defer cleanValNode()
 
-	node, cleanup := createL1ValidatorPosterNode(ctx, t)
+	builder, cleanup := createL1ValidatorPosterNode(ctx, t)
 	defer cleanup()
+	node := builder.L2
 
 	err := waitFor(t, ctx, func() bool {
 		if e := exec.Command(
@@ -163,6 +275,76 @@ func TestEspressoE2E(t *testing.T) {
 		validatedCnt := node.ConsensusNode.BlockValidator.Validated(t)
 		log.Info("waiting for validation", "validatedCnt", validatedCnt, "msgCnt", msgCnt)
 		return validatedCnt >= msgCnt
+	})
+	Require(t, err)
+
+	hostIo, err := ospgen.NewOneStepProverHostIo(common.HexToAddress(hostIoAddress), builder.L1.Client)
+	Require(t, err)
+	actualCommitment, err := hostIo.GetHotShotCommitment(&bind.CallOpts{}, big.NewInt(1))
+	Require(t, err)
+	commitmentBytes := actualCommitment.Bytes()
+	if len(commitmentBytes) != 32 {
+		t.Fatal("failed to read hotshot via hostio contract, length is not 32")
+	}
+	empty := true
+	for _, i := range commitmentBytes {
+		if i != 0 {
+			empty = false
+			break
+		}
+	}
+	if empty {
+		t.Fatal("failed to read hotshot via hostio contract, empty")
+	}
+	log.Info("Read hotshot commitment via hostio contract successfully", "height", 1, "commitment", commitmentBytes)
+
+	lastValidatedInfo, err := node.ConsensusNode.BlockValidator.ReadLastValidatedInfo()
+	Require(t, err)
+	incorrectHeight := lastValidatedInfo.GlobalState.HotShotHeight
+	log.Info("setting incorrect hotshot height!", "height", incorrectHeight)
+	validated := node.ConsensusNode.BlockValidator.Validated(t)
+
+	goodStaker, blockValidatorA, cleanA := createStaker(ctx, t, builder, 0)
+	defer cleanA()
+	badStaker, blockValidatorB, cleanB := createStaker(ctx, t, builder, incorrectHeight)
+	defer cleanB()
+
+	err = waitFor(t, ctx, func() bool {
+		validatedA := blockValidatorA.Validated(t)
+		validatedB := blockValidatorB.Validated(t)
+		shouldValidated := validated
+		condition := validatedA >= shouldValidated && validatedB >= shouldValidated
+		if !condition {
+			log.Info("waiting for stakers to catch up the incorrect hotshot height", "stakerA", validatedA, "stakerB", validatedB, "target", shouldValidated)
+		}
+		return condition
+	})
+	Require(t, err)
+	validatorUtils, err := rollupgen.NewValidatorUtils(builder.L2.ConsensusNode.DeployInfo.ValidatorUtils, builder.L1.Client)
+	Require(t, err)
+	goodOpts := builder.L1Info.GetDefaultCallOpts("Staker1", ctx)
+	badOpts := builder.L1Info.GetDefaultCallOpts("Staker2", ctx)
+	i := 0
+	err = waitFor(t, ctx, func() bool {
+		log.Info("good staker acts", "step", i)
+		txA, err := goodStaker.Act(ctx)
+		Require(t, err)
+		if txA != nil {
+			_, err = builder.L1.EnsureTxSucceeded(txA)
+			Require(t, err)
+		}
+
+		log.Info("bad staker acts", "step", i)
+		txB, err := badStaker.Act(ctx)
+		Require(t, err)
+		if txB != nil {
+			_, err = builder.L1.EnsureTxSucceeded(txB)
+			Require(t, err)
+		}
+		i += 1
+		conflict, err := validatorUtils.FindStakerConflict(&bind.CallOpts{}, builder.L2.ConsensusNode.DeployInfo.Rollup, goodOpts.From, badOpts.From, big.NewInt(1024))
+		Require(t, err)
+		return staker.ConflictType(conflict.Ty) == staker.CONFLICT_TYPE_FOUND
 	})
 	Require(t, err)
 }

--- a/system_tests/espresso_test.go
+++ b/system_tests/espresso_test.go
@@ -189,7 +189,7 @@ func createValidatorAndPosterNode(ctx context.Context, t *testing.T) (*TestClien
 	builder.chainConfig.ArbitrumChainParams.EnableEspresso = true
 
 	cleanup := builder.Build(t)
-	builder.L2.ConsensusNode.StatelessBlockValidator.SetHotShotReader(&hotShotReader, t)
+	builder.L2.ConsensusNode.StatelessBlockValidator.DebugEspresso_SetHotShotReader(&hotShotReader, t)
 	return builder.L2, cleanup
 }
 

--- a/system_tests/full_challenge_impl_test.go
+++ b/system_tests/full_challenge_impl_test.go
@@ -269,7 +269,7 @@ func RunChallengeTest(t *testing.T, asserterIsCorrect bool, useStubs bool, chall
 	configByValidationNode(t, conf, valStack)
 
 	fatalErrChan := make(chan error, 10)
-	asserterRollupAddresses, initMessage := DeployOnTestL1(t, ctx, l1Info, l1Backend, chainConfig)
+	asserterRollupAddresses, initMessage := DeployOnTestL1(t, ctx, l1Info, l1Backend, chainConfig, common.Address{})
 
 	deployerTxOpts := l1Info.GetDefaultTransactOpts("deployer", ctx)
 	sequencerTxOpts := l1Info.GetDefaultTransactOpts("sequencer", ctx)


### PR DESCRIPTION
In this PR:
- Fix some bugs related with global state
- Hack the stateless block validator and the challenge manager, providing a convenient way to mock the wrong node and challenge for testing
- Mock the wrong global states and hotshot commitments after a certain hotshot height(which I believe will make the challenge end up to the one-step proof of reading hotshot commitment at this certain height)
- Test if the conflict occurs as intended
- Test if one-step prover can read the hotshot commitment

Current state:
- challenges could be created successfully
- bisecting happens and it seems that the one-step proof is submitted sucessfully
- the hash of this challenge will become zero hash after that. (From [here](https://github.com/EspressoSystems/nitro-contracts/blob/acb0ef919cce9f41da531f8dab1b0b31d9860dcb/src/challenge/ChallengeManager.sol#L341) it looks like this means the challenge is solved. But I am not quite sure)

Todo:
- Find out the winner and write a test for it
- Check if the submitted one-step proof is as intended