### PR TITLE
ci: fix `git ls-remote` error in docker build

### DIFF
--- a/.github/actions/docker-image/action.yml
+++ b/.github/actions/docker-image/action.yml
@@ -1,6 +1,9 @@
 name: Espresso Docker Image
 
 inputs:
+  context:
+    required: true
+    type: string
   images:
     required: true
     type: string
@@ -36,6 +39,7 @@ runs:
       uses: docker/build-push-action@v5
       id: build
       with:
+        context: ${{ inputs.context }}
         file: ${{ inputs.file }}
         target: ${{ inputs.target }}
         labels: ${{ steps.metadata.outputs.labels  }}

--- a/.github/workflows/espresso-docker.yml
+++ b/.github/workflows/espresso-docker.yml
@@ -89,11 +89,6 @@ jobs:
         with:
           submodules: recursive
 
-      # TODO shouldn't need this
-      - name: Clean up Git worktree files
-        run: |
-          find . -type f -name '.git' -print -exec rm -f {} \;
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -107,6 +102,7 @@ jobs:
       - name: Build nitro-node image
         uses: ./.github/actions/docker-image
         with:
+          context: .
           file: Dockerfile
           images: ghcr.io/espressosystems/nitro-espresso-integration/nitro-node
           target: nitro-node
@@ -116,6 +112,7 @@ jobs:
         uses: ./.github/actions/docker-image
         id: nitro-node-dev
         with:
+          context: .
           file: Dockerfile
           images: ghcr.io/espressosystems/nitro-espresso-integration/nitro-node-dev
           target: nitro-node-dev

--- a/.github/workflows/espresso-docker.yml
+++ b/.github/workflows/espresso-docker.yml
@@ -89,6 +89,11 @@ jobs:
         with:
           submodules: recursive
 
+      # TODO shouldn't need this
+      - name: Clean up Git worktree files
+        run: |
+          find . -type f -name '.git' -print -exec rm -f {} \;
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,9 @@ COPY contracts/package.json contracts/yarn.lock contracts/
 RUN cd contracts && yarn install
 COPY contracts contracts/
 COPY safe-smart-account safe-smart-account/
-RUN cd safe-smart-account && yarn install
+# Check if there are any unexpected .git directories or worktree files
+RUN find . -type d -name ".git" -printf "%p DIR\n" -o -type f -name ".git" -printf "%p FILE\n" && exit 1
+RUN cd safe-smart-account && yarn install --verbose
 COPY Makefile .
 RUN . ~/.bashrc && NITRO_BUILD_IGNORE_TIMESTAMPS=1 make build-solidity
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,7 @@ COPY contracts/package.json contracts/yarn.lock contracts/
 RUN cd contracts && yarn install
 COPY contracts contracts/
 COPY safe-smart-account safe-smart-account/
-# Check if there are any unexpected .git directories or worktree files
-RUN find . -type d -name ".git" -printf "%p DIR\n" -o -type f -name ".git" -printf "%p FILE\n" && exit 1
-RUN cd safe-smart-account && yarn install --verbose
+RUN cd safe-smart-account && yarn install
 COPY Makefile .
 RUN . ~/.bashrc && NITRO_BUILD_IGNORE_TIMESTAMPS=1 make build-solidity
 


### PR DESCRIPTION
With the default git context the repository is re-cloned at the start of
the docker build and the .dockerignore file is ignored.

> Be careful because any file mutation in the steps that precede the
> build step will be ignored, including processing of the .dockerignore
> file since the context is based on the Git reference.

https://github.com/docker/build-push-action?tab=readme-ov-file#git-context

This leads to some `.git` worktree files showing up inside the
dockerbuild which triggers a bug in yarn.

See https://github.com/yarnpkg/yarn/issues/7537#issuecomment-1099584308
for more details about the yarn bug.

CI docker run: https://github.com/EspressoSystems/nitro-espresso-integration/actions/runs/11796364645/job/32858065321