### PR TITLE
Fix typos

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -136,7 +136,7 @@ jobs:
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
     #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+    #   modify them (or add more) to build your code for your project, please refer to the EXAMPLE below for guidance.
 
     # - run: |
     #   echo "Run, Build Application using script"

--- a/.github/workflows/espresso-docker.yml
+++ b/.github/workflows/espresso-docker.yml
@@ -2,13 +2,13 @@
 #
 # The reason for building the ARM image natively instead of with QEMU is that
 # the QEMU build always failed after around 40 minutes. I'm currently not sure
-# why it failed. I did also run into insufficient space issuse on public runners
+# why it failed. I did also run into an insufficient space issuse on public runners
 # so it's possible this was always the culprit.
 #
 # After building, the images are merged together to make a multiplatform image.
 #
 # The latest wavm machine is also copied and exported as an artifact. In nitro
-# this seems to be later used as machine for the non-dev nitro-node build.
+# this seems to be later used as a machine for the non-dev nitro-node build.
 # For more details on that see the Dockerfile and ./scripts/download.sh
 name: Espresso Docker build CI
 run-name: Docker build CI triggered from @${{ github.actor }} of ${{ github.head_ref }}

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -109,7 +109,7 @@ type BatchPoster struct {
 	non4844BatchCount  int // Count of consecutive non-4844 batches posted
 	// This is an atomic variable that should only be accessed atomically.
 	// An estimate of the number of batches we want to post but haven't yet.
-	// This doesn't include batches which we don't want to post yet due to the L1 bounds.
+	// This doesn't include batches that we don't want to post yet due to the L1 bounds.
 	backlog         uint64
 	lastHitL1Bounds time.Time // The last time we wanted to post a message but hit the L1 bounds
 
@@ -381,7 +381,7 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 	if err != nil {
 		return nil, err
 	}
-	// Dataposter sender may be external signer address, so we should initialize
+	// Dataposter sender may be an external signer address, so we should initialize
 	// access list after initializing dataposter.
 	b.accessList = func(SequencerInboxAccs, AfterDelayedMessagesRead int) types.AccessList {
 		if !b.config().UseAccessLists || opts.L1Reader.IsParentChainArbitrum() {

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -51,7 +51,7 @@ import (
 )
 
 // Dataposter implements functionality to post transactions on the chain. It
-// is initialized with specified sender/signer and keeps nonce of that address
+// is initialized with the specified sender/signer and keeps nonce of that address
 // as it posts transactions.
 // Transactions are also saved in the queue when it's being sent, and when
 // persistent storage is used for the queue, after restarting the node
@@ -73,7 +73,7 @@ type DataPoster struct {
 	parentChainID256       *uint256.Int
 
 	// These fields are protected by the mutex.
-	// TODO: factor out these fields into separate structure, since now one
+	// TODO: factor out these fields into separate structures, since now one
 	// needs to make sure call sites of methods that change these values hold
 	// the lock (currently ensured by having comments like:
 	// "the mutex must be held by the caller" above the function).
@@ -252,7 +252,7 @@ func rpcClient(ctx context.Context, opts *ExternalSignerCfg) (*rpc.Client, error
 }
 
 // externalSigner returns signer function and ethereum address of the signer.
-// Returns an error if address isn't specified or if it can't connect to the
+// Returns an error if the address isn't specified or if it can't connect to the
 // signer RPC server.
 func externalSigner(ctx context.Context, opts *ExternalSignerCfg) (signerFn, common.Address, error) {
 	if opts.Address == "" {
@@ -379,7 +379,7 @@ func (p *DataPoster) waitForL1Finality() bool {
 	return p.config().WaitForL1Finality && !p.headerReader.IsParentChainArbitrum()
 }
 
-// Requires the caller hold the mutex.
+// Requires the caller to hold the mutex.
 // Returns the next nonce, its metadata if stored, a bool indicating if the metadata is present, the cumulative weight, and an error if present.
 // Unlike GetNextNonceAndMeta, this does not call the metadataRetriever if the metadata is not stored in the queue.
 func (p *DataPoster) getNextNonceAndMaybeMeta(ctx context.Context, thisWeight uint64) (uint64, []byte, bool, uint64, error) {

--- a/arbnode/dataposter/dataposter_test.go
+++ b/arbnode/dataposter/dataposter_test.go
@@ -291,12 +291,12 @@ func TestFeeAndTipCaps_EnoughBalance_NoBacklog_NoUnconfirmed_BlobTx(t *testing.T
 		t.Fatalf("%s", err)
 	}
 
-	// There is no backlog and almost no time elapses since the batch data was
-	// created to when it was posted so the maxNormalizedFeeCap is ~60.01 gwei.
+	// There is no backlog and almost no time has elapsed since the batch data was
+	// created when it was posted so the maxNormalizedFeeCap is ~60.01 gwei.
 	// This is multiplied with the normalizedGas to get targetMaxCost.
 	// This is greatly in excess of currentTotalCost * MaxFeeBidMultipleBips,
 	// so targetMaxCost is reduced to the current base fee + suggested tip cap +
-	// current blob fee multipled by MaxFeeBidMultipleBips (factor of 10).
+	// current blob fee multiplied by MaxFeeBidMultipleBips (factor of 10).
 	// The blob and non blob factors are then proportionally split out and so
 	// the newGasFeeCap is set to (current base fee + suggested tip cap) * 10
 	// and newBlobFeeCap is set to current blob gas base fee (1 wei

--- a/arbnode/dataposter/storage/storage.go
+++ b/arbnode/dataposter/storage/storage.go
@@ -80,7 +80,7 @@ func (qt *QueuedTransaction) DecodeRLP(s *rlp.Stream) error {
 	return nil
 }
 
-// LegacyQueuedTransaction is used for backwards compatibility.
+// LegacyQueuedTransaction is used for backward compatibility.
 // Before https://github.com/OffchainLabs/nitro/pull/1773: the queuedTransaction
 // looked like this and was rlp encoded directly. After the pr, we are store
 // rlp encoding of Meta into queuedTransaction and rlp encoding it once more
@@ -187,7 +187,7 @@ func (le *LegacyEncoderDecoder) Decode(data []byte) (*QueuedTransaction, error) 
 	return decode(data)
 }
 
-// Typically interfaces belong to where they are being used, not at implementing
+// Typically interfaces belong to where they are being used, not to implementing
 // site, but this is used in all storages (besides no-op) and all of them
 // require all the functions for this interface.
 type EncoderDecoderInterface interface {

--- a/arbnode/message_pruner_test.go
+++ b/arbnode/message_pruner_test.go
@@ -32,15 +32,15 @@ func TestMessagePrunerTwoHalves(t *testing.T) {
 
 	messagesCount := uint64(10)
 	_, transactionStreamerDb, pruner := setupDatabase(t, messagesCount, messagesCount)
-	// In first iteration message till messagesCount/2 are tried to be deleted.
+	// In the first iteration message till messagesCount/2 are tried to be deleted.
 	err := pruner.deleteOldMessagesFromDB(ctx, arbutil.MessageIndex(messagesCount/2), messagesCount/2)
 	Require(t, err)
-	// In first iteration all the message till messagesCount/2 are deleted.
+	// In the first iteration all the message till messagesCount/2 are deleted.
 	checkDbKeys(t, messagesCount/2, transactionStreamerDb, messagePrefix)
-	// In second iteration message till messagesCount are tried to be deleted.
+	// In the second iteration message till messagesCount are tried to be deleted.
 	err = pruner.deleteOldMessagesFromDB(ctx, arbutil.MessageIndex(messagesCount), messagesCount)
 	Require(t, err)
-	// In second iteration all the message till messagesCount are deleted.
+	// In the second iteration all the message till messagesCount are deleted.
 	checkDbKeys(t, messagesCount, transactionStreamerDb, messagePrefix)
 }
 

--- a/arbnode/seq_coordinator.go
+++ b/arbnode/seq_coordinator.go
@@ -574,7 +574,7 @@ func (c *SeqCoordinator) update(ctx context.Context) time.Duration {
 		if err != nil {
 			log.Warn("coordinator failed to parse message from redis", "pos", msgToRead, "err", err)
 			msgReadErr = fmt.Errorf("failed to parse message: %w", err)
-			// redis messages spelled "INVALID" will be parsed as invalid L1 message, but only one at a time
+			// redis messages spelled "INVALID" will be parsed as invalid L1 messages, but only one at a time
 			if len(messages) > 0 || string(rsBytes) != redisutil.INVALID_VAL {
 				break
 			}


### PR DESCRIPTION

This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.

Hope it helps,
Elias.