### PR TITLE
Use ArbOS chain config as the cannonial chain config.

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -496,7 +496,18 @@ func (b *BatchPoster) addEspressoBlockMerkleProof(
 	ctx context.Context,
 	msg *arbostypes.MessageWithMetadata,
 ) error {
+
 	if arbos.IsEspressoMsg(msg.Message) {
+		arbOSConfig, err := b.arbOSVersionGetter.GetArbOSConfigAtHeight(0)
+		if err != nil {
+			return fmt.Errorf("Failed call to GetArbOSConfigAtHeight: %w", err)
+		}
+		if !arbOSConfig.ArbitrumChainParams.EnableEspresso {
+			// This case should be highly unlikely, as espresso messages are not produced while ArbitrumChainParams.EnableEspresso is false
+			// However, in the event that an espresso message was created, and then Enable Espresso was set to false, we should ensure
+			// the transaction streamer doesn't send any more messages to the espresso network.
+			return fmt.Errorf("Cannot process Espresso messages when Espresso is not enabled in the ArbOS chain config")
+		}
 		txs, jst, err := arbos.ParseEspressoMsg(msg.Message)
 		if err != nil {
 			return err

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -502,6 +502,9 @@ func (b *BatchPoster) addEspressoBlockMerkleProof(
 		if err != nil {
 			return fmt.Errorf("Failed call to GetArbOSConfigAtHeight: %w", err)
 		}
+		if arbOSConfig == nil {
+			return fmt.Errorf("Cannot use a nil ArbOSConfig")
+		}
 		if !arbOSConfig.ArbitrumChainParams.EnableEspresso {
 			// This case should be highly unlikely, as espresso messages are not produced while ArbitrumChainParams.EnableEspresso is false
 			// However, in the event that an espresso message was created, and then Enable Espresso was set to false, we should ensure

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1520,10 +1520,20 @@ func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context, ig
 }
 
 func (s *TransactionStreamer) espressoSwitch(ctx context.Context, ignored struct{}) time.Duration {
-	if s.ChainConfig().ArbitrumChainParams.EnableEspresso {
+	retryRate := s.config().EspressoTxnsPollingInterval * 50
+	config, err := s.exec.GetArbOSConfigAtHeight(0) // Pass 0 to get the ArbOS config at current block height.
+	if err != nil {
+		log.Error("Error Obtaining ArbOS Config ", "err", err)
+		return retryRate
+	}
+	if config == nil {
+		log.Error("ArbOS Config is nil")
+		return retryRate
+	}
+	if config.ArbitrumChainParams.EnableEspresso {
 		return s.submitEspressoTransactions(ctx, ignored)
 	} else {
-		return s.config().EspressoTxnsPollingInterval * 10
+		return retryRate
 	}
 }
 

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -16,6 +16,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -130,6 +131,67 @@ func (s *ExecutionEngine) backlogL1GasCharged() uint64 {
 	return (s.cachedL1PriceData.msgToL1PriceData[size-1].cummulativeL1GasCharged -
 		s.cachedL1PriceData.msgToL1PriceData[0].cummulativeL1GasCharged +
 		s.cachedL1PriceData.msgToL1PriceData[0].l1GasCharged)
+}
+
+// GetArbOSConfigAtHeight is a data retrieval function on the execution engine.
+// Params:
+//
+//	height: An optional unsinged 64 bit integer that represents the block height at which we wish to view the
+//	ArbOS config. This must be less than or equal to the current block height.
+//
+// Returns:
+//
+//	A reference to a params.ChainConfig struct that contains the cannonical ArbOS chain config at the given block
+//	height,	the current block height if height was 0, or an error if the execution engine was unable to obtain the
+//	chain config.
+//
+// Safety:
+//
+//	This function should be thread safe as the functions it calls in the execution engine are thread safe.
+func (s *ExecutionEngine) GetArbOSConfigAtHeight(height uint64) (*params.ChainConfig, error) {
+	var (
+		chainConfig *params.ChainConfig
+		state       *state.StateDB
+		err         error
+	)
+	// if height was provided, get the ArbOS chainConfig at that height, otherwise get the config at current tip height.
+	if height != 0 {
+		state, err = s.bc.StateAt(s.bc.GetBlockByNumber(height).Root())
+		if err != nil {
+			log.Error("Error fetching stateDb at height to obtain ArbOS config", "height", height, "err", err)
+			return nil, err
+		}
+	} else {
+		state, err = s.bc.State()
+		if err != nil {
+			log.Error("Error fetching stateDb at current height to obtain ArbOS config", "err", err)
+			return nil, err
+		}
+	}
+	// Open ArbOS state from the requested statedb
+	arbOSState, err := arbosState.OpenSystemArbosState(state, nil, true)
+	if err != nil {
+		log.Error("Error fetching ArbOS state", "err", err)
+		return nil, err
+	}
+	// Get the chain config bytes from ArbOS state
+	chainConfigBytes, err := arbOSState.ChainConfig()
+	if err != nil {
+		log.Error("Error fetching ArbOS chainConfig from ArbOS state", "err", err)
+		return nil, err
+	}
+	// Deserialize the chainConfig from bytes
+	if chainConfigBytes != nil {
+		err = json.Unmarshal(chainConfigBytes, &chainConfig)
+		if err != nil {
+			log.Error("Error deserializing ArbOS chainConfig from bytes", "err", err)
+			return nil, err
+		}
+		return chainConfig, nil
+	} else {
+		return nil, fmt.Errorf("chain config bytes is nil")
+	}
+	// If we made it here everything has gone well; we can return the chain config struct.
 }
 
 func (s *ExecutionEngine) MarkFeedStart(to arbutil.MessageIndex) {

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/params"
 	"reflect"
 	"sync/atomic"
 	"testing"
@@ -281,6 +282,30 @@ func CreateExecutionNode(
 		ClassicOutbox:     classicOutbox,
 	}, nil
 
+}
+
+// GetArbOSConfigAtHeight is a data retrieval function on the execution engine.
+// Params:
+//
+//	height: An optional unsinged 64 bit integer that represents the block height at which we wish to view the
+//	ArbOS config. This must be less than or equal to the current block height.
+//
+// Returns:
+//
+//	A reference to a params.ChainConfig struct that contains the cannonical ArbOS chain config at the given block
+//	height,	the current block height if height was 0, or an error if the execution engine was unable to obtain the
+//	chain config.
+//
+// Safety:
+//
+//	This function should be thread safe as the functions it calls in the execution engine are thread safe.
+func (n *ExecutionNode) GetArbOSConfigAtHeight(height uint64) (*params.ChainConfig, error) {
+	config, err := n.ExecEngine.GetArbOSConfigAtHeight(height)
+	if err != nil {
+		log.Error("GetArbOSConfigAtHeight", "height", height, "err", err)
+		return nil, err
+	}
+	return config, nil
 }
 
 func (n *ExecutionNode) MarkFeedStart(to arbutil.MessageIndex) {

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -971,12 +971,12 @@ func (s *Sequencer) createBlock(ctx context.Context) (returnValue bool) {
 	// This is a side effect of the sequencer having the capability to run without an L1 reader. For the Espresso integration this is a necessary component of the sequencer.
 	// However, many tests use the case of having a nil l1 reader
 	if s.lightClientReader != nil {
-		shouldSequenceWithEspresso, err = s.lightClientReader.IsHotShotLiveAtHeight(l1Block, s.config().SwitchDelayThreshold)
-	}
-
-	if err != nil {
-		log.Warn("An error occurred while attempting to determine if hotshot is live at l1 block, sequencing transactions without espresso", "l1Block", l1Block, "err", err)
-		shouldSequenceWithEspresso = false
+		isHotShotLive, err := s.lightClientReader.IsHotShotLiveAtHeight(l1Block, s.config().SwitchDelayThreshold)
+		if err != nil {
+			log.Warn("An error occurred while attempting to determine if hotshot is live at l1 block, sequencing transactions without espresso", "l1Block", l1Block, "err", err)
+			shouldSequenceWithEspresso = false
+		}
+		shouldSequenceWithEspresso = isHotShotLive && s.execEngine.bc.Config().ArbitrumChainParams.EnableEspresso
 	}
 
 	if config.EnableProfiling {

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -979,7 +979,6 @@ func (s *Sequencer) createBlock(ctx context.Context) (returnValue bool) {
 		isHotShotLive, err := s.lightClientReader.IsHotShotLiveAtHeight(l1Block, s.config().SwitchDelayThreshold)
 		if err != nil {
 			log.Warn("An error occurred while attempting to determine if hotshot is live at l1 block, sequencing transactions without espresso", "l1Block", l1Block, "err", err)
-			shouldSequenceWithEspresso = false
 		}
 		shouldSequenceWithEspresso = isHotShotLive && arbOSconfig.ArbitrumChainParams.EnableEspresso
 

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -967,6 +967,8 @@ func (s *Sequencer) createBlock(ctx context.Context) (returnValue bool) {
 		shouldSequenceWithEspresso bool
 	)
 
+	arbOSconfig, err := s.execEngine.GetArbOSConfigAtHeight(0) // pass 0 to get the current ArbOS config.
+
 	// Initialize shouldSequenceWithEspresso to false and if we have a light client reader then give it a value based on hotshot liveness
 	// This is a side effect of the sequencer having the capability to run without an L1 reader. For the Espresso integration this is a necessary component of the sequencer.
 	// However, many tests use the case of having a nil l1 reader
@@ -976,7 +978,9 @@ func (s *Sequencer) createBlock(ctx context.Context) (returnValue bool) {
 			log.Warn("An error occurred while attempting to determine if hotshot is live at l1 block, sequencing transactions without espresso", "l1Block", l1Block, "err", err)
 			shouldSequenceWithEspresso = false
 		}
-		shouldSequenceWithEspresso = isHotShotLive && s.execEngine.bc.Config().ArbitrumChainParams.EnableEspresso
+		shouldSequenceWithEspresso = isHotShotLive && arbOSconfig.ArbitrumChainParams.EnableEspresso
+
+		log.Info("After escape-hatch and chain config logic in sequencer", "ShouldSequenceWithEspresso", shouldSequenceWithEspresso, "EnableEspresso", arbOSconfig.ArbitrumChainParams.EnableEspresso, "isHotShotLive", isHotShotLive)
 	}
 
 	if config.EnableProfiling {

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -968,11 +968,14 @@ func (s *Sequencer) createBlock(ctx context.Context) (returnValue bool) {
 	)
 
 	arbOSconfig, err := s.execEngine.GetArbOSConfigAtHeight(0) // pass 0 to get the current ArbOS config.
+	if err != nil {
+		log.Warn("Error fetching ArbOS chainConfig in sequencer.")
+	}
 
 	// Initialize shouldSequenceWithEspresso to false and if we have a light client reader then give it a value based on hotshot liveness
 	// This is a side effect of the sequencer having the capability to run without an L1 reader. For the Espresso integration this is a necessary component of the sequencer.
 	// However, many tests use the case of having a nil l1 reader
-	if s.lightClientReader != nil {
+	if s.lightClientReader != nil && arbOSconfig != nil {
 		isHotShotLive, err := s.lightClientReader.IsHotShotLiveAtHeight(l1Block, s.config().SwitchDelayThreshold)
 		if err != nil {
 			log.Warn("An error occurred while attempting to determine if hotshot is live at l1 block, sequencing transactions without espresso", "l1Block", l1Block, "err", err)

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -3,6 +3,7 @@ package execution
 import (
 	"context"
 	"errors"
+	"github.com/ethereum/go-ethereum/params"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -60,6 +61,7 @@ type ExecutionSequencer interface {
 	MarkFeedStart(to arbutil.MessageIndex)
 	Synced() bool
 	FullSyncProgressMap() map[string]interface{}
+	GetArbOSConfigAtHeight(height uint64) (*params.ChainConfig, error)
 }
 
 type FullExecutionClient interface {

--- a/system_tests/espresso_arbos_test.go
+++ b/system_tests/espresso_arbos_test.go
@@ -1,0 +1,128 @@
+package arbtest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/offchainlabs/nitro/arbutil"
+	"github.com/offchainlabs/nitro/solgen/go/precompilesgen"
+)
+
+func EspressoArbOSTestChainConfig() *params.ChainConfig {
+	return &params.ChainConfig{
+		ChainID:             big.NewInt(412346),
+		HomesteadBlock:      big.NewInt(0),
+		DAOForkBlock:        nil,
+		DAOForkSupport:      true,
+		EIP150Block:         big.NewInt(0),
+		EIP155Block:         big.NewInt(0),
+		EIP158Block:         big.NewInt(0),
+		ByzantiumBlock:      big.NewInt(0),
+		ConstantinopleBlock: big.NewInt(0),
+		PetersburgBlock:     big.NewInt(0),
+		IstanbulBlock:       big.NewInt(0),
+		MuirGlacierBlock:    big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
+		ArbitrumChainParams: EspressoTestChainParams(),
+		Clique: &params.CliqueConfig{
+			Period: 0,
+			Epoch:  0,
+		},
+	}
+}
+func EspressoTestChainParams() params.ArbitrumChainParams {
+	return params.ArbitrumChainParams{
+		EnableArbOS:               true,
+		AllowDebugPrecompiles:     true,
+		DataAvailabilityCommittee: false,
+		InitialArbOSVersion:       31,
+		InitialChainOwner:         common.Address{},
+		EnableEspresso: 		   false,
+	}
+}
+
+func waitForConfigUpdate(t *testing.T, ctx context.Context, builder *NodeBuilder) error{
+
+    return waitForWith(t, ctx, 120*time.Second, 1*time.Second, func() bool{
+      newArbOSConfig, err := builder.L2.ExecNode.GetArbOSConfigAtHeight(0)
+      Require(t, err)
+
+      if newArbOSConfig.ArbitrumChainParams.EnableEspresso != false{
+        return false
+      }
+      Require(t,err)
+      return true
+    })
+}
+
+func TestEspressoArbOSConfig(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	builder, cleanup := createL1AndL2Node(ctx, t)
+	defer cleanup()
+
+	err := waitForL1Node(t, ctx)
+	Require(t, err)
+
+	cleanEspresso := runEspresso(t, ctx)
+	defer cleanEspresso()
+
+	// wait for the builder
+	err = waitForEspressoNode(t, ctx)
+	Require(t, err)
+
+	l2Node := builder.L2
+
+	// Wait for the initial message
+	expected := arbutil.MessageIndex(1)
+	err = waitFor(t, ctx, func() bool {
+		msgCnt, err := l2Node.ConsensusNode.TxStreamer.GetMessageCount()
+		if err != nil {
+			panic(err)
+		}
+
+		validatedCnt := l2Node.ConsensusNode.BlockValidator.Validated(t)
+		return msgCnt >= expected && validatedCnt >= expected
+	})
+	Require(t, err)
+  
+
+  initialArbOSConfig, err := builder.L2.ExecNode.GetArbOSConfigAtHeight(0)
+  Require(t,err)
+
+  //assert that espresso is initially enabled
+  if initialArbOSConfig.ArbitrumChainParams.EnableEspresso != true{
+    err = fmt.Errorf("Initial config should have EnableEspresso == true!")
+    
+  } 
+  Require(t,err)
+
+  newArbOwner, err := precompilesgen.NewArbOwner(common.HexToAddress("0x070"), builder.L2.Client)
+  Require(t, err)
+
+  newArbDebug, err := precompilesgen.NewArbDebug(common.HexToAddress("0xff"), builder.L2.Client)
+  Require(t, err)
+  
+  l2auth := builder.L2Info.GetDefaultTransactOpts("Owner", ctx)
+
+  _, err = newArbDebug.BecomeChainOwner(&l2auth)
+  Require(t, err)
+  chainConfig, err := json.Marshal(EspressoArbOSTestChainConfig())
+  Require(t, err)
+  
+  chainConfigString := string(chainConfig)
+
+  _, err = newArbOwner.SetChainConfig(&l2auth, chainConfigString)
+  Require(t, err)
+  // check if chain config is updated TODO replace this with a wait for with to poll for some time potentially
+  
+  waitForConfigUpdate(t, ctx, builder)
+}


### PR DESCRIPTION
Closes #228 

### This PR: 
Adds a method for nitro nodes, primarily the sequencer, to read the ArbOS chain config when determining if espresso is enabled. This allows the `EnableEspresso` field of the chain config to act as a live switch to enable espresso independently of any upgrade.

### Key places to review:
Key files to review are `transaction_streamer.go`, `sequencer.go`, `executionengine.go`, and `node.go` are the primary places to review, changes to `interface.go` are important as well.

### How to test this PR:
Testing this PR also involves using the work in the set-chain-config branch of the nitro-testnode repo [here](https://github.com/EspressoSystems/nitro-testnode/pull/61)

You can either check this branch out in a different repository, or likely point the nitro-testnode submodule in this repo at that branch.

My testing process included the following steps:

- Run docker build . -t espresso-integration-testnode in this repo checked out to this branch.
- Run nitro-testnode/espresso-tests/migration-test.bash to run the migration test.
- If the migration test finishes, everything is in working order.

There should be some output near the end of the test that looks similar to this:
```
+ '[' 119 '!=' 200 ']'
++ curl http://localhost:41000/v0/availability/block/119/namespace/412346
++ jq -r '.transactions.[0].namespace'
++ tail -n 1
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   732  100   732    0     0   373k      0 --:--:-- --:--:-- --:--:--  714k
+ export namespace=412346
+ namespace=412346
+ '[' 412346 -eq 412346 ']'
+ echo 'ChainID matches chainID from transaction stored in Espresso network!, chain config has been successfully set.'
ChainID matches chainID from transaction stored in Espresso network!, chain config has been successfully set.
+ break
+ cd /home/nixnovice/espresso/nitro-testnode/orbit-actions
++ cast call 0x784FC11476F3d06801A76b944795E6367391b12e 'osp()(address)' --rpc-url http://localhost:8545
+ CHALLENGE_MANAGER_OSP_ADDRESS=0x773D62Ce1794b11788907b32F793e647A4f9A1F7
+ '[' 0x773D62Ce1794b11788907b32F793e647A4f9A1F7 '!=' 0x773D62Ce1794b11788907b32F793e647A4f9A1F7 ']'
+ RECIPIENT_ADDRESS=0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
++ cast balance 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA -e --rpc-url http://localhost:8547
+ BALANCE_ORIG=0.000000000000000000
+ cast send 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA --value 1ether --rpc-url http://localhost:8547 --private-key 0xdc04c5399f82306ec4b4d654a342f40e2e0620fe39950d967e1e574b32d4dd36

```

This shows that the chain config has switched as we are successfully forwarding transactions to the espresso confirmation layer in the test.

 ### Things tested:
I have confirmed that locally this change is working with the testnode and is showing the chain config switching.