### PR TITLE
Refactor and expand validator preconditions to espresso STF logic

### DIFF
--- a/cmd/replay/espresso_validation.go
+++ b/cmd/replay/espresso_validation.go
@@ -42,8 +42,5 @@ func handleEspressoPreConditions(message *arbostypes.MessageWithMetadata, isEnab
 			panic("The messaged received by the STF is not an Espresso message, but the validator is running in Espresso mode")
 		}
 	}
-	panicCase := func() {
-		// This no-op allows us to cause no panic in the code that receives the result of this function while keeping the function signature consistent.
-	}
-	return validatingAgainstEspresso, panicCase
+	return validatingAgainstEspresso, nil // return nil for the panic handler such that it is a no-op in the caller if no errors need occur.
 }

--- a/cmd/replay/espresso_validation.go
+++ b/cmd/replay/espresso_validation.go
@@ -20,7 +20,7 @@ import (
 // / 		as this is an invalid state for the STF to reside in.
 // /
 func handleEspressoPreConditions(message *arbostypes.MessageWithMetadata, isEnabled bool) bool {
-	//calculate and cache all values needed to determine if the preconditions are met to enter the Espresso STF logic
+	// calculate and cache all values needed to determine if the preconditions are met to enter the Espresso STF logic
 	isNonEspressoMessage := arbos.IsL2NonEspressoMsg(message.Message)
 	isEspressoMessage := !isNonEspressoMessage
 	hotShotHeight := wavmio.GetEspressoHeight()

--- a/cmd/replay/espresso_validation.go
+++ b/cmd/replay/espresso_validation.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/offchainlabs/nitro/arbos"
+	"github.com/offchainlabs/nitro/arbos/arbostypes"
+	"github.com/offchainlabs/nitro/wavmio"
+)
+
+// / Perform Espresso
+// /
+// / Description: This function takes in the most recently recieved message (of type arbostypes.MessageWithMetadata),
+// /	 			  and a boolean from the ChainConfig
+// / 			 and uses the parameters to perform all checks gating the modified STF logic in the arbitrum validator.
+// /
+// / Return: A boolean representing the result of a logical and of all checks (that don't result in panics) gating espressos STF logic.
+// /
+// / Panics: This function will panic if the message type is not an espresso message, but the HotShot height is non zero
+// / 		as this is an invalid state for the STF to reside in.
+// /
+func handleEspressoPreConditions(message *arbostypes.MessageWithMetadata, isEnabled bool) bool {
+	//calculate and cache all values needed to determine if the preconditions are met to enter the Espresso STF logic
+	isNonEspressoMessage := arbos.IsL2NonEspressoMsg(message.Message)
+	hotShotHeight := wavmio.GetEspressoHeight()
+	validatingEspressoLivenessFailure := isNonEspressoMessage && (isEnabled || hotShotHeight != 0)
+	validatingAgainstEspresso := !isNonEspressoMessage && isEnabled
+
+	// If conditions are such that we have been working in espresso mode, but we are suddenly receiving non espresso messages, something wrong
+	// something incorrect has occured and we must panic
+	if validatingEspressoLivenessFailure {
+		l1Block := message.Message.Header.BlockNumber
+		if wavmio.IsHotShotLive(l1Block) {
+			panic(fmt.Sprintf("getting the centralized message while hotshot is good, l1Height: %v", l1Block))
+		}
+		panic("The messaged recieved by the STF is not an Espresso message, but the validator is running in Espresso mode")
+	}
+	return validatingAgainstEspresso
+}

--- a/cmd/replay/espresso_validation.go
+++ b/cmd/replay/espresso_validation.go
@@ -8,7 +8,7 @@ import (
 	"github.com/offchainlabs/nitro/wavmio"
 )
 
-// / Perform Espresso
+// / Handle Espresso Pre Conditions
 // /
 // / Description: This function takes in the most recently recieved message (of type arbostypes.MessageWithMetadata),
 // /	 			  and a boolean from the ChainConfig

--- a/cmd/replay/espresso_validation.go
+++ b/cmd/replay/espresso_validation.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-
 	"github.com/offchainlabs/nitro/arbos"
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/wavmio"
@@ -10,31 +9,41 @@ import (
 
 // / Handle Espresso Pre Conditions
 // /
-// / Description: This function takes in the most recently recieved message (of type arbostypes.MessageWithMetadata),
+// / Description: This function takes in the most recently received message (of type arbostypes.MessageWithMetadata),
 // /	 			  and a boolean from the ChainConfig
 // / 			 and uses the parameters to perform all checks gating the modified STF logic in the arbitrum validator.
 // /
 // / Return: A boolean representing the result of a logical and of all checks (that don't result in panics) gating espressos STF logic.
 // /
-// / Panics: This function will panic if the message type is not an espresso message, but the HotShot height is non zero
+// / Panics: This function will panic if the message type is not an espresso message, but the HotShot height is non-zero
 // / 		as this is an invalid state for the STF to reside in.
 // /
-func handleEspressoPreConditions(message *arbostypes.MessageWithMetadata, isEnabled bool) bool {
+func handleEspressoPreConditions(message *arbostypes.MessageWithMetadata, isEnabled bool) (bool, func()) {
 	// calculate and cache all values needed to determine if the preconditions are met to enter the Espresso STF logic
 	isNonEspressoMessage := arbos.IsL2NonEspressoMsg(message.Message)
-	isEspressoMessage := !isNonEspressoMessage
-	hotShotHeight := wavmio.GetEspressoHeight()
-	validatingEspressoLivenessFailure := isNonEspressoMessage && (isEnabled || hotShotHeight != 0)
-	validatingAgainstEspresso := isEspressoMessage && isEnabled
+	hotshotHeight := wavmio.GetEspressoHeight()
 
-	// If conditions are such that we have been working in espresso mode, but we are suddenly receiving non espresso messages, something wrong
-	// something incorrect has occured and we must panic
+	validatingEspressoLivenessFailure := isNonEspressoMessage && isEnabled
+	validatingEspressoHeightFailure := isNonEspressoMessage && hotshotHeight != 0
+	validatingAgainstEspresso := arbos.IsEspressoMsg(message.Message) && isEnabled
+
 	if validatingEspressoLivenessFailure {
-		l1Block := message.Message.Header.BlockNumber
-		if wavmio.IsHotShotLive(l1Block) {
-			panic(fmt.Sprintf("getting the centralized message while hotshot is good, l1Height: %v", l1Block))
+		// previously this was the only other branch that was checked when `validatingAgainstEspresso`
+		return validatingAgainstEspresso, func() {
+			l1Block := message.Message.Header.BlockNumber
+			if wavmio.IsHotShotLive(l1Block) {
+				panic(fmt.Sprintf("getting the centralized message while hotshot is good, l1Height: %v", l1Block))
+			}
 		}
-		panic("The messaged recieved by the STF is not an Espresso message, but the validator is running in Espresso mode")
+	} else if validatingEspressoHeightFailure {
+		// If conditions are such that we have been working in espresso mode, but we are suddenly receiving non espresso messages,
+		// something incorrect has occurred and we must panic
+		return validatingAgainstEspresso, func() {
+			panic("The messaged received by the STF is not an Espresso message, but the validator is running in Espresso mode")
+		}
 	}
-	return validatingAgainstEspresso
+	panicCase := func() {
+		// This no-op allows us to cause no panic in the code that receives the result of this function while keeping the function signature consistent.
+	}
+	return validatingAgainstEspresso, panicCase
 }

--- a/cmd/replay/espresso_validation.go
+++ b/cmd/replay/espresso_validation.go
@@ -22,9 +22,10 @@ import (
 func handleEspressoPreConditions(message *arbostypes.MessageWithMetadata, isEnabled bool) bool {
 	//calculate and cache all values needed to determine if the preconditions are met to enter the Espresso STF logic
 	isNonEspressoMessage := arbos.IsL2NonEspressoMsg(message.Message)
+	isEspressoMessage := !isNonEspressoMessage
 	hotShotHeight := wavmio.GetEspressoHeight()
 	validatingEspressoLivenessFailure := isNonEspressoMessage && (isEnabled || hotShotHeight != 0)
-	validatingAgainstEspresso := !isNonEspressoMessage && isEnabled
+	validatingAgainstEspresso := isEspressoMessage && isEnabled
 
 	// If conditions are such that we have been working in espresso mode, but we are suddenly receiving non espresso messages, something wrong
 	// something incorrect has occured and we must panic

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -280,8 +280,7 @@ func main() {
 		}
 
 		// Handle the various pre-conditions and panics that can happen before we should enter the espresso logic in the validators STF
-		validatingAgainstEspresso := handleEspressoPreConditions(message, chainConfig.ArbitrumChainParams.EnableEspresso)
-
+		validatingAgainstEspresso, panicHandler := handleEspressoPreConditions(message, chainConfig.ArbitrumChainParams.EnableEspresso)
 		if validatingAgainstEspresso {
 			txs, jst, err := arbos.ParseEspressoMsg(message.Message)
 			if err != nil {
@@ -326,6 +325,9 @@ func main() {
 				espressocrypto.VerifyNamespace(chainConfig.ChainID.Uint64(), *jst.Proof, *jst.Header.PayloadCommitment, *jst.Header.NsTable, txs, *jst.VidCommon)
 			}
 
+		} else {
+			// Call the error case closure returned by handleEspressoPreconditions()
+			panicHandler()
 		}
 
 		newBlock, _, err = arbos.ProduceBlock(message.Message, message.DelayedMessagesRead, lastBlockHeader, statedb, chainContext, chainConfig, batchFetcher, false)

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -325,11 +325,9 @@ func main() {
 				espressocrypto.VerifyNamespace(chainConfig.ChainID.Uint64(), *jst.Proof, *jst.Header.PayloadCommitment, *jst.Header.NsTable, txs, *jst.VidCommon)
 			}
 
-		} else {
-			// Call the error case closure returned by handleEspressoPreconditions()
-			if panicHandler != nil {
-				panicHandler()
-			}
+		} else if panicHandler != nil {
+			// Call the error case closure returned by handleEspressoPreconditions() if it isn't nil
+			panicHandler()
 		}
 
 		newBlock, _, err = arbos.ProduceBlock(message.Message, message.DelayedMessagesRead, lastBlockHeader, statedb, chainContext, chainConfig, batchFetcher, false)

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -327,7 +327,9 @@ func main() {
 
 		} else {
 			// Call the error case closure returned by handleEspressoPreconditions()
-			panicHandler()
+			if panicHandler != nil {
+				panicHandler()
+			}
 		}
 
 		newBlock, _, err = arbos.ProduceBlock(message.Message, message.DelayedMessagesRead, lastBlockHeader, statedb, chainContext, chainConfig, batchFetcher, false)

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -279,8 +279,9 @@ func main() {
 			return wavmio.ReadInboxMessage(batchNum), nil
 		}
 
-		validatingAgainstEspresso := arbos.IsEspressoMsg(message.Message) && chainConfig.ArbitrumChainParams.EnableEspresso
-		validatingEspressoLivenessFailure := arbos.IsL2NonEspressoMsg(message.Message) && chainConfig.ArbitrumChainParams.EnableEspresso
+		// Handle the various pre-conditions and panics that can happen before we should enter the espresso logic in the validators STF
+		validatingAgainstEspresso := handleEspressoPreConditions(message, chainConfig.ArbitrumChainParams.EnableEspresso)
+
 		if validatingAgainstEspresso {
 			txs, jst, err := arbos.ParseEspressoMsg(message.Message)
 			if err != nil {
@@ -325,11 +326,6 @@ func main() {
 				espressocrypto.VerifyNamespace(chainConfig.ChainID.Uint64(), *jst.Proof, *jst.Header.PayloadCommitment, *jst.Header.NsTable, txs, *jst.VidCommon)
 			}
 
-		} else if validatingEspressoLivenessFailure {
-			l1Block := message.Message.Header.BlockNumber
-			if wavmio.IsHotShotLive(l1Block) {
-				panic(fmt.Sprintf("getting the centralized message while hotshot is good, l1Height: %v", l1Block))
-			}
 		}
 
 		newBlock, _, err = arbos.ProduceBlock(message.Message, message.DelayedMessagesRead, lastBlockHeader, statedb, chainContext, chainConfig, batchFetcher, false)


### PR DESCRIPTION
Closes [#140](https://github.com/EspressoSystems/nitro-espresso-integration/issues/140) 


### This PR:

Refactors the current checks before entering the espresso logic for the validator STF into it's own function to improve readability. Additionally, this pr adds an additional item to validate that if the hotshot height is non zero, that the message being received is an espresso message. In the event that the hotshot height is nonzero, and the message received is not an espresso message, the validator now panics.

### This PR does not:
Add a unit test in espresso_machine_test.go as the new panics only occur whenever the message being received is not an espresso message, and I was unable to determine how to feed a non espresso message to the validator logic. 

### Key places to review:

The new file that lives in `nitro-espresso-integration/cmd/replay/espresso_validation.go`

The changed logic on line 283 of `nitro-espresso-integration/cmd/replay/main`

 ### How to test this PR:

`go test -run ^TestEspressoArbMachine$ github.com/offchainlabs/nitro/system_tests -v`  
This test will validate that no previous behavior has been broken by these changes.
