### PR TITLE
Escape Hatch

### DIFF
--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -289,13 +289,6 @@ func main() {
 		// Handle the various pre-conditions if the message is an Espresso message
 		validatingAgainstEspresso := chainConfig.ArbitrumChainParams.EnableEspresso && arbos.IsEspressoMsg(message.Message)
 
-		// Currently we don't check the hotshot liveness here as it introduces a panic if the wavmio call fails.
-		// When we can again panic in the STF, we should re-add this check.
-		//
-		// The following call will be used to check the liveness based on the l1 block height.
-		// isHotShotLive := wavmio.IsHotShotLive(message.Message.Header.BlockNumber)
-		//
-		// The following line should be changed to if validatingAgainstEspresso && isHotShotLive {
 		if validatingAgainstEspresso {
 			txs, jst, err := arbos.ParseEspressoMsg(message.Message)
 			if err != nil {

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -288,6 +288,14 @@ func main() {
 
 		// Handle the various pre-conditions if the message is an Espresso message
 		validatingAgainstEspresso := chainConfig.ArbitrumChainParams.EnableEspresso && arbos.IsEspressoMsg(message.Message)
+
+		// Currently we don't check the hotshot liveness here as it introduces a panic if the wavmio call fails.
+		// When we can again panic in the STF, we should re-add this check.
+		//
+		// The following call will be used to check the liveness based on the l1 block height.
+		// isHotShotLive := wavmio.IsHotShotLive(message.Message.Header.BlockNumber)
+		//
+		// The following line should be changed to if validatingAgainstEspresso && isHotShotLive {
 		if validatingAgainstEspresso {
 			txs, jst, err := arbos.ParseEspressoMsg(message.Message)
 			if err != nil {

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -186,11 +186,6 @@ func CreateExecutionNode(
 			return nil, err
 		}
 
-		// sovereign sequencer should not be configured with espresso finality node
-		if config.Sequencer.EnableEspressoFinalityNode && config.Sequencer.EnableEspressoSovereign {
-			return nil, errors.New("espresso finality node cannot be configured with espresso sovereign sequencer")
-		}
-
 		if config.Sequencer.EnableEspressoFinalityNode {
 			espressoFinalityNode := NewEspressoFinalityNode(execEngine, seqConfigFetcher)
 			txPublisher = espressoFinalityNode

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -86,6 +86,7 @@ type SequencerConfig struct {
 	EspressoFinalityNodeConfig EspressoFinalityNodeConfig `koanf:"espresso-finality-node-config"`
 	// Espresso Finality Node creates blocks with finalized hotshot transactions
 	EnableEspressoFinalityNode bool `koanf:"enable-espresso-finality-node"`
+	EnableEspressoSovereign    bool `koanf:"enable-espresso-sovereign"`
 }
 
 func (c *SequencerConfig) Validate() error {
@@ -131,6 +132,7 @@ var DefaultSequencerConfig = SequencerConfig{
 	EnableProfiling:              false,
 
 	EnableEspressoFinalityNode: false,
+	EnableEspressoSovereign:    false,
 }
 
 var TestSequencerConfig = SequencerConfig{
@@ -151,6 +153,7 @@ var TestSequencerConfig = SequencerConfig{
 	EnableProfiling:              false,
 
 	EnableEspressoFinalityNode: false,
+	EnableEspressoSovereign:    false,
 }
 
 func SequencerConfigAddOptions(prefix string, f *flag.FlagSet) {
@@ -172,6 +175,7 @@ func SequencerConfigAddOptions(prefix string, f *flag.FlagSet) {
 
 	// Espresso specific flags
 	f.Bool(prefix+".enable-espresso-finality-node", DefaultSequencerConfig.EnableEspressoFinalityNode, "enable espresso finality node")
+	f.Bool(prefix+".enable-espresso-sovereign", DefaultSequencerConfig.EnableEspressoSovereign, "enable sovereign sequencer mode for the Espresso integration")
 }
 
 type txQueueItem struct {

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -358,6 +358,9 @@ func NewSequencer(execEngine *ExecutionEngine, l1Reader *headerreader.HeaderRead
 		senderWhitelist[common.HexToAddress(address)] = struct{}{}
 	}
 
+	// For the sovereign sequencer to have an escape hatch, we need to be able to read the state of the light client.
+	// To accomplish this, we introduce a requirement on the l1Reader/ParentChainReader to not be null. This is a soft
+	// requirement as the sequencer will still run if we don't have this reader, but it will not create espresso messages.
 	var (
 		lightClientReader *lightclient.LightClientReader
 		err               error

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -370,13 +370,16 @@ func NewSequencer(execEngine *ExecutionEngine, l1Reader *headerreader.HeaderRead
 		err               error
 	)
 
-	if l1Reader != nil {
-		lightClientReader, err = lightclient.NewLightClientReader(common.HexToAddress(config.LightClientAddress), l1Reader.Client())
+	if l1Reader == nil && config.EnableEspressoSovereign {
+		return nil, fmt.Errorf("Cannot enable espresso sequencing mode in the sovereign sequencer with no l1 reader")
 	}
 
-	if err != nil {
-		log.Error("Could not construct light client reader for sequencer. Failing.", "err", err)
-		return nil, err
+	if l1Reader != nil {
+		lightClientReader, err = lightclient.NewLightClientReader(common.HexToAddress(config.LightClientAddress), l1Reader.Client())
+		if err != nil {
+			log.Error("Could not construct light client reader for sequencer. Failing.", "err", err)
+			return nil, err
+		}
 	}
 
 	s := &Sequencer{

--- a/system_tests/espresso_e2e_test.go
+++ b/system_tests/espresso_e2e_test.go
@@ -223,11 +223,11 @@ func TestEspressoE2E(t *testing.T) {
 	})
 	Require(t, err)
 
-	//make light client reader
+	// make light client reader
 
 	lightClientReader, err := lightclient.NewLightClientReader(common.HexToAddress(lightClientAddress), builder.L1.Client)
 	Require(t, err)
-	//wait for hotshot liveness
+	// wait for hotshot liveness
 
 	err = waitForHotShotLiveness(t, ctx, lightClientReader)
 	Require(t, err)

--- a/system_tests/espresso_e2e_test.go
+++ b/system_tests/espresso_e2e_test.go
@@ -3,7 +3,11 @@ package arbtest
 import (
 	"context"
 	"encoding/json"
+	lightclient "github.com/EspressoSystems/espresso-sequencer-go/light-client"
+	lightclientmock "github.com/EspressoSystems/espresso-sequencer-go/light-client-mock"
+	"github.com/ethereum/go-ethereum/common"
 	"math/big"
+	"os"
 	"os/exec"
 	"testing"
 	"time"
@@ -22,6 +26,7 @@ var workingDir = "./espresso-e2e"
 var lightClientAddress = "0xb075b82c7a23e0994df4793422a1f03dbcf9136f"
 
 var hotShotUrl = "http://127.0.0.1:41000"
+var delayThreshold = 10
 
 var (
 	jitValidationPort = 54320
@@ -141,6 +146,17 @@ func waitForEspressoNode(t *testing.T, ctx context.Context) error {
 	})
 }
 
+func waitForHotShotLiveness(t *testing.T, ctx context.Context, lightClientReader *lightclient.LightClientReader) error {
+	return waitForWith(t, ctx, 400*time.Second, 1*time.Second, func() bool {
+		log.Info("Waiting for HotShot Liveness")
+		live, err := lightClientReader.IsHotShotLive(10)
+		if err != nil {
+			return false
+		}
+		return live
+	})
+}
+
 func waitForL1Node(t *testing.T, ctx context.Context) error {
 	return waitFor(t, ctx, func() bool {
 		if e := exec.Command(
@@ -207,6 +223,15 @@ func TestEspressoE2E(t *testing.T) {
 	})
 	Require(t, err)
 
+	//make light client reader
+
+	lightClientReader, err := lightclient.NewLightClientReader(common.HexToAddress(lightClientAddress), builder.L1.Client)
+	Require(t, err)
+	//wait for hotshot liveness
+
+	err = waitForHotShotLiveness(t, ctx, lightClientReader)
+	Require(t, err)
+
 	// Check if the tx is executed correctly
 	err = checkTransferTxOnL2(t, ctx, l2Node, "User10", l2Info)
 	Require(t, err)
@@ -246,6 +271,66 @@ func TestEspressoE2E(t *testing.T) {
 		return balance2.Cmp(transferAmount) >= 0
 	})
 	Require(t, err)
+
+	// Pause l1 height and verify that the escape hatch is working
+	checkStaker := os.Getenv("E2E_SKIP_ESCAPE_HATCH_TEST")
+	if checkStaker == "" {
+		log.Info("Checking the escape hatch")
+		// Start to check the escape hatch
+		address := common.HexToAddress(lightClientAddress)
+
+		txOpts := builder.L1Info.GetDefaultTransactOpts("Faucet", ctx)
+
+		// Freeze the l1 height
+		err := lightclientmock.FreezeL1Height(t, builder.L1.Client, address, &txOpts)
+		log.Info("waiting for light client to report hotshot is down")
+		Require(t, err)
+		err = waitForWith(t, ctx, 10*time.Minute, 1*time.Second, func() bool {
+			isLive, err := lightclientmock.IsHotShotLive(t, builder.L1.Client, address, uint64(delayThreshold))
+			if err != nil {
+				return false
+			}
+			return !isLive
+		})
+		Require(t, err)
+		log.Info("light client has reported that hotshot is down")
+		// Wait for the switch to be totally finished
+		currMsg, err := builder.L2.ConsensusNode.TxStreamer.GetMessageCount()
+		Require(t, err)
+		log.Info("waiting for message count", "currMsg", currMsg)
+		var validatedMsg arbutil.MessageIndex
+		err = waitForWith(t, ctx, 6*time.Minute, 60*time.Second, func() bool {
+			validatedCnt := builder.L2.ConsensusNode.BlockValidator.Validated(t)
+			log.Info("Validation status", "validatedCnt", validatedCnt, "msgCnt", msgCnt)
+			if validatedCnt >= currMsg {
+				validatedMsg = validatedCnt
+				return true
+			}
+			return false
+		})
+		Require(t, err)
+		err = checkTransferTxOnL2(t, ctx, l2Node, "User12", l2Info)
+		Require(t, err)
+		err = checkTransferTxOnL2(t, ctx, l2Node, "User13", l2Info)
+		Require(t, err)
+
+		err = waitForWith(t, ctx, 3*time.Minute, 20*time.Second, func() bool {
+			validated := builder.L2.ConsensusNode.BlockValidator.Validated(t)
+			return validated >= validatedMsg
+		})
+		Require(t, err)
+
+		// Unfreeze the l1 height
+		err = lightclientmock.UnfreezeL1Height(t, builder.L1.Client, address, &txOpts)
+		Require(t, err)
+
+		// Check if the validated count is increasing
+		err = waitForWith(t, ctx, 3*time.Minute, 20*time.Second, func() bool {
+			validated := builder.L2.ConsensusNode.BlockValidator.Validated(t)
+			return validated >= validatedMsg+10
+		})
+		Require(t, err)
+	}
 }
 
 func checkTransferTxOnL2(

--- a/system_tests/espresso_finality_node_test.go
+++ b/system_tests/espresso_finality_node_test.go
@@ -34,8 +34,6 @@ func createEspressoFinalityNode(t *testing.T, builder *NodeBuilder) (*TestClient
 	execConfig.Sequencer.EspressoFinalityNodeConfig.StartBlock = 1
 	execConfig.Sequencer.EspressoFinalityNodeConfig.HotShotUrl = hotShotUrl
 
-	// disable sovereign sequencer
-	execConfig.Sequencer.EnableEspressoSovereign = false
 	builder.nodeConfig.TransactionStreamer.SovereignSequencerEnabled = false
 
 	return builder.Build2ndNode(t, &SecondNodeParams{

--- a/system_tests/espresso_sovereign_sequencer_test.go
+++ b/system_tests/espresso_sovereign_sequencer_test.go
@@ -82,9 +82,11 @@ func TestSovereignSequencer(t *testing.T) {
 	// create light client reader
 	lightClientReader, err := lightclient.NewLightClientReader(common.HexToAddress(lightClientAddress), builder.L1.Client)
 
+	Require(t, err)
+
 	// wait for hotshot liveness
 	err = waitForHotShotLiveness(t, ctx, lightClientReader)
-
+	Require(t, err)
 	err = checkTransferTxOnL2(t, ctx, builder.L2, "User14", builder.L2Info)
 	Require(t, err)
 

--- a/system_tests/espresso_sovereign_sequencer_test.go
+++ b/system_tests/espresso_sovereign_sequencer_test.go
@@ -3,6 +3,8 @@ package arbtest
 import (
 	"context"
 	"fmt"
+	lightclient "github.com/EspressoSystems/espresso-sequencer-go/light-client"
+	"github.com/ethereum/go-ethereum/common"
 	"math/big"
 	"testing"
 	"time"
@@ -76,6 +78,12 @@ func TestSovereignSequencer(t *testing.T) {
 	// wait for the builder
 	err = waitForEspressoNode(t, ctx)
 	Require(t, err)
+
+	// create light client reader
+	lightClientReader, err := lightclient.NewLightClientReader(common.HexToAddress(lightClientAddress), builder.L1.Client)
+
+	// wait for hotshot liveness
+	err = waitForHotShotLiveness(t, ctx, lightClientReader)
 
 	err = checkTransferTxOnL2(t, ctx, builder.L2, "User14", builder.L2Info)
 	Require(t, err)

--- a/system_tests/espresso_sovereign_sequencer_test.go
+++ b/system_tests/espresso_sovereign_sequencer_test.go
@@ -41,8 +41,6 @@ func createL1AndL2Node(ctx context.Context, t *testing.T) (*NodeBuilder, func())
 	builder.nodeConfig.Sequencer = true
 	builder.nodeConfig.Dangerous.NoSequencerCoordinator = true
 	builder.execConfig.Sequencer.Enable = true
-	// using the sovereign sequencer
-	builder.execConfig.Sequencer.EnableEspressoSovereign = true
 
 	// transaction stream config
 	builder.nodeConfig.TransactionStreamer.SovereignSequencerEnabled = true

--- a/system_tests/espresso_sovereign_sequencer_test.go
+++ b/system_tests/espresso_sovereign_sequencer_test.go
@@ -41,8 +41,10 @@ func createL1AndL2Node(ctx context.Context, t *testing.T) (*NodeBuilder, func())
 
 	// sequencer config
 	builder.nodeConfig.Sequencer = true
+	builder.nodeConfig.ParentChainReader.Enable = true // This flag is necessary to enable sequencing transactions with espresso behavior
 	builder.nodeConfig.Dangerous.NoSequencerCoordinator = true
 	builder.execConfig.Sequencer.Enable = true
+	builder.execConfig.Sequencer.LightClientAddress = lightClientAddress
 
 	// transaction stream config
 	builder.nodeConfig.TransactionStreamer.SovereignSequencerEnabled = true

--- a/system_tests/espresso_sovereign_sequencer_test.go
+++ b/system_tests/espresso_sovereign_sequencer_test.go
@@ -43,6 +43,7 @@ func createL1AndL2Node(ctx context.Context, t *testing.T) (*NodeBuilder, func())
 	builder.nodeConfig.Sequencer = true
 	builder.nodeConfig.ParentChainReader.Enable = true // This flag is necessary to enable sequencing transactions with espresso behavior
 	builder.nodeConfig.Dangerous.NoSequencerCoordinator = true
+	builder.execConfig.Sequencer.EnableEspressoSovereign = true
 	builder.execConfig.Sequencer.Enable = true
 	builder.execConfig.Sequencer.LightClientAddress = lightClientAddress
 

--- a/system_tests/espresso_transaction_payload_signature_test.go
+++ b/system_tests/espresso_transaction_payload_signature_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
+	lightclient "github.com/EspressoSystems/espresso-sequencer-go/light-client"
+	"github.com/ethereum/go-ethereum/common"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -33,6 +35,13 @@ func TestEspressoTransactionSignatureForSovereignSequencer(t *testing.T) {
 
 	// wait for the builder
 	err = waitForEspressoNode(t, ctx)
+	Require(t, err)
+
+	lightClientReader, err := lightclient.NewLightClientReader(common.HexToAddress(lightClientAddress), builder.L1.Client)
+	Require(t, err)
+	// wait for hotshot liveness
+
+	err = waitForHotShotLiveness(t, ctx, lightClientReader)
 	Require(t, err)
 
 	err = checkTransferTxOnL2(t, ctx, l2Node, "User14", l2Info)


### PR DESCRIPTION
Closes #221 

### This PR:

Adds a check in the sequencer that takes the l1 block height for transactions that are about to be sequencedand determines if hotshot is live based on that height. If hot shot is live we designate these transactions as espresso messages and attempt to sequence them with the sovereign sequencer. otherwise we designate them as normal Arbitrum messages and sequence them based on normal Arbitrum behavior.

In the future the `shouldSequenceWithEspresso` will also be gated by the `chainConfig.EnableEspresso` flag to enable correct migration.

This PR may break the espresso finality node test as we have no clear way to disable the sovereign sequencer until we add the chain config checks. I will fix this in the PR related to adding chain config checks. 

### This PR does not:
Add any checks related to the chain config.

### Key places to review:

`sequencer.go` in `execution/gethexec` and the E2E test for correctness.

<!-- ### How to test this PR:  -->
 Run the E2E test with `go test -run ^TestEspressoE2E$ github.com/offchainlabs/nitro/system_tests -v`

<!-- ### Things tested -->
The E2E test passes locally.