### PR TITLE
Use faster retry time when HotShot block is not available

### DIFF
--- a/execution/gethexec/espresso_sequencer.go
+++ b/execution/gethexec/espresso_sequencer.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	retryTime = time.Second * 5
+	retryTime = time.Second * 1
 )
 
 type HotShotState struct {


### PR DESCRIPTION
This should lead to smoother block production.