### PR TITLE
Save digest artifacts into own directory per run

### DIFF
--- a/.github/actions/docker-image/action.yml
+++ b/.github/actions/docker-image/action.yml
@@ -44,10 +44,13 @@ runs:
         cache-to: type=gha,mode=max
         outputs: type=image,name=${{ inputs.images }},push-by-digest=true,name-canonical=true,push=true
 
+    # This will upload the digest for each architecture to the same artifact,
+    # Note: upload-artifact@v4 will no longer support this.
+    # https://github.com/actions/upload-artifact?tab=readme-ov-file#not-uploading-to-the-same-artifact
     - name: Export digest
       shell: bash
       run: |
-        digest_dir="${{ runner.temp }}/${{ inputs.target }}-digests"
+        digest_dir="${{ runner.temp }}/${{ inputs.target }}-${{ github.run_number }}-digests"
         mkdir -p "${digest_dir}"
         digest="${{ steps.build.outputs.digest }}"
         touch "${digest_dir}/${digest#sha256:}"
@@ -56,6 +59,6 @@ runs:
       uses: actions/upload-artifact@v3
       with:
         name: "${{ inputs.target }}-digests"
-        path: "${{ runner.temp }}/${{ inputs.target }}-digests/*"
+        path: "${{ runner.temp }}/${{ inputs.target }}-${{ github.run_number }}-digests/*"
         if-no-files-found: error
         retention-days: 1

--- a/.github/workflows/espresso-docker.yml
+++ b/.github/workflows/espresso-docker.yml
@@ -161,6 +161,16 @@ jobs:
       - name: Create manifest list and push
         working-directory: "${{ runner.temp }}/digests"
         run: |
+          # Count the number of files in the directory
+          file_count=$(find . -type f | wc -l)
+
+          ls -lah
+
+          if [ "$file_count" -ne 2 ]; then
+            echo "Should have exactly 2 digests to combine, something went wrong"
+            exit 1
+          fi
+
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ matrix.image }}@sha256:%s ' *)
       - name: Inspect image

--- a/.github/workflows/espresso-docker.yml
+++ b/.github/workflows/espresso-docker.yml
@@ -146,6 +146,10 @@ jobs:
           username: ${{ github.repository_owner  }}
           password: ${{ secrets.GITHUB_TOKEN  }}
 
+      - name: Remove digests dir
+        run: |
+          rm -rf "${{ runner.temp }}/digests"
+
       - name: Download digests
         uses: actions/download-artifact@v3
         with:
@@ -164,10 +168,9 @@ jobs:
           # Count the number of files in the directory
           file_count=$(find . -type f | wc -l)
 
-          ls -lah
-
           if [ "$file_count" -ne 2 ]; then
             echo "Should have exactly 2 digests to combine, something went wrong"
+            ls -lah
             exit 1
           fi
 


### PR DESCRIPTION
Close #182

Currently it seems that we have too many digests in the folder and I think this breaks the assembly of the multiarch docker image.

With this change only digests for the same run are saved in the same directory.