### PR TITLE
Pin the golint version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         uses: golangci/golangci-lint-action@v5
         with:
           annotations: false
-          version: latest
+          version: v1.59.1
           skip-pkg-cache: true
       - name: Custom Lint
         run: |


### PR DESCRIPTION
### This PR:
Pin the golint version. As the latest golint version [v1.60.1](https://github.com/golangci/golangci-lint/releases/tag/v1.60.1) feels unhappy with many files that are maintained by our upstream and in our recent plan, we won't sync with the upstream as soon as they fix this issue.
So we pin the golint version to unblock our CI.
