### PR TITLE
Add dockerfiles and other files needed to decode attestation quote

### DIFF
--- a/Dockerfile.sgx-poster
+++ b/Dockerfile.sgx-poster
@@ -1,0 +1,17 @@
+FROM ghcr.io/espressosystems/nitro-espresso-integration/nitro-node:20241203-celestia
+
+RUN curl -L -o kzg10-aztec20-srs-1048584.bin https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0/kzg10-aztec20-srs-1048584.bin
+
+
+EXPOSE 8547
+EXPOSE 8548
+
+ENV AZTEC_SRS_PATH=/home/user/kzg10-aztec20-srs-1048584.bin
+ENV HOME=/home/user
+
+COPY --chown=user:user entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+USER user
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/decode_report_data.sh
+++ b/decode_report_data.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Read the binary file and convert to hex using xxd
+xxd -p report.bin | tr -d '\n' > report.hex
+
+# Extract the desired byte ranges (64:96 and 128:160)
+mr_enclave=$(cut -c 129-192 report.hex)  # Extract bytes 64:96 (1-based index)
+mr_signer=$(cut -c 257-320 report.hex)  # Extract bytes 128:160 (1-based index)
+
+# Print the hex values
+echo "MRENCLAVE: $mr_enclave"
+echo "MRSIGNER: $mr_signer"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Define dummy data
+DUMMY_DATA="some-dummy-data"
+
+# Create the user_report_data structure with dummy data
+REPORT_DATA=$(printf "%-64s" "$DUMMY_DATA")
+
+# Write to /dev/attestation/user_report_data
+echo -n "$REPORT_DATA" > /dev/attestation/user_report_data
+if [ $? -ne 0 ]; then
+  echo "Failed to write to /dev/attestation/user_report_data"
+  exit 1
+fi
+echo "Successfully wrote user report data."
+
+# Attempt to read and print the report as a hex dump
+if ! dd if=/dev/attestation/report bs=1 | xxd -p; then
+  echo "Failed to read from /dev/attestation/report"
+  exit 1
+fi
+
+echo "Successfully read attestation report."
+
+# Adjust ownership for the .arbitrum folder to the 'user' inside the container
+if [ -d "/home/user/.arbitrum" ]; then
+   sudo chown -R user:user /home/user/.arbitrum
+fi
+
+# Start Nitro process
+exec /usr/local/bin/nitro \
+    --validation.wasm.enable-wasmroots-check=false \
+    --conf.file /config/poster_config.json


### PR DESCRIPTION
- `Dockerfile.sgx-poster` is used to build the sgx-poster image
- `entrypoint.sh` is used for generating report data from which we can extract the the `MR_ENCLAVE` and `MR_SIGNER` and to add some permissions
- `decode_report_data.sh` is useful for decoding the report data printed by `entrypoint.sh`