### PR TITLE
Inbox Multiplexer

### DIFF
--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -620,6 +620,10 @@ func (b *multiplexerBackend) ReadDelayedInbox(seqNum uint64) (*arbostypes.L1Inco
 	return b.inbox.GetDelayedMessage(seqNum)
 }
 
+func (b *multiplexerBackend) RecedeSequencerInbox() {
+	panic("This method is not supposed to be used")
+}
+
 var delayedMessagesMismatch = errors.New("sequencer batch delayed messages missing or different")
 
 func (t *InboxTracker) AddSequencerBatches(ctx context.Context, client arbutil.L1Interface, batches []*SequencerInboxBatch) error {

--- a/arbos/arbostypes/messagewithmeta.go
+++ b/arbos/arbostypes/messagewithmeta.go
@@ -49,4 +49,6 @@ func (m *MessageWithMetadata) Hash(sequenceNumber arbutil.MessageIndex, chainId 
 type InboxMultiplexer interface {
 	Pop(context.Context) (*MessageWithMetadata, error)
 	DelayedMessagesRead() uint64
+	RecedeSequencerMessage(context.Context) ([]byte, error)
+	SetCurrentIndex(uint64)
 }

--- a/arbstate/inbox_fuzz_test.go
+++ b/arbstate/inbox_fuzz_test.go
@@ -57,6 +57,10 @@ func (b *multiplexerBackend) ReadDelayedInbox(seqNum uint64) (*arbostypes.L1Inco
 	return msg, nil
 }
 
+func (b *multiplexerBackend) RecedeSequencerInbox() {
+	panic("This method is not supposed to be used here")
+}
+
 func FuzzInboxMultiplexer(f *testing.F) {
 	f.Fuzz(func(t *testing.T, seqMsg []byte, delayedMsg []byte) {
 		if len(seqMsg) < 40 {

--- a/wavmio/higher.go
+++ b/wavmio/higher.go
@@ -85,6 +85,11 @@ func AdvanceInboxMessage() {
 	setGlobalStateU64(IDX_INBOX_POSITION, pos+1)
 }
 
+func RecedeInboxMessage() {
+	pos := getGlobalStateU64(IDX_INBOX_POSITION)
+	setGlobalStateU64(IDX_INBOX_POSITION, pos-1)
+}
+
 func ResolveTypedPreimage(ty arbutil.PreimageType, hash common.Hash) ([]byte, error) {
 	return readBuffer(func(offset uint32, buf unsafe.Pointer) uint32 {
 		hashUnsafe := unsafe.Pointer(&hash[0])

--- a/wavmio/stub.go
+++ b/wavmio/stub.go
@@ -154,6 +154,10 @@ func AdvanceInboxMessage() {
 	seqAdvanced++
 }
 
+func RecedeInboxMessage() {
+	seqAdvanced--
+}
+
 func ResolveTypedPreimage(ty arbutil.PreimageType, hash common.Hash) ([]byte, error) {
 	val, ok := preimages[hash]
 	if !ok {


### PR DESCRIPTION
## This PR:
Shows how we can find the messages required for the completeness check in the WASM reader.
In brief, we adds some functions to the multiplexer that helps us `getPrevMessage` one by one. By skipping the unconfirmed L2 messages and fetching the transaction number of the hotshot blocks, we can build the hotshot payload.