### PR TITLE
Update emsdk version to get around 404 error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ RUN apt-get update && \
     apt-get install -y cmake make git lbzip2 python3 xz-utils && \
     git clone https://github.com/emscripten-core/emsdk.git && \
     cd emsdk && \
-    ./emsdk install 3.1.7 && \
-    ./emsdk activate 3.1.7
+    ./emsdk install 3.1.8 && \
+    ./emsdk activate 3.1.8
 COPY scripts/build-brotli.sh scripts/
 COPY brotli brotli
 RUN cd emsdk && . ./emsdk_env.sh && cd .. && ./scripts/build-brotli.sh -w -t /workspace/install/


### PR DESCRIPTION
### This PR:
Update the emsdk version while building our docker images.

This should help us to get rid of the 404 error mentioned here:

https://github.com/emscripten-core/emscripten/issues/23117

### This PR does not:
Change any logic