### PR TITLE
Use upstream contracts submodule

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -61,7 +61,6 @@ func main() {
 	authorizevalidators := flag.Uint64("authorizevalidators", 0, "Number of validators to preemptively authorize")
 	txTimeout := flag.Duration("txtimeout", 10*time.Minute, "Timeout when waiting for a transaction to be included in a block")
 	prod := flag.Bool("prod", false, "Whether to configure the rollup for production or testing")
-	hotshotAddr := flag.String("hotshot", "", "the address of hotshot contract in L1")
 	flag.Parse()
 	l1ChainId := new(big.Int).SetUint64(*l1ChainIdUint)
 	maxDataSize := new(big.Int).SetUint64(*maxDataSizeUint)
@@ -180,7 +179,6 @@ func main() {
 	defer l1Reader.StopAndWait()
 
 	nativeToken := common.HexToAddress(*nativeTokenAddressString)
-	hotshot := common.HexToAddress(*hotshotAddr)
 	deployedAddresses, err := deploycode.DeployOnParentChain(
 		ctx,
 		l1Reader,
@@ -192,7 +190,6 @@ func main() {
 		nativeToken,
 		maxDataSize,
 		true,
-		hotshot,
 	)
 	if err != nil {
 		flag.Usage()

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -128,7 +128,7 @@ func deployBridgeCreator(ctx context.Context, parentChainReader *headerreader.He
 	return bridgeCreatorAddr, nil
 }
 
-func deployChallengeFactory(ctx context.Context, parentChainReader *headerreader.HeaderReader, auth *bind.TransactOpts, hotshot common.Address) (common.Address, common.Address, error) {
+func deployChallengeFactory(ctx context.Context, parentChainReader *headerreader.HeaderReader, auth *bind.TransactOpts) (common.Address, common.Address, error) {
 	client := parentChainReader.Client()
 	osp0, tx, _, err := ospgen.DeployOneStepProver0(auth, client)
 	err = andTxSucceeded(ctx, parentChainReader, tx, err)
@@ -148,7 +148,7 @@ func deployChallengeFactory(ctx context.Context, parentChainReader *headerreader
 		return common.Address{}, common.Address{}, fmt.Errorf("ospMath deploy error: %w", err)
 	}
 
-	ospHostIo, tx, _, err := ospgen.DeployOneStepProverHostIo(auth, client, hotshot)
+	ospHostIo, tx, _, err := ospgen.DeployOneStepProverHostIo(auth, client)
 	err = andTxSucceeded(ctx, parentChainReader, tx, err)
 	if err != nil {
 		return common.Address{}, common.Address{}, fmt.Errorf("ospHostIo deploy error: %w", err)
@@ -169,13 +169,13 @@ func deployChallengeFactory(ctx context.Context, parentChainReader *headerreader
 	return ospEntryAddr, challengeManagerAddr, nil
 }
 
-func deployRollupCreator(ctx context.Context, parentChainReader *headerreader.HeaderReader, auth *bind.TransactOpts, maxDataSize *big.Int, chainSupportsBlobs bool, hotshot common.Address) (*rollupgen.RollupCreator, common.Address, common.Address, common.Address, error) {
+func deployRollupCreator(ctx context.Context, parentChainReader *headerreader.HeaderReader, auth *bind.TransactOpts, maxDataSize *big.Int, chainSupportsBlobs bool) (*rollupgen.RollupCreator, common.Address, common.Address, common.Address, error) {
 	bridgeCreator, err := deployBridgeCreator(ctx, parentChainReader, auth, maxDataSize, chainSupportsBlobs)
 	if err != nil {
 		return nil, common.Address{}, common.Address{}, common.Address{}, fmt.Errorf("bridge creator deploy error: %w", err)
 	}
 
-	ospEntryAddr, challengeManagerAddr, err := deployChallengeFactory(ctx, parentChainReader, auth, hotshot)
+	ospEntryAddr, challengeManagerAddr, err := deployChallengeFactory(ctx, parentChainReader, auth)
 	if err != nil {
 		return nil, common.Address{}, common.Address{}, common.Address{}, err
 	}
@@ -242,12 +242,12 @@ func deployRollupCreator(ctx context.Context, parentChainReader *headerreader.He
 	return rollupCreator, rollupCreatorAddress, validatorUtils, validatorWalletCreator, nil
 }
 
-func DeployOnParentChain(ctx context.Context, parentChainReader *headerreader.HeaderReader, deployAuth *bind.TransactOpts, batchPosters []common.Address, batchPosterManager common.Address, authorizeValidators uint64, config rollupgen.Config, nativeToken common.Address, maxDataSize *big.Int, chainSupportsBlobs bool, hotshot common.Address) (*chaininfo.RollupAddresses, error) {
+func DeployOnParentChain(ctx context.Context, parentChainReader *headerreader.HeaderReader, deployAuth *bind.TransactOpts, batchPosters []common.Address, batchPosterManager common.Address, authorizeValidators uint64, config rollupgen.Config, nativeToken common.Address, maxDataSize *big.Int, chainSupportsBlobs bool) (*chaininfo.RollupAddresses, error) {
 	if config.WasmModuleRoot == (common.Hash{}) {
 		return nil, errors.New("no machine specified")
 	}
 
-	rollupCreator, _, validatorUtils, validatorWalletCreator, err := deployRollupCreator(ctx, parentChainReader, deployAuth, maxDataSize, chainSupportsBlobs, hotshot)
+	rollupCreator, _, validatorUtils, validatorWalletCreator, err := deployRollupCreator(ctx, parentChainReader, deployAuth, maxDataSize, chainSupportsBlobs)
 	if err != nil {
 		return nil, fmt.Errorf("error deploying rollup creator: %w", err)
 	}

--- a/staker/challenge_test.go
+++ b/staker/challenge_test.go
@@ -36,7 +36,7 @@ func DeployOneStepProofEntry(t *testing.T, auth *bind.TransactOpts, client bind.
 	ospMath, _, _, err := ospgen.DeployOneStepProverMath(auth, client)
 	Require(t, err)
 
-	ospHostIo, _, _, err := ospgen.DeployOneStepProverHostIo(auth, client, common.Address{})
+	ospHostIo, _, _, err := ospgen.DeployOneStepProverHostIo(auth, client)
 	Require(t, err)
 
 	ospEntry, _, _, err := ospgen.DeployOneStepProofEntry(auth, client, osp0, ospMem, ospMath, ospHostIo)

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -405,7 +405,6 @@ func (b *NodeBuilder) BuildL1(t *testing.T) {
 		locator.LatestWasmModuleRoot(),
 		b.withProdConfirmPeriodBlocks,
 		true,
-		common.Address{},
 	)
 	b.L1.cleanup = func() { requireClose(t, b.L1.Stack) }
 }
@@ -507,7 +506,6 @@ func (b *NodeBuilder) BuildL3OnL2(t *testing.T) func() {
 		locator.LatestWasmModuleRoot(),
 		b.l3Config.withProdConfirmPeriodBlocks,
 		false,
-		common.Address{},
 	)
 
 	b.L3 = buildOnParentChain(
@@ -1246,7 +1244,6 @@ func deployOnParentChain(
 	wasmModuleRoot common.Hash,
 	prodConfirmPeriodBlocks bool,
 	chainSupportsBlobs bool,
-	hotshotAddr common.Address,
 ) (*chaininfo.RollupAddresses, *arbostypes.ParsedInitMessage) {
 	parentChainInfo.GenerateAccount("RollupOwner")
 	parentChainInfo.GenerateAccount("Sequencer")
@@ -1282,7 +1279,6 @@ func deployOnParentChain(
 		nativeToken,
 		maxDataSize,
 		chainSupportsBlobs,
-		hotshotAddr,
 	)
 	Require(t, err)
 	parentChainInfo.SetContract("Bridge", addresses.Bridge)

--- a/system_tests/full_challenge_impl_test.go
+++ b/system_tests/full_challenge_impl_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/offchainlabs/nitro/validator/server_common"
 )
 
-func DeployOneStepProofEntry(t *testing.T, ctx context.Context, auth *bind.TransactOpts, client *ethclient.Client, hotshot common.Address) common.Address {
+func DeployOneStepProofEntry(t *testing.T, ctx context.Context, auth *bind.TransactOpts, client *ethclient.Client) common.Address {
 	osp0, tx, _, err := ospgen.DeployOneStepProver0(auth, client)
 	Require(t, err)
 	_, err = EnsureTxSucceeded(ctx, client, tx)
@@ -53,7 +53,7 @@ func DeployOneStepProofEntry(t *testing.T, ctx context.Context, auth *bind.Trans
 	_, err = EnsureTxSucceeded(ctx, client, tx)
 	Require(t, err)
 
-	ospHostIo, tx, _, err := ospgen.DeployOneStepProverHostIo(auth, client, hotshot)
+	ospHostIo, tx, _, err := ospgen.DeployOneStepProverHostIo(auth, client)
 	Require(t, err)
 	_, err = EnsureTxSucceeded(ctx, client, tx)
 	Require(t, err)
@@ -330,7 +330,7 @@ func RunChallengeTest(t *testing.T, asserterIsCorrect bool, useStubs bool, chall
 		trueDelayedBridge = asserterBridgeAddr
 		expectedWinner = l1Info.GetAddress("asserter")
 	}
-	ospEntry := DeployOneStepProofEntry(t, ctx, &deployerTxOpts, l1Backend, common.Address{})
+	ospEntry := DeployOneStepProofEntry(t, ctx, &deployerTxOpts, l1Backend)
 
 	var wasmModuleRoot common.Hash
 	if useStubs {


### PR DESCRIPTION
We no longer need the customizations in nitro-contracts (except potentially some deployment tools) so this commit resets it to the one before the celestia contracts were added

https://github.com/celestiaorg/nitro-contracts/commit/4f8c65c163a25296777d30813a10022b1d287b65

and makes the nitro code work with that version by removing the hotshot / light client address passed to the OSP.

I'm keeping our fork as the submodule remote because we will make changes again.