### PR TITLE
CI: fix rust and go cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,11 +129,11 @@ jobs:
           path: |
             ~/.cargo/registry/
             ~/.cargo/git/
-            arbitrator/target/
+            arbitrator/**/target/
             arbitrator/wasm-libraries/target/
             arbitrator/wasm-libraries/soft-float/SoftFloat/build
             target/etc/initial-machine-cache/
-          key: v1-${{ runner.os }}-cargo-${{ steps.install-rust.outputs.rustc_hash }}-min-${{ hashFiles('arbitrator/Cargo.lock') }}-${{ matrix.test-mode }}
+          key: v2-${{ runner.os }}-cargo-${{ steps.install-rust.outputs.rustc_hash }}-min-${{ hashFiles('arbitrator/Cargo.lock') }}-${{ matrix.test-mode }}
           restore-keys: v1-${{ runner.os }}-cargo-${{ steps.install-rust.outputs.rustc_hash }}-
 
       - name: Cache cbrotli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
           # HACK: move to directory with shorter path to avoid IPC paths over 107 characters
           CHECKOUT_DIR=$PWD
           cd /
-          mv -v CHECKOUT_DIR /tmp/gha-work
+          mv -v $CHECKOUT_DIR /tmp/gha-work
           cd /tmp/gha-work
 
           TEST_REDIS=redis://localhost:6379/0 gotestsum --format short-verbose -- -timeout 20m -p 1 -run TestRedis ./arbnode/... ./system_tests/... -coverprofile=coverage-redis.txt -covermode=atomic -coverpkg=./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,20 +189,9 @@ jobs:
         if: matrix.test-mode == 'defaults'
         shell: bash
         run: |
-
-          # HACK: move to directory with shorter path to avoid IPC paths over 107 characters
-          cd /
-          mv -v $GITHUB_WORKSPACE /tmp/gha-work
-          cd /tmp/gha-work
-
-          # Run the tests
           skip_tests=`grep -vE '^\s*#|^\s*$' ci_skip_tests | sed 's/.*/^&$/g' | tr '\n' '|' | sed 's/|$//'`
           packages=`go list ./...`
           stdbuf -oL gotestsum --format short-verbose --packages="$packages" --rerun-fails=1 --no-color=false -- ./... -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/... -timeout 35m -skip "$skip_tests"  > >(stdbuf -oL tee full.log | grep -vE "INFO|seal")
-
-          # HACK: move directory back to GITHUB_WORKSPACE
-          cd /
-          mv -v /tmp/gha-work $GITHUB_WORKSPACE
 
       - name: run tests with race detection
         if: matrix.test-mode == 'race'
@@ -214,7 +203,19 @@ jobs:
 
       - name: run redis tests
         if: matrix.test-mode == 'redis'
-        run: TEST_REDIS=redis://localhost:6379/0 gotestsum --format short-verbose -- -timeout 20m -p 1 -run TestRedis ./arbnode/... ./system_tests/... -coverprofile=coverage-redis.txt -covermode=atomic -coverpkg=./...
+        run: |
+
+          # HACK: move to directory with shorter path to avoid IPC paths over 107 characters
+          CHECKOUT_DIR=$PWD
+          cd /
+          mv -v CHECKOUT_DIR /tmp/gha-work
+          cd /tmp/gha-work
+
+          TEST_REDIS=redis://localhost:6379/0 gotestsum --format short-verbose -- -timeout 20m -p 1 -run TestRedis ./arbnode/... ./system_tests/... -coverprofile=coverage-redis.txt -covermode=atomic -coverpkg=./...
+
+          # HACK: move directory back to GITHUB_WORKSPACE
+          cd /
+          mv -v /tmp/gha-work $CHECKOUT_DIR
 
       - name: run challenge tests
         if: matrix.test-mode == 'challenge'
@@ -248,7 +249,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
-        if: matrix.test-mode == 'defaults'
+        if: false
         with:
           fail_ci_if_error: false
           files: ./coverage.txt,./coverage-redis.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,8 @@ jobs:
         run: |
 
           # HACK: move to directory with shorter path to avoid IPC paths over 107 characters
+          ls -lah /tmp
+          rm -rf /tmp/gha-work
           CHECKOUT_DIR=$PWD
           cd /
           mv -v $CHECKOUT_DIR /tmp/gha-work

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,8 +180,6 @@ jobs:
 
       - name: Set environment variables
         run: |
-          mkdir -p target/tmp/x
-          echo "TMPDIR=$(pwd)/target/tmp/x" >> "$GITHUB_ENV"
           echo "GOMEMLIMIT=6GiB" >> "$GITHUB_ENV"
           echo "GOGC=80" >> "$GITHUB_ENV"
 
@@ -189,21 +187,9 @@ jobs:
         if: matrix.test-mode == 'defaults'
         shell: bash
         run: |
-          # HACK: move to directory with shorter path to avoid IPC paths over 107 characters
-          ls -lah /tmp
-          rm -rf /tmp/gha-work
-          CHECKOUT_DIR=$PWD
-          cd /
-          mv -v $CHECKOUT_DIR /tmp/gha-work
-          cd /tmp/gha-work
-
           skip_tests=`grep -vE '^\s*#|^\s*$' ci_skip_tests | sed 's/.*/^&$/g' | tr '\n' '|' | sed 's/|$//'`
           packages=`go list ./...`
           stdbuf -oL gotestsum --format short-verbose --packages="$packages" --rerun-fails=1 --no-color=false -- ./... -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/... -timeout 35m -skip "$skip_tests"  > >(stdbuf -oL tee full.log | grep -vE "INFO|seal")
-
-          # HACK: move directory back to GITHUB_WORKSPACE
-          cd /
-          mv -v /tmp/gha-work $CHECKOUT_DIR
 
       - name: run tests with race detection
         if: matrix.test-mode == 'race'
@@ -215,21 +201,7 @@ jobs:
 
       - name: run redis tests
         if: matrix.test-mode == 'redis'
-        run: |
-
-          # HACK: move to directory with shorter path to avoid IPC paths over 107 characters
-          ls -lah /tmp
-          rm -rf /tmp/gha-work
-          CHECKOUT_DIR=$PWD
-          cd /
-          mv -v $CHECKOUT_DIR /tmp/gha-work
-          cd /tmp/gha-work
-
-          TEST_REDIS=redis://localhost:6379/0 gotestsum --format short-verbose -- -timeout 20m -p 1 -run TestRedis ./arbnode/... ./system_tests/... -coverprofile=coverage-redis.txt -covermode=atomic -coverpkg=./...
-
-          # HACK: move directory back to GITHUB_WORKSPACE
-          cd /
-          mv -v /tmp/gha-work $CHECKOUT_DIR
+        run: TEST_REDIS=redis://localhost:6379/0 gotestsum --format short-verbose -- -timeout 20m -p 1 -run TestRedis ./arbnode/... ./system_tests/... -coverprofile=coverage-redis.txt -covermode=atomic -coverpkg=./...
 
       - name: run challenge tests
         if: matrix.test-mode == 'challenge'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,6 @@ jobs:
         test-mode: [defaults, race, challenge, stylus, long, redis]
 
     steps:
-      - name: Move repo to avoid too long file paths
-        run: |
-          mkdir /tmp/gha-work
-          cd /tmp/gha-work
-          rm -rf $GITHUB_WORKSPACE
-          # Link the original workspace to the new workspace directory
-          ln -sv /tmp/gha-work $GITHUB_WORKSPACE
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -197,9 +189,20 @@ jobs:
         if: matrix.test-mode == 'defaults'
         shell: bash
         run: |
+
+          # HACK: move to directory with shorter path to avoid IPC paths over 107 characters
+          cd /
+          mv -v $GITHUB_WORKSPACE /tmp/gha-work
+          cd /tmp/gha-work
+
+          # Run the tests
           skip_tests=`grep -vE '^\s*#|^\s*$' ci_skip_tests | sed 's/.*/^&$/g' | tr '\n' '|' | sed 's/|$//'`
           packages=`go list ./...`
           stdbuf -oL gotestsum --format short-verbose --packages="$packages" --rerun-fails=1 --no-color=false -- ./... -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/... -timeout 35m -skip "$skip_tests"  > >(stdbuf -oL tee full.log | grep -vE "INFO|seal")
+
+          # HACK: move directory back to GITHUB_WORKSPACE
+          cd /
+          mv -v /tmp/gha-work $GITHUB_WORKSPACE
 
       - name: run tests with race detection
         if: matrix.test-mode == 'race'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,9 +189,21 @@ jobs:
         if: matrix.test-mode == 'defaults'
         shell: bash
         run: |
+          # HACK: move to directory with shorter path to avoid IPC paths over 107 characters
+          ls -lah /tmp
+          rm -rf /tmp/gha-work
+          CHECKOUT_DIR=$PWD
+          cd /
+          mv -v $CHECKOUT_DIR /tmp/gha-work
+          cd /tmp/gha-work
+
           skip_tests=`grep -vE '^\s*#|^\s*$' ci_skip_tests | sed 's/.*/^&$/g' | tr '\n' '|' | sed 's/|$//'`
           packages=`go list ./...`
           stdbuf -oL gotestsum --format short-verbose --packages="$packages" --rerun-fails=1 --no-color=false -- ./... -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/... -timeout 35m -skip "$skip_tests"  > >(stdbuf -oL tee full.log | grep -vE "INFO|seal")
+
+          # HACK: move directory back to GITHUB_WORKSPACE
+          cd /
+          mv -v /tmp/gha-work $CHECKOUT_DIR
 
       - name: run tests with race detection
         if: matrix.test-mode == 'race'


### PR DESCRIPTION
Currently the go and rust `actions/cache` uses are broken. This change limits the changing of directories to the one test job where it's needed so caching should start working again.