### PR TITLE
Nitro testnode migration test

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,7 @@
 [submodule "arbitrator/langs/bf"]
 	path = arbitrator/langs/bf
 	url = https://github.com/OffchainLabs/stylus-sdk-bf.git
+[submodule "orbit-actions"]
+	path = orbit-actions
+	url = git@github.com:EspressoSystems/orbit-actions.git
+	branch = espresso-migration

--- a/migration/create-espresso-integrated-nitro-node.bash
+++ b/migration/create-espresso-integrated-nitro-node.bash
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ESPRESSO_VERSION=ghcr.io/espressosystems/nitro-espresso-integration/nitro-node-dev:integration
+lightClientAddr=0xb6eb235fa509e3206f959761d11e3777e16d0e98
+espresso=true
+
+cd ../nitro-testnode
+
+# docker pull and tag the espresso integration nitro node.
+docker pull $ESPRESSO_VERSION
+
+docker tag $ESPRESSO_VERSION espresso-integration-testnode
+
+# write the espresso configs to the config volume
+echo == Writing configs
+docker compose run scripts write-config --espresso $espresso --lightClientAddress $lightClientAddr
+
+# do whatever other espresso setup is needed.
+
+# run esprsso-integrated nitro node for sequencing.
+docker compose up espresso-sequencer --detach

--- a/migration/migration-test.bash
+++ b/migration/migration-test.bash
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#enter the testnode directory
+cd ../nitro-testnode
+
+#Initialize a standard network not compatible with espresso
+./test-node.bash --simple --init --detach 
+
+#start espresso sequencer node
+docker compose up espresso-dev-node --detach
+
+#shutdown nitro node'
+docker stop nitro-testnode-sequencer-1
+# return to the migration directory to execute the script for starting an espresso-integrated nitro node
+cd ../migration
+
+#start nitro node in new docker container with espresso image (create a new script to do this from pieces of test-node.bash)
+./create-espresso-integrated-nitro-node.bash 
+
+#source env files needed by forge
+source /test-env/.env
+
+#forge script to deploy new OSP entry and upgrade actions
+export NEW_OSP_ENTRY=`forge script --chain $CHAIN_NAME ../orbit-actions/contracts/parent-chain/contract-upgrades/DeployEspressoOsp.s.sol:DeployEspressoOsp --rpc-url $RPC_URL --broadcast --verify -vvvv | tail -n 1 | tr -d '\r\n'` # save ospentryaddr here to propegate to next part of script.    
+#forge script to execute upgrade actions
+forge script --chain $CHAIN_NAME ../orbit-actions/contracts/parent-chain/contract-upgrades/DeployAndExecuteEspressoMigrationActions.s.sol --rpc-url $RPC_URL --broadcast --verify -vvvv
+#check the upgrade happened
+
+
+#./test-node.bash --espresso --latest-espresso-image --validate --tokenbridge --init --detach

--- a/migration/test-env/.env
+++ b/migration/test-env/.env
@@ -1,0 +1,13 @@
+# env vars for chain name and rpc_url
+export CHAIN_NAME="1337"
+export RPC_URL="http://localhost:8545"
+# env vars for new OSP deployment
+export HOTSHOT_ADDRESS=""
+# env vars for osp migration action contract
+export NEW_WASM_MODULE_ROOT="0x43683fe4e619e9ee7c0d959259d10ff2a38f4325a2b8936c47d9162704fe072a"
+export CURRENT_OSP_ENTRY="0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97"
+export CURRENT_WASM_MODULE_ROOT="0xbc1026ff45c20ea97e9e6057224a5668ea78d8f885c9b14fc849238e8ef5c5dc"
+export ROLLUP_ADDRESS="0xF2099c4783921f44Ac988B67e743DAeFd4A00efd"
+export PROXY_ADMIN="0x94e2090Fb86906C799A67263e6beAe528b81B3D6"
+# env vars for ArbOS upgrade action.
+export UPGRADE_TIMESTAMP="1723664126"


### PR DESCRIPTION
Closes # [162](https://github.com/EspressoSystems/nitro-espresso-integration/issues/162)

### This PR:

Is meant to work in conjunction with the PR in the nitro-testnode [here](https://github.com/EspressoSystems/nitro-testnode/pull/46)  to properly locate all items for the upgrade actions. (It's there is some duplication of the orbit-actions submodule as a result, as well as the bash scripts. The bash scripts in this PR represent their current state.


### Key places to review:
 Running the associated forge scripts present in the migration-test.bash script with a running instance of the testnode (with the --simple flag) will show the current progress getting the scripts to run.
 I left off after deploying the new OSP entry and then seeing the second script claim the address is not a contract.
