### PR TITLE
Use the latest espresso dev node

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -567,6 +567,8 @@ func (b *BatchPoster) addEspressoBlockMerkleProof(
 		// If the message is an Espresso message, store the pos in the database to be used later
 		// to submit the message to hotshot for finalization.
 		log.Info("Submitting pos", "pos", b.building.msgCount)
+		// TODO: Verify if this msgCount is already in the pending queue.
+		// Currently, this check is performed in the function below.
 		err = b.streamer.SubmitEspressoTransactionPos(b.building.msgCount, b.streamer.db.NewBatch())
 		if err != nil {
 			log.Error("failed to submit espresso transaction pos", "pos", b.building.msgCount, "err", err)

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1283,7 +1283,7 @@ func (s *TransactionStreamer) executeMessages(ctx context.Context, ignored struc
 	return s.config().ExecuteMessageLoopDelay
 }
 
-func (s *TransactionStreamer) PollSubmittedTransactionForFinality(ctx context.Context) time.Duration {
+func (s *TransactionStreamer) pollSubmittedTransactionForFinality(ctx context.Context) time.Duration {
 	submittedTxnPos, err := s.getEspressoSubmittedPos()
 	if err != nil {
 		log.Warn("submitted pos not found", "err", err)
@@ -1481,6 +1481,14 @@ func (s *TransactionStreamer) setEspressoPendingTxnsPos(batch ethdb.KeyValueWrit
 }
 
 func (s *TransactionStreamer) SubmitEspressoTransactionPos(pos arbutil.MessageIndex, batch ethdb.Batch) error {
+	submitted, err := s.getEspressoSubmittedPos()
+	if err != nil && !dbutil.IsErrNotFound(err) {
+		return err
+	}
+
+	if pos == submitted {
+		return fmt.Errorf("Submitting the same position messages")
+	}
 	pendingTxnsPos, err := s.getEspressoPendingTxnsPos()
 	if err != nil && !dbutil.IsErrNotFound(err) {
 		log.Error("failed to get the pending txns position", "err", err)
@@ -1490,6 +1498,8 @@ func (s *TransactionStreamer) SubmitEspressoTransactionPos(pos arbutil.MessageIn
 	if err != nil && dbutil.IsErrNotFound(err) {
 		// if the key doesn't exist, create a new array with the pos
 		pendingTxnsPos = []*arbutil.MessageIndex{&pos}
+	} else if pendingTxnsPos[len(pendingTxnsPos)-1] == &pos {
+		return fmt.Errorf("Submitting the same position messages")
 	} else {
 		pendingTxnsPos = append(pendingTxnsPos, &pos)
 	}
@@ -1517,7 +1527,7 @@ func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context, ig
 	}
 
 	if err == nil {
-		if s.PollSubmittedTransactionForFinality(ctx) != time.Duration(0) {
+		if s.pollSubmittedTransactionForFinality(ctx) != time.Duration(0) {
 			return s.config().EspressoTxnsPollingInterval
 		}
 	}

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1487,7 +1487,7 @@ func (s *TransactionStreamer) SubmitEspressoTransactionPos(pos arbutil.MessageIn
 	}
 
 	if pos == submitted {
-		return fmt.Errorf("Submitting the same position messages")
+		return fmt.Errorf("Submitting the same position messages %v", pos)
 	}
 	pendingTxnsPos, err := s.getEspressoPendingTxnsPos()
 	if err != nil && !dbutil.IsErrNotFound(err) {
@@ -1499,7 +1499,7 @@ func (s *TransactionStreamer) SubmitEspressoTransactionPos(pos arbutil.MessageIn
 		// if the key doesn't exist, create a new array with the pos
 		pendingTxnsPos = []*arbutil.MessageIndex{&pos}
 	} else if pendingTxnsPos[len(pendingTxnsPos)-1] == &pos {
-		return fmt.Errorf("Submitting the same position messages")
+		return fmt.Errorf("Submitting the same position messages %v", pos)
 	} else {
 		pendingTxnsPos = append(pendingTxnsPos, &pos)
 	}

--- a/system_tests/espresso-e2e/docker-compose.yaml
+++ b/system_tests/espresso-e2e/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   espresso-dev-node:
-    image: ghcr.io/espressosystems/espresso-sequencer/espresso-dev-node:20240919-dev-node-legacy-builder
+    image: ghcr.io/espressosystems/espresso-sequencer/espresso-dev-node:main
     ports:
       - "$ESPRESSO_SEQUENCER_API_PORT:$ESPRESSO_SEQUENCER_API_PORT"
       - "$ESPRESSO_BUILDER_PORT:$ESPRESSO_BUILDER_PORT"

--- a/system_tests/espresso_e2e_test.go
+++ b/system_tests/espresso_e2e_test.go
@@ -225,6 +225,8 @@ func TestEspressoE2E(t *testing.T) {
 		if err != nil {
 			return false
 		}
+		// Wait for the hotshot to generate some blocks to better simulate the real-world environment.
+		// Chosen based on intuition; no empirical data supports this value.
 		return h > 10
 	})
 	Require(t, err)

--- a/system_tests/espresso_e2e_test.go
+++ b/system_tests/espresso_e2e_test.go
@@ -24,7 +24,7 @@ import (
 var workingDir = "./espresso-e2e"
 
 // light client proxy
-var lightClientAddress = "0xb075b82c7a23e0994df4793422a1f03dbcf9136f"
+var lightClientAddress = "0x60571c8f4b52954a24a5e7306d435e951528d963"
 
 var hotShotUrl = "http://127.0.0.1:41000"
 var delayThreshold uint64 = 10
@@ -155,7 +155,7 @@ func waitForHotShotLiveness(ctx context.Context, lightClientReader *lightclient.
 }
 
 func waitForL1Node(ctx context.Context) error {
-	return waitFor(ctx, func() bool {
+	err := waitFor(ctx, func() bool {
 		if e := exec.Command(
 			"curl",
 			"-X",
@@ -170,6 +170,15 @@ func waitForL1Node(ctx context.Context) error {
 		}
 		return true
 	})
+	if err != nil {
+		return err
+	}
+
+	// wait for L1 to be totally ready to better simulate real-world environment
+	// this is necessary right now to avoid some unknown issues in the dev-node
+	// TODO: find a better way
+	time.Sleep(10 * time.Second)
+	return nil
 }
 
 func TestEspressoE2E(t *testing.T) {
@@ -216,7 +225,7 @@ func TestEspressoE2E(t *testing.T) {
 		if err != nil {
 			return false
 		}
-		return h > 0
+		return h > 10
 	})
 	Require(t, err)
 


### PR DESCRIPTION
Use the latest `espresso-dev-node` in Espresso tests.
This is quite necessary since we are still testing our code with an outdated version

### This PR:
- Unpin the `espresso-dev-node` version
- Fix an issue that causes the reorg in validation. This was because the goroutine in batch poster didn't check the pending positions and the submitted position before it added one to the queue. In the case where the batch poster processes its task twice while the goroutine in tx-streamer haven't submitted the responding message, duplicated messages would be submitted to hotshot. I do think it is better write the relevent code in batch poster, but it requires a bit refactor and seems not efficient
- Wait for the L1 node a bit in tests. This seems a potential issue in `espresso dev node`. If we don't do this, `espresso-dev-node` will miss some leaves, eventually leading to the failure of fetching the merkle proof in batch poster.


### Key places to review:
[arbnode/transaction_streamer.go](https://github.com/EspressoSystems/nitro-espresso-integration/compare/integration...EspressoSystems:nitro-espresso-integration:jh/dev-node?expand=1#diff-4c43892baa92d7cf1b422d5e9e7d5534ca1109dbecd5b647c8f8aaf57d3cc391)


<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
