### PR TITLE
Remove the global state for HotShot height

### DIFF
--- a/.github/workflows/espresso-e2e.yml
+++ b/.github/workflows/espresso-e2e.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,7 +14,7 @@
 [submodule "contracts"]
 	path = contracts
 	url = https://github.com/EspressoSystems/nitro-contracts.git
-	branch = jh/remove-global-state
+	branch = develop
 [submodule "arbitrator/wasm-testsuite/testsuite"]
 	path = arbitrator/wasm-testsuite/testsuite
 	url = https://github.com/WebAssembly/testsuite.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "go-ethereum"]
 	path = go-ethereum
 	url = https://github.com/EspressoSystems/geth-arbitrum.git
-	branch = integration
+	branch = jh/remove-global-state
 [submodule "fastcache"]
 	path = fastcache
 	url = https://github.com/OffchainLabs/fastcache.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,7 +14,7 @@
 [submodule "contracts"]
 	path = contracts
 	url = https://github.com/EspressoSystems/nitro-contracts.git
-	branch = develop
+	branch = jh/remove-global-state
 [submodule "arbitrator/wasm-testsuite/testsuite"]
 	path = arbitrator/wasm-testsuite/testsuite
 	url = https://github.com/WebAssembly/testsuite.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "go-ethereum"]
 	path = go-ethereum
 	url = https://github.com/EspressoSystems/geth-arbitrum.git
-	branch = jh/remove-global-state
+	branch = integration
 [submodule "fastcache"]
 	path = fastcache
 	url = https://github.com/OffchainLabs/fastcache.git

--- a/arbitrator/jit/src/machine.rs
+++ b/arbitrator/jit/src/machine.rs
@@ -202,7 +202,7 @@ pub struct WasmEnv {
     /// Go's general runtime state
     pub go_state: GoRuntimeState,
     /// An ordered list of the 8-byte globals
-    pub small_globals: [u64; 3],
+    pub small_globals: [u64; 2],
     /// An ordered list of the 32-byte globals
     pub large_globals: [Bytes32; 2],
     /// An oracle allowing the prover to reverse keccak256
@@ -288,7 +288,7 @@ impl WasmEnv {
 
         let last_block_hash = parse_hex(&opts.last_block_hash, "--last-block-hash")?;
         let last_send_root = parse_hex(&opts.last_send_root, "--last-send-root")?;
-        env.small_globals = [opts.inbox_position, opts.position_within_message, 0];
+        env.small_globals = [opts.inbox_position, opts.position_within_message];
         env.large_globals = [last_block_hash, last_send_root];
         Ok(env)
     }
@@ -318,7 +318,6 @@ impl WasmEnv {
         check!(socket::write_u8(writer, socket::SUCCESS));
         check!(socket::write_u64(writer, self.small_globals[0]));
         check!(socket::write_u64(writer, self.small_globals[1]));
-        check!(socket::write_u64(writer, self.small_globals[2]));
         check!(socket::write_bytes32(writer, &self.large_globals[0]));
         check!(socket::write_bytes32(writer, &self.large_globals[1]));
         check!(socket::write_u64(writer, memory_used.bytes().0 as u64));

--- a/arbitrator/jit/src/wavmio.rs
+++ b/arbitrator/jit/src/wavmio.rs
@@ -298,16 +298,11 @@ fn ready_hostio(env: &mut WasmEnv) -> MaybeEscape {
     let position_within_message = socket::read_u64(stream)?;
     let last_block_hash = socket::read_bytes32(stream)?;
     let last_send_root = socket::read_bytes32(stream)?;
-    let validated_hotshot_height = socket::read_u64(stream)?;
     let hotshot_comm = socket::read_bytes32(stream)?;
     let block_height = socket::read_u64(stream)?;
     let hotshot_liveness = socket::read_u8(stream)?;
 
-    env.small_globals = [
-        inbox_position,
-        position_within_message,
-        validated_hotshot_height,
-    ];
+    env.small_globals = [inbox_position, position_within_message];
     env.large_globals = [last_block_hash, last_send_root];
     if hotshot_liveness > 0 {
         // HotShot is up

--- a/arbitrator/prover/src/machine.rs
+++ b/arbitrator/prover/src/machine.rs
@@ -780,7 +780,7 @@ impl From<Function> for FunctionSerdeAll {
 // uint64 - position_within_message
 // uint64 - espresso hotshot height
 pub const GLOBAL_STATE_BYTES32_NUM: usize = 2;
-pub const GLOBAL_STATE_U64_NUM: usize = 3;
+pub const GLOBAL_STATE_U64_NUM: usize = 2;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[repr(C)]

--- a/arbitrator/prover/src/main.rs
+++ b/arbitrator/prover/src/main.rs
@@ -85,8 +85,6 @@ struct Opts {
     skip_until_host_io: bool,
     #[structopt(long)]
     max_steps: Option<u64>,
-    #[structopt(long, default_value = "0")]
-    hotshot_height: u64,
 }
 
 fn file_with_stub_header(path: &Path, headerlength: usize) -> Result<Vec<u8>> {
@@ -186,11 +184,7 @@ fn main() -> Result<()> {
     let last_send_root = decode_hex_arg(&opts.last_send_root, "--last-send-root")?;
 
     let global_state = GlobalState {
-        u64_vals: [
-            opts.inbox_position,
-            opts.position_within_message,
-            opts.hotshot_height,
-        ],
+        u64_vals: [opts.inbox_position, opts.position_within_message],
         bytes32_vals: [last_block_hash, last_send_root],
     };
 

--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -556,7 +556,6 @@ func FinalizeBlock(header *types.Header, txs types.Transactions, statedb *state.
 		var sendCount uint64
 		var nextL1BlockNumber uint64
 		var arbosVersion uint64
-		var hotShotHeight uint64
 
 		if header.Number.Uint64() == chainConfig.ArbitrumChainParams.GenesisBlockNum {
 			arbosVersion = chainConfig.ArbitrumChainParams.InitialArbOSVersion
@@ -572,14 +571,12 @@ func FinalizeBlock(header *types.Header, txs types.Transactions, statedb *state.
 			sendCount, _ = acc.Size()
 			nextL1BlockNumber, _ = state.Blockhashes().L1BlockNumber()
 			arbosVersion = state.ArbOSVersion()
-			hotShotHeight = binary.BigEndian.Uint64(header.MixDigest[24:32])
 		}
 		arbitrumHeader := types.HeaderInfo{
 			SendRoot:           sendRoot,
 			SendCount:          sendCount,
 			L1BlockNumber:      nextL1BlockNumber,
 			ArbOSFormatVersion: arbosVersion,
-			HotShotHeight:      hotShotHeight,
 		}
 		arbitrumHeader.UpdateHeaderWithInfo(header)
 		header.Root = statedb.IntermediateRoot(true)

--- a/cmd/replay/espresso_validation.go
+++ b/cmd/replay/espresso_validation.go
@@ -24,7 +24,7 @@ func handleEspressoPreConditions(message *arbostypes.MessageWithMetadata, isEnab
 	isNonEspressoMessage := arbos.IsL2NonEspressoMsg(message.Message)
 
 	validatingEspressoLivenessFailure := isNonEspressoMessage && isEnabled
-	validatingEspressoHeightFailure := isNonEspressoMessage
+	validatingEspressoHeightFailure := isNonEspressoMessage && isEnabled
 	validatingAgainstEspresso := arbos.IsEspressoMsg(message.Message) && isEnabled
 
 	if validatingEspressoLivenessFailure {

--- a/cmd/replay/espresso_validation.go
+++ b/cmd/replay/espresso_validation.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/offchainlabs/nitro/arbos"
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/wavmio"
@@ -21,10 +22,9 @@ import (
 func handleEspressoPreConditions(message *arbostypes.MessageWithMetadata, isEnabled bool) (bool, func()) {
 	// calculate and cache all values needed to determine if the preconditions are met to enter the Espresso STF logic
 	isNonEspressoMessage := arbos.IsL2NonEspressoMsg(message.Message)
-	hotshotHeight := wavmio.GetEspressoHeight()
 
 	validatingEspressoLivenessFailure := isNonEspressoMessage && isEnabled
-	validatingEspressoHeightFailure := isNonEspressoMessage && hotshotHeight != 0
+	validatingEspressoHeightFailure := isNonEspressoMessage
 	validatingAgainstEspresso := arbos.IsEspressoMsg(message.Message) && isEnabled
 
 	if validatingEspressoLivenessFailure {

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -300,19 +300,6 @@ func main() {
 			hotshotHeader := jst.Header
 			height := hotshotHeader.Height
 
-			// Check the continuity of the hotshot block if we are not running the sovereign sequencer.
-			if !arbos.IsEspressoSovereignMsg(message.Message) {
-				validatedHeight := wavmio.GetEspressoHeight()
-				if validatedHeight == 0 {
-					// Validators can choose their own trusted starting point to start their validation.
-					// TODO: Check the starting point is greater than the first valid hotshot block number.
-					wavmio.SetEspressoHeight(height)
-				} else if validatedHeight+1 == height {
-					wavmio.SetEspressoHeight(height)
-				} else {
-					panic(fmt.Sprintf("invalid hotshot block height: %v, got: %v", height, validatedHeight+1))
-				}
-			}
 			if jst.BlockMerkleJustification == nil {
 				panic("block merkle justification missing")
 			}

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -789,9 +789,8 @@ func (s *ExecutionEngine) resultFromHeader(header *types.Header) (*execution.Mes
 	}
 	info := types.DeserializeHeaderExtraInformation(header)
 	return &execution.MessageResult{
-		BlockHash:     header.Hash(),
-		SendRoot:      info.SendRoot,
-		HotShotHeight: info.HotShotHeight,
+		BlockHash: header.Hash(),
+		SendRoot:  info.SendRoot,
 	}, nil
 }
 

--- a/staker/block_challenge_backend.go
+++ b/staker/block_challenge_backend.go
@@ -132,11 +132,10 @@ func (b *BlockChallengeBackend) FindGlobalStateFromMessageCount(count arbutil.Me
 	}
 
 	return validator.GoGlobalState{
-		BlockHash:     res.BlockHash,
-		SendRoot:      res.SendRoot,
-		Batch:         batch,
-		PosInBatch:    uint64(count - prevBatchMsgCount),
-		HotShotHeight: res.HotShotHeight,
+		BlockHash:  res.BlockHash,
+		SendRoot:   res.SendRoot,
+		Batch:      batch,
+		PosInBatch: uint64(count - prevBatchMsgCount),
 	}, nil
 }
 
@@ -155,9 +154,6 @@ func (b *BlockChallengeBackend) GetInfoAtStep(step uint64) (validator.GoGlobalSt
 	globalState, err := b.FindGlobalStateFromMessageCount(msgNum)
 	if err != nil {
 		return validator.GoGlobalState{}, 0, err
-	}
-	if b.EspressoDebugging(globalState.HotShotHeight) {
-		globalState.BlockHash = mockHash(globalState.HotShotHeight)
 	}
 	return globalState, StatusFinished, nil
 }

--- a/staker/block_validator.go
+++ b/staker/block_validator.go
@@ -571,9 +571,8 @@ func (v *BlockValidator) createNextValidationEntry(ctx context.Context) (bool, e
 		v.nextCreateBatchReread = false
 	}
 	endGS := validator.GoGlobalState{
-		BlockHash:     endRes.BlockHash,
-		SendRoot:      endRes.SendRoot,
-		HotShotHeight: endRes.HotShotHeight,
+		BlockHash: endRes.BlockHash,
+		SendRoot:  endRes.SendRoot,
 	}
 	if pos+1 < v.nextCreateBatchMsgCount {
 		endGS.Batch = v.nextCreateStartGS.Batch
@@ -1188,11 +1187,10 @@ func (v *BlockValidator) checkLegacyValid() error {
 		return fmt.Errorf("legacy validated blockHash does not fit chain")
 	}
 	validGS := validator.GoGlobalState{
-		BlockHash:     result.BlockHash,
-		SendRoot:      result.SendRoot,
-		Batch:         v.legacyValidInfo.AfterPosition.BatchNumber,
-		PosInBatch:    v.legacyValidInfo.AfterPosition.PosInBatch,
-		HotShotHeight: result.HotShotHeight,
+		BlockHash:  result.BlockHash,
+		SendRoot:   result.SendRoot,
+		Batch:      v.legacyValidInfo.AfterPosition.BatchNumber,
+		PosInBatch: v.legacyValidInfo.AfterPosition.PosInBatch,
 	}
 	err = v.writeLastValidated(validGS, nil)
 	if err == nil {

--- a/staker/challenge_manager.go
+++ b/staker/challenge_manager.go
@@ -509,10 +509,6 @@ func (m *ChallengeManager) createExecutionBackend(ctx context.Context, step uint
 	if err != nil {
 		return fmt.Errorf("error getting execution challenge final state: %w", err)
 	}
-	if m.blockChallengeBackend.EspressoDebugging(computedState.HotShotHeight) {
-		computedState.BlockHash = mockHash(computedState.HotShotHeight)
-		computedStatus = expectedStatus
-	}
 	if expectedStatus != computedStatus {
 		return fmt.Errorf("after msg %v expected status %v but got %v", initialCount, expectedStatus, computedStatus)
 	}

--- a/staker/l1_validator.go
+++ b/staker/l1_validator.go
@@ -265,10 +265,6 @@ func (v *L1Validator) generateNodeAction(
 	}
 
 	caughtUp, startCount, err := GlobalStateToMsgCount(v.inboxTracker, v.txStreamer, startState.GlobalState)
-	if v.blockValidator != nil && v.blockValidator.EspressoDebugging(startState.GlobalState.HotShotHeight) {
-		caughtUp = true
-		err = nil
-	}
 	if err != nil {
 		return nil, false, fmt.Errorf("start state not in chain: %w", err)
 	}
@@ -427,10 +423,6 @@ func (v *L1Validator) generateNodeAction(
 			log.Error("Found incorrect assertion: Machine status not finished", "node", nd.NodeNum, "machineStatus", nd.Assertion.AfterState.MachineStatus)
 			continue
 		}
-		if v.blockValidator != nil && v.blockValidator.EspressoDebugging(afterGS.HotShotHeight) {
-			log.Error("Mocking wrong global state")
-			afterGS.BlockHash = mockHash(afterGS.HotShotHeight)
-		}
 		caughtUp, nodeMsgCount, err := GlobalStateToMsgCount(v.inboxTracker, v.txStreamer, afterGS)
 		if errors.Is(err, ErrGlobalStateNotInChain) {
 			wrongNodesExist = true
@@ -453,10 +445,6 @@ func (v *L1Validator) generateNodeAction(
 			number: nd.NodeNum,
 			hash:   nd.NodeHash,
 		}
-	}
-
-	if v.blockValidator != nil && v.blockValidator.EspressoDebugging(validatedGlobalState.HotShotHeight) {
-		validatedGlobalState.BlockHash = mockHash(validatedGlobalState.HotShotHeight)
 	}
 
 	if correctNode != nil || strategy == WatchtowerStrategy {

--- a/staker/stateless_block_validator.go
+++ b/staker/stateless_block_validator.go
@@ -335,11 +335,10 @@ func (v *StatelessBlockValidator) ValidationEntryRecord(ctx context.Context, e *
 
 func buildGlobalState(res execution.MessageResult, pos GlobalStatePosition) validator.GoGlobalState {
 	return validator.GoGlobalState{
-		BlockHash:     res.BlockHash,
-		SendRoot:      res.SendRoot,
-		Batch:         pos.BatchNumber,
-		PosInBatch:    pos.PosInBatch,
-		HotShotHeight: res.HotShotHeight,
+		BlockHash:  res.BlockHash,
+		SendRoot:   res.SendRoot,
+		Batch:      pos.BatchNumber,
+		PosInBatch: pos.PosInBatch,
 	}
 }
 

--- a/system_tests/full_challenge_impl_test.go
+++ b/system_tests/full_challenge_impl_test.go
@@ -112,11 +112,11 @@ func CreateChallenge(
 		[2]mocksgen.GlobalState{
 			{
 				Bytes32Vals: [2][32]byte{startGlobalState.BlockHash, startGlobalState.SendRoot},
-				U64Vals:     [3]uint64{startGlobalState.Batch, startGlobalState.PosInBatch},
+				U64Vals:     [2]uint64{startGlobalState.Batch, startGlobalState.PosInBatch},
 			},
 			{
 				Bytes32Vals: [2][32]byte{endGlobalState.BlockHash, endGlobalState.SendRoot},
-				U64Vals:     [3]uint64{endGlobalState.Batch, endGlobalState.PosInBatch},
+				U64Vals:     [2]uint64{endGlobalState.Batch, endGlobalState.PosInBatch},
 			},
 		},
 		numBlocks,

--- a/validator/execution_state.go
+++ b/validator/execution_state.go
@@ -12,11 +12,10 @@ import (
 )
 
 type GoGlobalState struct {
-	BlockHash     common.Hash
-	SendRoot      common.Hash
-	Batch         uint64
-	PosInBatch    uint64
-	HotShotHeight uint64
+	BlockHash  common.Hash
+	SendRoot   common.Hash
+	Batch      uint64
+	PosInBatch uint64
 }
 
 type MachineStatus uint8
@@ -45,14 +44,13 @@ func (s GoGlobalState) Hash() common.Hash {
 	data = append(data, s.SendRoot.Bytes()...)
 	data = append(data, u64ToBe(s.Batch)...)
 	data = append(data, u64ToBe(s.PosInBatch)...)
-	data = append(data, u64ToBe(s.HotShotHeight)...)
 	return crypto.Keccak256Hash(data)
 }
 
 func (s GoGlobalState) AsSolidityStruct() challengegen.GlobalState {
 	return challengegen.GlobalState{
 		Bytes32Vals: [2][32]byte{s.BlockHash, s.SendRoot},
-		U64Vals:     [3]uint64{s.Batch, s.PosInBatch, s.HotShotHeight},
+		U64Vals:     [2]uint64{s.Batch, s.PosInBatch},
 	}
 }
 
@@ -65,11 +63,10 @@ func NewExecutionStateFromSolidity(eth rollupgen.ExecutionState) *ExecutionState
 
 func GoGlobalStateFromSolidity(gs challengegen.GlobalState) GoGlobalState {
 	return GoGlobalState{
-		BlockHash:     gs.Bytes32Vals[0],
-		SendRoot:      gs.Bytes32Vals[1],
-		Batch:         gs.U64Vals[0],
-		PosInBatch:    gs.U64Vals[1],
-		HotShotHeight: gs.U64Vals[2],
+		BlockHash:  gs.Bytes32Vals[0],
+		SendRoot:   gs.Bytes32Vals[1],
+		Batch:      gs.U64Vals[0],
+		PosInBatch: gs.U64Vals[1],
 	}
 }
 

--- a/validator/server_arb/prover_interface.go
+++ b/validator/server_arb/prover_interface.go
@@ -45,7 +45,6 @@ func GlobalStateToC(gsIn validator.GoGlobalState) C.GlobalState {
 	gs := C.GlobalState{}
 	gs.u64_vals[0] = C.uint64_t(gsIn.Batch)
 	gs.u64_vals[1] = C.uint64_t(gsIn.PosInBatch)
-	gs.u64_vals[2] = C.uint64_t(gsIn.HotShotHeight)
 	for i, b := range gsIn.BlockHash {
 		gs.bytes32_vals[0].bytes[i] = C.uint8_t(b)
 	}
@@ -65,11 +64,10 @@ func GlobalStateFromC(gs C.GlobalState) validator.GoGlobalState {
 		sendRoot[i] = byte(gs.bytes32_vals[1].bytes[i])
 	}
 	return validator.GoGlobalState{
-		Batch:         uint64(gs.u64_vals[0]),
-		PosInBatch:    uint64(gs.u64_vals[1]),
-		BlockHash:     blockHash,
-		SendRoot:      sendRoot,
-		HotShotHeight: uint64(gs.u64_vals[2]),
+		Batch:      uint64(gs.u64_vals[0]),
+		PosInBatch: uint64(gs.u64_vals[1]),
+		BlockHash:  blockHash,
+		SendRoot:   sendRoot,
 	}
 }
 

--- a/validator/server_jit/jit_machine.go
+++ b/validator/server_jit/jit_machine.go
@@ -147,9 +147,6 @@ func (machine *JitMachine) prove(
 	if err := writeExact(entry.StartState.SendRoot[:]); err != nil {
 		return state, err
 	}
-	if err := writeUint64(entry.StartState.HotShotHeight); err != nil {
-		return state, err
-	}
 	if err := writeExact(entry.HotShotCommitment[:]); err != nil {
 		return state, err
 	}
@@ -291,9 +288,6 @@ func (machine *JitMachine) prove(
 				return state, err
 			}
 			if state.PosInBatch, err = readUint64(); err != nil {
-				return state, err
-			}
-			if state.HotShotHeight, err = readUint64(); err != nil {
 				return state, err
 			}
 			if state.BlockHash, err = readHash(); err != nil {

--- a/wavmio/higher.go
+++ b/wavmio/higher.go
@@ -23,7 +23,6 @@ const IDX_SEND_ROOT = 1
 // u64
 const IDX_INBOX_POSITION = 0
 const IDX_POSITION_WITHIN_MESSAGE = 1
-const IDX_ESPRESSO_HEIGHT = 2
 
 func readBuffer(f func(uint32, unsafe.Pointer) uint32) []byte {
 	buf := make([]byte, 0, INITIAL_CAPACITY)
@@ -64,14 +63,6 @@ func ReadHotShotCommitment(h uint64) (commitment [32]byte) {
 
 func IsHotShotLive(l1Height uint64) bool {
 	return isHotShotLive(l1Height) > 0
-}
-
-func GetEspressoHeight() uint64 {
-	return getGlobalStateU64(IDX_ESPRESSO_HEIGHT)
-}
-
-func SetEspressoHeight(h uint64) {
-	setGlobalStateU64(IDX_ESPRESSO_HEIGHT, h)
 }
 
 func ReadDelayedInboxMessage(seqNum uint64) []byte {

--- a/wavmio/stub.go
+++ b/wavmio/stub.go
@@ -42,7 +42,6 @@ var (
 	hotShotCommitment  [32]byte
 	preimages          map[common.Hash][]byte
 	seqAdvanced        uint64
-	espressoHeight     uint64
 )
 
 func parsePreimageBytes(path string) {
@@ -126,14 +125,6 @@ func ReadHotShotCommitment(h uint64) [32]byte {
 
 func IsHotShotLive(l1Height uint64) bool {
 	return true
-}
-
-func GetEspressoHeight() uint64 {
-	return espressoHeight
-}
-
-func SetEspressoHeight(h uint64) {
-	espressoHeight = h
 }
 
 func ReadInboxMessage(msgNum uint64) []byte {


### PR DESCRIPTION
Remove the extra global state that we added for the hotshot block height. We don't need this anymore for following reasons:
- Since the L1 arbitrator and block validator have the ability to look back to the previous messages, we don't need to store the hotshot height in the global state for checking the continuity of hotshot block
- Removing the extra global state helps the nitro integration keep in line with the upstream so that we can utilize their tools, such as `arbitrum-sdk`, without any change.
- This change is also friendly to the migration

### This PR:
- Remove the extra global state.
- Remove the continuity check of hotshot block for now, this is not necessary in sovereign sequencer.
- Also remove the staker check which is largely based on this global state. We have to figure out how to do the similar things later.
