### PR TITLE
Typo fix in lib.rs

### DIFF
--- a/arbitrator/brotli/src/lib.rs
+++ b/arbitrator/brotli/src/lib.rs
@@ -215,7 +215,7 @@ pub fn decompress(input: &[u8], dictionary: Dictionary) -> Result<Vec<u8>, Brotl
         // TODO: consider window and quality check?
         // TODO: fuzz
         if let Some(dict) = dictionary.slice() {
-            let attatched = BrotliDecoderAttachDictionary(
+            let attached = BrotliDecoderAttachDictionary(
                 state,
                 BrotliSharedDictionaryType::Raw,
                 dict.len(),


### PR DESCRIPTION
# Pull Request Title: Typo fix in lib.rs

## Description:
This pull request fixes a typo in the `lib.rs` file. The comment about attaching the dictionary was incorrectly spelled as "attatched." It has been corrected to "attached."

## Changes:
- Corrected the spelling of "attatched" to "attached" in the code.

## File(s) Modified:
- `arbitrator/brotli/src/lib.rs`

## Reasoning:
Correcting the typo improves readability and ensures consistency in the code comments.

## Checklist:
- [x] The code follows the project's coding guidelines.
- [x] All relevant tests are passing.
- [x] I have updated the documentation (if necessary).
- [x] I have tested the changes locally.

## Related Issues:
N/A

## Additional Notes:
N/A
