### PR TITLE
Exclude non-espresso messages from commitment check

### DIFF
--- a/arbos/parse_l2_test.go
+++ b/arbos/parse_l2_test.go
@@ -31,7 +31,7 @@ func TestEspressoParsing(t *testing.T) {
 	msg, err := MessageFromEspresso(expectHeader, expectTxes, expectJst)
 	Require(t, err)
 
-	actualTxes, actualJst, err := ParseEspressoMsg(&msg)
+	actualTxes, actualJst, _, err := ParseEspressoMsg(&msg)
 	Require(t, err)
 
 	if !reflect.DeepEqual(actualTxes, expectTxes) {

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -250,7 +250,7 @@ func main() {
 		commitment := espressoTypes.Commitment(wavmio.ReadHotShotCommitment(inboxPos, posInInbox))
 		validatingAgainstEspresso := commitment != [32]byte{}
 		if isL2Message && validatingAgainstEspresso {
-			txs, jst, err := arbos.ParseEspressoMsg(message.Message)
+			txs, jst, _, err := arbos.ParseEspressoMsg(message.Message)
 			if err != nil {
 				panic(err)
 			}

--- a/staker/block_validator.go
+++ b/staker/block_validator.go
@@ -515,7 +515,7 @@ func (v *BlockValidator) createNextValidationEntry(ctx context.Context) (bool, e
 			if err != nil {
 				return false, err
 			}
-			_, prevJst, err := arbos.ParseEspressoMsg(msg.Message)
+			_, prevJst, _, err := arbos.ParseEspressoMsg(msg.Message)
 			if err != nil {
 				prevEspressoJst = prevJst
 				break

--- a/staker/block_validator.go
+++ b/staker/block_validator.go
@@ -501,8 +501,10 @@ func (v *BlockValidator) createNextValidationEntry(ctx context.Context) (bool, e
 		return false, fmt.Errorf("illegal batch msg count %d pos %d batch %d", v.nextCreateBatchMsgCount, pos, endGS.Batch)
 	}
 	var comm espressoTypes.Commitment
-	if v.config().Espresso && msg.Message.Header.Kind == arbostypes.L1MessageType_L2Message {
-		_, jst, err := arbos.ParseEspressoMsg(msg.Message)
+	_, jst, msgKind, err := arbos.ParseEspressoMsg(msg.Message)
+	// If the message is not an espresso message (i.e. delayed inbox message), skip the commitment check.
+	var checkCommitment = msgKind == 10
+	if v.config().Espresso && msg.Message.Header.Kind == arbostypes.L1MessageType_L2Message && checkCommitment {
 		if err != nil {
 			return false, err
 		}

--- a/staker/stateless_block_validator.go
+++ b/staker/stateless_block_validator.go
@@ -386,7 +386,7 @@ func (v *StatelessBlockValidator) CreateReadyValidationEntry(ctx context.Context
 	// Note: this code path is not used in the staker validation pipeline, return to this
 	// when we look into fraud proofs
 	if v.config.Espresso && msg.Message.Header.Kind == arbostypes.L1MessageType_L2Message {
-		_, jst, err := arbos.ParseEspressoMsg(msg.Message)
+		_, jst, _, err := arbos.ParseEspressoMsg(msg.Message)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Short term fix to avoid treating delayed inbox messages as espresso messages, which can cause the validator to fail because it expects a justification. 