### PR TITLE
Fix/err

### DIFF
--- a/arbitrator/brotli/src/dicts/mod.rs
+++ b/arbitrator/brotli/src/dicts/mod.rs
@@ -33,7 +33,7 @@ struct ForceSync<T>(T);
 unsafe impl<T> Sync for ForceSync<T> {}
 
 lazy_static! {
-    /// Memoizes dictionary preperation.
+    /// Memoizes dictionary preparation.
     static ref STYLUS_PROGRAM_DICT: ForceSync<*const EncoderPreparedDictionary> =
         ForceSync(unsafe {
             let data = Dictionary::StylusProgram.slice().unwrap();

--- a/arbitrator/jit/src/program.rs
+++ b/arbitrator/jit/src/program.rs
@@ -220,7 +220,7 @@ pub fn set_response(
     thread.set_response(id, result, raw_data, gas)
 }
 
-/// sends previos response
+/// sends previous response
 /// MUST be called right after set_response to the same id
 /// returns request_id for the next request
 pub fn send_response(mut env: WasmEnvMut, req_id: u32) -> Result<u32, Escape> {


### PR DESCRIPTION
# Fix: Corrected typos in source files

## Changes
- `arbitrator/jit/src/program.rs:223`: "previos" corrected to "previous".
- `arbitrator/brotli/src/dicts/mod.rs:36`: "preperation" corrected to "preparation".

## Purpose
- Ensured code accuracy and improved clarity in source files.
