### PR TITLE
CI: use buildjet instead of self-hosted runner

### DIFF
--- a/.github/actions/docker-image/action.yml
+++ b/.github/actions/docker-image/action.yml
@@ -40,8 +40,6 @@ runs:
         target: ${{ inputs.target }}
         labels: ${{ steps.metadata.outputs.labels  }}
         platforms: ${{ inputs.platforms }}
-        cache-from: type=registry,ref=${{ steps.metadata.outputs.tags }}
-        cache-to: type=inline
         outputs: type=image,name=${{ inputs.images }},push-by-digest=true,name-canonical=true,push=true
 
     # This will upload the digest for each architecture to the same artifact,

--- a/.github/actions/docker-image/action.yml
+++ b/.github/actions/docker-image/action.yml
@@ -40,6 +40,8 @@ runs:
         target: ${{ inputs.target }}
         labels: ${{ steps.metadata.outputs.labels  }}
         platforms: ${{ inputs.platforms }}
+        cache-from: type=registry,ref=${{ steps.metadata.outputs.tags }}
+        cache-to: type=inline
         outputs: type=image,name=${{ inputs.images }},push-by-digest=true,name-canonical=true,push=true
 
     # This will upload the digest for each architecture to the same artifact,

--- a/.github/actions/docker-image/action.yml
+++ b/.github/actions/docker-image/action.yml
@@ -40,8 +40,8 @@ runs:
         target: ${{ inputs.target }}
         labels: ${{ steps.metadata.outputs.labels  }}
         platforms: ${{ inputs.platforms }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=registry,ref=user/app:latest
+        cache-to: type=inline
         outputs: type=image,name=${{ inputs.images }},push-by-digest=true,name-canonical=true,push=true
 
     # This will upload the digest for each architecture to the same artifact,

--- a/.github/actions/docker-image/action.yml
+++ b/.github/actions/docker-image/action.yml
@@ -40,7 +40,7 @@ runs:
         target: ${{ inputs.target }}
         labels: ${{ steps.metadata.outputs.labels  }}
         platforms: ${{ inputs.platforms }}
-        cache-from: type=registry,ref=${{ steps.metadata.output.tags }}
+        cache-from: type=registry,ref=${{ steps.metadata.outputs.tags }}
         cache-to: type=inline
         outputs: type=image,name=${{ inputs.images }},push-by-digest=true,name-canonical=true,push=true
 

--- a/.github/actions/docker-image/action.yml
+++ b/.github/actions/docker-image/action.yml
@@ -40,7 +40,7 @@ runs:
         target: ${{ inputs.target }}
         labels: ${{ steps.metadata.outputs.labels  }}
         platforms: ${{ inputs.platforms }}
-        cache-from: type=registry,ref=user/app:latest
+        cache-from: type=registry,ref=${{ steps.metadata.output.tags }}
         cache-to: type=inline
         outputs: type=image,name=${{ inputs.images }},push-by-digest=true,name-canonical=true,push=true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   test:
     name: Go Tests
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
 
     # Creates a redis container for redis tests
     services:
@@ -33,6 +33,36 @@ jobs:
         test-mode: [defaults, race, challenge, stylus, long]
 
     steps:
+      - uses: cargo-bins/cargo-binstall@main
+        if: matrix.runs-on == 'ubuntu-latest'
+
+      # Make more disk space available on public runner
+      - name: Remove unused software
+        if: matrix.runs-on == 'ubuntu-latest'
+        run: |
+          cargo binstall -y rmz
+          sudo mv /home/runner/.cargo/bin/rmz /usr/local/bin/rmz
+
+          echo "Available storage before:"
+          sudo df -h
+          echo
+          sudo rmz -f /usr/share/dotnet
+          sudo rmz -f /usr/share/swift
+          sudo rmz -f /usr/share/gradle-*
+          sudo rmz -f /usr/share/az_*
+          sudo rmz -f /usr/local/lib/android
+          sudo rmz -f /usr/local/lib/node_modules
+          sudo rmz -f /opt/ghc
+          sudo rmz -f /opt/az
+          sudo rmz -f /opt/pipx
+          sudo rmz -f /opt/google
+          sudo rmz -f /opt/microsoft
+          sudo rmz -f /opt/hostedtoolcache
+          echo "Available storage after:"
+          sudo df -h
+          echo
+
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -89,7 +119,7 @@ jobs:
           rustup target add wasm32-unknown-unknown --toolchain nightly
 
       - name: Cache Build Products
-        uses: buildjet/cache@v3
+        uses: actions/cache@v3
         with:
           path: |
             ~/go/pkg/mod
@@ -98,7 +128,7 @@ jobs:
           restore-keys: ${{ runner.os }}-go-
 
       - name: Cache Rust Build Products
-        uses: buildjet/cache@v3
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry/
@@ -111,7 +141,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-${{ steps.install-rust.outputs.rustc_hash }}-
 
       - name: Cache cbrotli
-        uses: buildjet/cache@v3
+        uses: actions/cache@v3
         id: cache-cbrotli
         with:
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,8 +127,8 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}-${{ matrix.test-mode }}
-          restore-keys: ${{ runner.os }}-go-
+          key: v1-${{ runner.os }}-go-${{ hashFiles('go.sum') }}-${{ matrix.test-mode }}
+          restore-keys: v1-${{ runner.os }}-go-
 
       - name: Cache Rust Build Products
         uses: actions/cache@v3
@@ -140,8 +140,8 @@ jobs:
             arbitrator/wasm-libraries/target/
             arbitrator/wasm-libraries/soft-float/SoftFloat/build
             target/etc/initial-machine-cache/
-          key: ${{ runner.os }}-cargo-${{ steps.install-rust.outputs.rustc_hash }}-min-${{ hashFiles('arbitrator/Cargo.lock') }}-${{ matrix.test-mode }}
-          restore-keys: ${{ runner.os }}-cargo-${{ steps.install-rust.outputs.rustc_hash }}-
+          key: v1-${{ runner.os }}-cargo-${{ steps.install-rust.outputs.rustc_hash }}-min-${{ hashFiles('arbitrator/Cargo.lock') }}-${{ matrix.test-mode }}
+          restore-keys: v1-${{ runner.os }}-cargo-${{ steps.install-rust.outputs.rustc_hash }}-
 
       - name: Cache cbrotli
         uses: actions/cache@v3
@@ -153,8 +153,8 @@ jobs:
             target/lib/libbrotlicommon-static.a
             target/lib/libbrotlienc-static.a
             target/lib/libbrotlidec-static.a
-          key: ${{ runner.os }}-brotli-${{ hashFiles('scripts/build-brotli.sh') }}-${{ hashFiles('.github/workflows/arbitrator-ci.yaml') }}-${{ matrix.test-mode }}
-          restore-keys: ${{ runner.os }}-brotli-
+          key: v1-${{ runner.os }}-brotli-${{ hashFiles('scripts/build-brotli.sh') }}-${{ hashFiles('.github/workflows/arbitrator-ci.yaml') }}-${{ matrix.test-mode }}
+          restore-keys: v1-${{ runner.os }}-brotli-
 
       - name: Build cbrotli-local
         if: steps.cache-cbrotli.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.test-mode }}-full.log
+          path: full.log
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,12 +76,13 @@ jobs:
           sudo apt update && sudo apt install -y wabt gotestsum
           cmake build-essential bison golang clang make wabt
 
-      # - name: Setup nodejs
-      #   uses: actions/setup-node@v3
-      #   with:
-      #     node-version: '18'
-      #     cache: 'yarn'
-      #     cache-dependency-path: '/tmp/gha-work/**/yarn.lock'
+      - name: Setup nodejs
+        if: false # fails to find yarn.lock when running in symlinked directory, doesn't seem to be needed
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'yarn'
+          cache-dependency-path: '**/yarn.lock'
 
       - name: Install go
         uses: actions/setup-go@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,7 @@ jobs:
         with:
           version: v1.59.1
           skip-cache: true
+          working-directory: /tmp/gha-work
 
       - name: Custom Lint
         run: |
@@ -240,7 +241,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.test-mode }}-full.log
-          path: full.log
+          path: /tmp/gha-work/full.log
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
@@ -250,6 +251,7 @@ jobs:
           files: ./coverage.txt,./coverage-redis.txt
           verbose: false
           token: ${{ secrets.CODECOV_TOKEN }}
+          working-directory: /tmp/gha-work
 
       - name: Check available space after CI run
         if: '!cancelled()'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,12 +76,12 @@ jobs:
           sudo apt update && sudo apt install -y wabt gotestsum
           cmake build-essential bison golang clang make wabt
 
-      - name: Setup nodejs
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-          cache: 'yarn'
-          cache-dependency-path: '/tmp/gha-work/**/yarn.lock'
+      # - name: Setup nodejs
+      #   uses: actions/setup-node@v3
+      #   with:
+      #     node-version: '18'
+      #     cache: 'yarn'
+      #     cache-dependency-path: '/tmp/gha-work/**/yarn.lock'
 
       - name: Install go
         uses: actions/setup-go@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,6 @@ jobs:
   test:
     name: Go Tests
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        # Set the default working directory for 'run:' steps
-        working-directory: /tmp/gha-work
 
     # Creates a redis container for redis tests
     services:
@@ -45,8 +41,10 @@ jobs:
       - name: Move repo to avoid too long file paths
         run: |
           rsync -a ./ /tmp/gha-work/
-        # Run from the original workspace directory because the new one doesn't exist yet.
-        working-directory: ${{ github.workspace }}
+          cd /tmp/gha-work
+          rm -rf $GITHUB_WORKSPACE
+          # Link the original workspace to the new workspace directory
+          ln -sv /tmp/gha-work $GITHUB_WORKSPACE
 
       - uses: cargo-bins/cargo-binstall@main
       - name: Make more disk space available on public runner
@@ -180,7 +178,6 @@ jobs:
         with:
           version: v1.59.1
           skip-cache: true
-          working-directory: /tmp/gha-work
 
       - name: Custom Lint
         run: |
@@ -241,7 +238,6 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.test-mode }}-full.log
-          path: /tmp/gha-work/full.log
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
@@ -251,7 +247,6 @@ jobs:
           files: ./coverage.txt,./coverage-redis.txt
           verbose: false
           token: ${{ secrets.CODECOV_TOKEN }}
-          working-directory: /tmp/gha-work
 
       - name: Check available space after CI run
         if: '!cancelled()'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,10 @@ jobs:
         test-mode: [defaults, race, challenge, stylus, long]
 
     steps:
-      # Make more disk space available on public runner
       - uses: cargo-bins/cargo-binstall@main
-      - name: Remove unused software
+      - name: Make more disk space available on public runner
         run: |
+          # rmz seems to be faster at deleting files than rm
           cargo binstall -y rmz
           sudo mv /home/runner/.cargo/bin/rmz /usr/local/bin/rmz
 
@@ -240,3 +240,7 @@ jobs:
           files: ./coverage.txt,./coverage-redis.txt
           verbose: false
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Check available space after CI run
+        run: |
+          sudo df -h

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-mode: [defaults, race, challenge, stylus, long]
+        test-mode: [defaults, race, challenge, stylus, long, redis]
 
     steps:
       - name: Move repo to avoid too long file paths
@@ -175,12 +175,14 @@ jobs:
         run: make -j build-node-deps
 
       - name: Lint
+        if: matrix.test-mode == 'defaults'
         uses: golangci/golangci-lint-action@v5
         with:
           version: v1.59.1
           skip-cache: true
 
       - name: Custom Lint
+        if: matrix.test-mode == 'defaults'
         run: |
           go run ./linters ./...
 
@@ -208,7 +210,7 @@ jobs:
           stdbuf -oL gotestsum --format short-verbose --packages="$packages" --rerun-fails=1 --no-color=false -- ./... -race -skip "$skip_tests" -timeout=40m > >(stdbuf -oL tee full.log | grep -vE "INFO|seal")
 
       - name: run redis tests
-        if: matrix.test-mode == 'defaults'
+        if: matrix.test-mode == 'redis'
         run: TEST_REDIS=redis://localhost:6379/0 gotestsum --format short-verbose -- -timeout 20m -p 1 -run TestRedis ./arbnode/... ./system_tests/... -coverprofile=coverage-redis.txt -covermode=atomic -coverpkg=./...
 
       - name: run challenge tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,13 +48,11 @@ jobs:
           sudo rmz -f /usr/share/gradle-*
           sudo rmz -f /usr/share/az_*
           sudo rmz -f /usr/local/lib/android
-          sudo rmz -f /usr/local/lib/node_modules
           sudo rmz -f /opt/ghc
           sudo rmz -f /opt/az
           sudo rmz -f /opt/pipx
           sudo rmz -f /opt/google
           sudo rmz -f /opt/microsoft
-          sudo rmz -f /opt/hostedtoolcache
           echo "Available storage after:"
           sudo df -h
           echo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,8 @@ jobs:
           sudo rmz -f /usr/share/dotnet
           sudo rmz -f /usr/share/swift
           sudo rmz -f /usr/share/gradle-*
-          sudo rmz -f /usr/share/az_*
           sudo rmz -f /usr/local/lib/android
           sudo rmz -f /opt/ghc
-          sudo rmz -f /opt/az
           sudo rmz -f /opt/pipx
           sudo rmz -f /opt/google
           sudo rmz -f /opt/microsoft

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,10 @@ jobs:
           sudo rmz -f /usr/share/dotnet
           sudo rmz -f /usr/share/swift
           sudo rmz -f /usr/share/gradle-*
+          sudo rmz -f /usr/share/az_*
           sudo rmz -f /usr/local/lib/android
           sudo rmz -f /opt/ghc
+          sudo rmz -f /opt/az
           sudo rmz -f /opt/pipx
           sudo rmz -f /opt/google
           sudo rmz -f /opt/microsoft

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
 
       - name: run redis tests
         if: matrix.test-mode == 'defaults'
-        run: TEST_REDIS=redis://redis:6379/0 gotestsum --format short-verbose -- -timeout 20m -p 1 -run TestRedis ./arbnode/... ./system_tests/... -coverprofile=coverage-redis.txt -covermode=atomic -coverpkg=./...
+        run: TEST_REDIS=redis://localhost:6379/0 gotestsum --format short-verbose -- -timeout 20m -p 1 -run TestRedis ./arbnode/... ./system_tests/... -coverprofile=coverage-redis.txt -covermode=atomic -coverpkg=./...
 
       - name: run challenge tests
         if: matrix.test-mode == 'challenge'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,18 +33,18 @@ jobs:
         test-mode: [defaults, race, challenge, stylus, long]
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
       - name: Move repo to avoid too long file paths
         run: |
-          rsync -a ./ /tmp/gha-work/
+          mkdir /tmp/gha-work
           cd /tmp/gha-work
           rm -rf $GITHUB_WORKSPACE
           # Link the original workspace to the new workspace directory
           ln -sv /tmp/gha-work $GITHUB_WORKSPACE
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - uses: cargo-bins/cargo-binstall@main
       - name: Make more disk space available on public runner
@@ -81,7 +81,7 @@ jobs:
         with:
           node-version: '18'
           cache: 'yarn'
-          cache-dependency-path: '**/yarn.lock'
+          cache-dependency-path: '/tmp/gha-work/**/yarn.lock'
 
       - name: Install go
         uses: actions/setup-go@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
   test:
     name: Go Tests
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        # Set the default working directory for 'run:' steps
+        working-directory: /tmp/gha-work
 
     # Creates a redis container for redis tests
     services:
@@ -33,6 +37,17 @@ jobs:
         test-mode: [defaults, race, challenge, stylus, long]
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Move repo to avoid too long file paths
+        run: |
+          rsync -a ./ /tmp/gha-work/
+        # Run from the original workspace directory because the new one doesn't exist yet.
+        working-directory: ${{ github.workspace }}
+
       - uses: cargo-bins/cargo-binstall@main
       - name: Make more disk space available on public runner
         run: |
@@ -57,11 +72,6 @@ jobs:
           sudo df -h
           echo
 
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Install dependencies
         run: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,5 +242,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Check available space after CI run
+        if: '!cancelled()'
         run: |
           sudo df -h

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,9 @@ jobs:
         test-mode: [defaults, race, challenge, stylus, long]
 
     steps:
-      - uses: cargo-bins/cargo-binstall@main
-        if: matrix.runs-on == 'ubuntu-latest'
-
       # Make more disk space available on public runner
+      - uses: cargo-bins/cargo-binstall@main
       - name: Remove unused software
-        if: matrix.runs-on == 'ubuntu-latest'
         run: |
           cargo binstall -y rmz
           sudo mv /home/runner/.cargo/bin/rmz /usr/local/bin/rmz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,7 @@ concurrency:
 jobs:
   test:
     name: Go Tests
-    container:
-      image: ghcr.io/catthehacker/ubuntu:js-22.04
-    runs-on: [self-hosted, X64]
+    runs-on: buildjet-4vcpu-ubuntu-2204
 
     # Creates a redis container for redis tests
     services:
@@ -91,7 +89,7 @@ jobs:
           rustup target add wasm32-unknown-unknown --toolchain nightly
 
       - name: Cache Build Products
-        uses: actions/cache@v3
+        uses: buildjet/cache@v3
         with:
           path: |
             ~/go/pkg/mod
@@ -100,7 +98,7 @@ jobs:
           restore-keys: ${{ runner.os }}-go-
 
       - name: Cache Rust Build Products
-        uses: actions/cache@v3
+        uses: buildjet/cache@v3
         with:
           path: |
             ~/.cargo/registry/
@@ -113,7 +111,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-${{ steps.install-rust.outputs.rustc_hash }}-
 
       - name: Cache cbrotli
-        uses: actions/cache@v3
+        uses: buildjet/cache@v3
         id: cache-cbrotli
         with:
           path: |

--- a/.github/workflows/espresso-docker.yml
+++ b/.github/workflows/espresso-docker.yml
@@ -46,7 +46,7 @@ jobs:
       # Make more disk space available on public runner
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
-        if: matrix.runs-on == ubuntu-latest
+        if: matrix.runs-on == "ubuntu-latest"
         with:
           root-reserve-mb: 512
           swap-size-mb: 1024

--- a/.github/workflows/espresso-docker.yml
+++ b/.github/workflows/espresso-docker.yml
@@ -36,11 +36,11 @@ jobs:
         platform: [linux/amd64, linux/arm64]
         include:
           - platform: linux/amd64
-            runs-on: X64
+            runs-on: ubuntu-latest
           - platform: linux/arm64
-            runs-on: ARM64
+            runs-on: buildjet-4vcpu-ubuntu-2204-arm
 
-    runs-on: [self-hosted, "${{ matrix.runs-on }}"]
+    runs-on: ${{ matrix.runs-on }}
 
     steps:
       # TODO We should be able to remove this but currently it's needed to avoid

--- a/.github/workflows/espresso-docker.yml
+++ b/.github/workflows/espresso-docker.yml
@@ -47,10 +47,10 @@ jobs:
       - uses: cargo-bins/cargo-binstall@main
         if: matrix.runs-on == 'ubuntu-latest'
 
-      # Make more disk space available on public runner
-      - name: Remove unused software
+      - name: Make more disk space available on public runner
         if: matrix.runs-on == 'ubuntu-latest'
         run: |
+          # rmz seems to be faster at deleting files than rm
           cargo binstall -y rmz
           sudo mv /home/runner/.cargo/bin/rmz /usr/local/bin/rmz
 
@@ -139,6 +139,10 @@ jobs:
         if: matrix.platform == 'linux/amd64' && startsWith(github.ref, 'refs/tags/')
         with:
           files: target/machines/latest/*
+
+      - name: Check available space after CI run
+        run: |
+          sudo df -h
 
   # Merge the AMD64 and ARM64 images into the final (multiplatform) image.
   #

--- a/.github/workflows/espresso-docker.yml
+++ b/.github/workflows/espresso-docker.yml
@@ -45,15 +45,15 @@ jobs:
     steps:
 
       - uses: cargo-bins/cargo-binstall@main
-
-      - run: |
-          cargo binstall -y rmz
-          sudo mv /home/runner/.cargo/bin/rmz /usr/local/bin/rmz
+        if: matrix.runs-on == 'ubuntu-latest'
 
       # Make more disk space available on public runner
       - name: Remove unused software
         if: matrix.runs-on == 'ubuntu-latest'
         run: |
+          cargo binstall -y rmz
+          sudo mv /home/runner/.cargo/bin/rmz /usr/local/bin/rmz
+
           echo "Available storage before:"
           sudo df -h
           echo

--- a/.github/workflows/espresso-docker.yml
+++ b/.github/workflows/espresso-docker.yml
@@ -44,20 +44,19 @@ jobs:
 
     steps:
       # Make more disk space available on public runner
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master
+      - name: Remove unused software
         if: matrix.runs-on == 'ubuntu-latest'
-        with:
-          root-reserve-mb: 50000
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-
-      - name: Check free space
         run: |
-          echo "Free space:"
-          df -h
+          echo "Available storage before:"
+          sudo df -h
+          echo
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          echo "Available storage after:"
+          sudo df -h
+          echo
 
       - name: Fix submodule permissions check
         run: |

--- a/.github/workflows/espresso-docker.yml
+++ b/.github/workflows/espresso-docker.yml
@@ -48,7 +48,7 @@ jobs:
         uses: easimon/maximize-build-space@master
         if: matrix.runs-on == 'ubuntu-latest'
         with:
-          root-reserve-mb: 512
+          root-reserve-mb: 50000
           swap-size-mb: 1024
           remove-dotnet: 'true'
           remove-android: 'true'

--- a/.github/workflows/espresso-docker.yml
+++ b/.github/workflows/espresso-docker.yml
@@ -46,7 +46,7 @@ jobs:
       # Make more disk space available on public runner
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
-        if: matrix.runs-on == "ubuntu-latest"
+        if: matrix.runs-on == 'ubuntu-latest'
         with:
           root-reserve-mb: 512
           swap-size-mb: 1024

--- a/.github/workflows/espresso-docker.yml
+++ b/.github/workflows/espresso-docker.yml
@@ -43,14 +43,22 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
 
     steps:
-      # TODO We should be able to remove this but currently it's needed to avoid
-      # permission errors during checkout.
-      - name: Fix submodule permissions check
+      # Make more disk space available on public runner
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        if: matrix.runs-on == ubuntu-latest
+        with:
+          root-reserve-mb: 512
+          swap-size-mb: 1024
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+
+      - name: Check free space
         run: |
-          sudo chown -R runner:runner .
-          # Remove potentially leftover files from last run, it's unclear why
-          # this only works with `sudo` despite the chown command above.
-          sudo rm -rfv ./target
+          echo "Free space:"
+          df -h
+
       - name: Fix submodule permissions check
         run: |
           git config --global --add safe.directory '*'

--- a/.github/workflows/espresso-docker.yml
+++ b/.github/workflows/espresso-docker.yml
@@ -43,6 +43,13 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
 
     steps:
+
+      - uses: cargo-bins/cargo-binstall@main
+
+      - run: |
+          cargo binstall -y rmz
+          sudo mv /home/runner/.cargo/bin/rmz /usr/local/bin/rmz
+
       # Make more disk space available on public runner
       - name: Remove unused software
         if: matrix.runs-on == 'ubuntu-latest'
@@ -50,10 +57,18 @@ jobs:
           echo "Available storage before:"
           sudo df -h
           echo
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rmz -f /usr/share/dotnet
+          sudo rmz -f /usr/share/swift
+          sudo rmz -f /usr/share/gradle-*
+          sudo rmz -f /usr/share/az_*
+          sudo rmz -f /usr/local/lib/android
+          sudo rmz -f /usr/local/lib/node_modules
+          sudo rmz -f /opt/ghc
+          sudo rmz -f /opt/az
+          sudo rmz -f /opt/pipx
+          sudo rmz -f /opt/google
+          sudo rmz -f /opt/microsoft
+          sudo rmz -f /opt/hostedtoolcache
           echo "Available storage after:"
           sudo df -h
           echo

--- a/.github/workflows/espresso-docker.yml
+++ b/.github/workflows/espresso-docker.yml
@@ -141,6 +141,7 @@ jobs:
           files: target/machines/latest/*
 
       - name: Check available space after CI run
+        if: '!cancelled()'
         run: |
           sudo df -h
 


### PR DESCRIPTION
- Remove usage of self hosted runners.
- Use buildjet for the arm docker build.
- Remove some unused software on public runners to have more disk space.

We only have 2 self hosted runners and each one can only run one workflow at a time. Using all public runners allows for much more parallelism. Not sure exactly how much parallelism but I see all the CI test jobs run in parallel now.

Docker build using public runner for amd64 and buildjet for arm seems to be working: [CI run ](https://github.com/EspressoSystems/nitro-espresso-integration/actions/runs/10602021518), another one [here](https://github.com/EspressoSystems/nitro-espresso-integration/actions/runs/10602910680).

For #197 