### PR TITLE
Check all "not found" errors

### DIFF
--- a/arbnode/dataposter/dbstorage/storage.go
+++ b/arbnode/dataposter/dbstorage/storage.go
@@ -62,7 +62,7 @@ func (s *Storage) Get(_ context.Context, index uint64) (*storage.QueuedTransacti
 	key := idxToKey(index)
 	value, err := s.db.Get(key)
 	if err != nil {
-		if errors.Is(err, leveldb.ErrNotFound) {
+		if isErrNotFound(err) {
 			return nil, nil
 		}
 		return nil, err


### PR DESCRIPTION
Currently only the leveldb not found errors are handled. If a pebble not found error is returned by the backend it is propagated, causing the batchposter to fail to send transactions.

With this change all DB not found errors are handled the same way.
