### PR TITLE
modify arbosstate.go to allow for upgrade to arbOS version 35

### DIFF
--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -74,8 +74,8 @@ func OpenArbosState(stateDB vm.StateDB, burner burn.Burner) (*ArbosState, error)
 	}
 	return &ArbosState{
 		arbosVersion,
-		31,
-		31,
+		35,
+		35,
 		backingStorage.OpenStorageBackedUint64(uint64(upgradeVersionOffset)),
 		backingStorage.OpenStorageBackedUint64(uint64(upgradeTimestampOffset)),
 		backingStorage.OpenStorageBackedAddress(uint64(networkFeeAccountOffset)),
@@ -323,6 +323,15 @@ func (state *ArbosState) UpgradeArbosVersion(
 			ensure(err)
 			ensure(params.UpgradeToVersion(2))
 			ensure(params.Save())
+
+		case 32, 33, 34:
+		// leave these versions open to orbit chains that may have performed ArbOS upgrades post Bianca.
+
+		case 35:
+			// Espresso marketplace compatible ArbOS version.
+
+		case 36, 37, 38, 39:
+			//leave these versions open to orbit chains that may want to perform ArbOS upgrades after upgrading to an espresso integration.
 
 		default:
 			return fmt.Errorf(

--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -329,6 +329,7 @@ func (state *ArbosState) UpgradeArbosVersion(
 
 		case 35:
 			// Espresso marketplace compatible ArbOS version.
+			chainConfig.ArbitrumChainParams.EnableEspresso = true
 
 		case 36, 37, 38, 39:
 			// these versions are left to Orbit chains for custom upgrades.

--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -325,13 +325,13 @@ func (state *ArbosState) UpgradeArbosVersion(
 			ensure(params.Save())
 
 		case 32, 33, 34:
-		// leave these versions open to orbit chains that may have performed ArbOS upgrades post Bianca.
+			// these versions are left to Orbit chains for custom upgrades.
 
 		case 35:
 			// Espresso marketplace compatible ArbOS version.
 
 		case 36, 37, 38, 39:
-			//leave these versions open to orbit chains that may want to perform ArbOS upgrades after upgrading to an espresso integration.
+			// these versions are left to Orbit chains for custom upgrades.
 
 		default:
 			return fmt.Errorf(


### PR DESCRIPTION
Closes [#215](https://github.com/EspressoSystems/nitro-espresso-integration/issues/215)


### This PR:
Allows the nitro-espresso-integration to upgrade it's ArbOS software to version 35 to signify that it is compatible with the espresso network.

### Key places to review:
nitro-espresso-integration/arbos/arbosState/arbosstate.go
