### PR TITLE
Release 20240723 with 20240723-consensus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -213,12 +213,13 @@ RUN ./download-machine.sh consensus-v31 0x260f5fa5c3176a856893642e149cf128b5a8de
 
 #Download Espresso WASM machine
 COPY ./scripts/download-machine-espresso.sh .
-#
-# To use a new wasm machine specify release tag from the page
-# https://github.com/EspressoSystems/nitro-espresso-integration/releases and the
-# corresponding module-root.
-#
-RUN ./download-machine-espresso.sh 20240711 0x5409e2c3aab6db3d6cea9603646d6cdf2ac6bc1b39325939ba81a498f88f334f
+# To use a new wasm machine
+# 1. Create a release on github: for example YYYYMMDD-consensus
+# 2. Find the module module-root.txt in the release artifacts on
+#    https://github.com/EspressoSystems/nitro-espresso-integration/releases
+#    and add the corresponding download step below.
+# 3. Create a new release on github with the change: for example YYYYMMDD
+RUN ./download-machine-espresso.sh 20240723-consensus 0x2422802a7cda99737209430b103689205bc8e56eab8b08c6ad409e65e45c3145
 
 FROM golang:1.21.10-bookworm AS node-builder
 WORKDIR /workspace

--- a/flake.nix
+++ b/flake.nix
@@ -136,6 +136,7 @@
                 yarn
 
                 python3
+                wget
 
                 # wasm
                 rust-cbindgen

--- a/scripts/download-machine-espresso.sh
+++ b/scripts/download-machine-espresso.sh
@@ -14,8 +14,16 @@ set -euxo pipefail
 mkdir "$2"
 ln -sfT "$2" latest
 cd "$2"
-echo "$2" > module-root.txt
+
 url_base="https://github.com/EspressoSystems/nitro-espresso-integration/releases/download/$1"
+
+# Download the module root from the release page
+wget "$url_base/module-root.txt"
+
+# Check that the module root specified matches the release
+grep -q "$2" module-root.txt ||
+    (echo "Module root mismatch: specified $2 != release $(cat module-root.txt)" && exit 1)
+
 wget "$url_base/machine.wavm.br"
 
 status_code="$(curl -LI "$url_base/replay.wasm" -so /dev/null -w '%{http_code}')"


### PR DESCRIPTION
This should include all our changes for nitro v3.1.

- Check that the module root matches when downloading releases from github.

CI with docker build run: https://github.com/EspressoSystems/nitro-espresso-integration/actions/runs/10056019112