### PR TITLE
CI: make more space

### DIFF
--- a/.github/workflows/espresso-docker.yml
+++ b/.github/workflows/espresso-docker.yml
@@ -57,18 +57,25 @@ jobs:
           echo "Available storage before:"
           sudo df -h
           echo
-          sudo rmz -f /usr/share/dotnet
-          sudo rmz -f /usr/share/swift
-          sudo rmz -f /usr/share/gradle-*
-          sudo rmz -f /usr/share/az_*
-          sudo rmz -f /usr/local/lib/android
-          sudo rmz -f /usr/local/lib/node_modules
-          sudo rmz -f /opt/ghc
+
+          sudo rmz -f $AGENT_TOOLSDIRECTORY
           sudo rmz -f /opt/az
-          sudo rmz -f /opt/pipx
+          sudo rmz -f /opt/ghc
           sudo rmz -f /opt/google
           sudo rmz -f /opt/microsoft
-          sudo rmz -f /opt/hostedtoolcache
+          sudo rmz -f /opt/pipx
+          sudo rmz -f /usr/lib/mono
+          sudo rmz -f /usr/local/julia*
+          sudo rmz -f /usr/local/lib/android
+          sudo rmz -f /usr/local/lib/node_modules
+          sudo rmz -f /usr/local/share/boost
+          sudo rmz -f /usr/local/share/chromium
+          sudo rmz -f /usr/local/share/powershell
+          sudo rmz -f /usr/share/az_*
+          sudo rmz -f /usr/share/dotnet
+          sudo rmz -f /usr/share/gradle-*
+          sudo rmz -f /usr/share/swift
+
           echo "Available storage after:"
           sudo df -h
           echo


### PR DESCRIPTION
Strangely, on the integration branch the docker build is running out of space again. This PR makes some more space. The docker build passed on the PR, but not sure if it would fix the build on the integration branch.