### PR TITLE
Fix rpc usage

### DIFF
--- a/arbnode/inbox_reader.go
+++ b/arbnode/inbox_reader.go
@@ -167,7 +167,7 @@ func (r *InboxReader) Start(ctxIn context.Context) error {
 			}
 			break
 		}
-		if i == 30*10 {
+		if i == 60*11 {
 			return errors.New("failed to read init message")
 		}
 		time.Sleep(time.Millisecond * 100)

--- a/arbnode/inbox_reader.go
+++ b/arbnode/inbox_reader.go
@@ -62,7 +62,7 @@ var DefaultInboxReaderConfig = InboxReaderConfig{
 	DelayBlocks:         0,
 	CheckDelay:          time.Minute,
 	HardReorg:           false,
-	MinBlocksToRead:     1,
+	MinBlocksToRead:     240,
 	DefaultBlocksToRead: 100,
 	TargetMessagesRead:  500,
 	MaxBlocksToRead:     2000,


### PR DESCRIPTION
Closes #[403](https://github.com/EspressoSystems/nitro-espresso-integration/issues/403) 

### This PR:

**WAIT TO MERGE**

We should wait to merge this PR until we have tested this against our current dev net to ensure this produces a big enough reduction for our needs.

Edits the default config of the inbox reader to poll the sequencer inbox and bridge contracts roughly once a minute, rather than once per block on the parent chain as it previously did. 
This PR also edits a condition during the inbox reader's start function so that it is allowed to wait this full minute and populate it's database with the init message so that the inbox reader can start successfully.
### This PR does not:
Edit any tests or make significant logic changes.

### Key places to review:
inbox_reader.go

### Things tested
This default configuration will reduce the number of rpc requests when the parent chain has fast block times (e.g. arb-sepolia, as is the case with the caldera dev net)
