### PR TITLE
Submit hotshot transactions in another goroutine

### DIFF
--- a/arbnode/espresso_utils.go
+++ b/arbnode/espresso_utils.go
@@ -17,6 +17,12 @@ const MAX_ATTESTATION_QUOTE_SIZE int = 4 * 1024
 const LEN_SIZE int = 8
 const INDEX_SIZE int = 8
 
+type SubmittedEspressoTx struct {
+	Hash    string
+	Pos     []arbutil.MessageIndex
+	Payload []byte
+}
+
 func buildRawHotShotPayload(
 	msgPositions []arbutil.MessageIndex,
 	msgFetcher func(arbutil.MessageIndex) ([]byte, error),

--- a/arbnode/espresso_utils_test.go
+++ b/arbnode/espresso_utils_test.go
@@ -8,6 +8,8 @@ import (
 
 	espressoTypes "github.com/EspressoSystems/espresso-sequencer-go/types"
 
+	"github.com/ethereum/go-ethereum/rlp"
+
 	"github.com/offchainlabs/nitro/arbutil"
 )
 
@@ -121,5 +123,36 @@ func TestParsePayloadInvalidCases(t *testing.T) {
 				t.Errorf("expected error for case '%s', but got none", tc.description)
 			}
 		})
+	}
+}
+
+func TestSerdeSubmittedEspressoTx(t *testing.T) {
+	submiitedTx := SubmittedEspressoTx{
+		Hash:    "0x1234",
+		Pos:     []arbutil.MessageIndex{arbutil.MessageIndex(10)},
+		Payload: []byte{0, 1, 2, 3},
+	}
+
+	b, err := rlp.EncodeToBytes(&submiitedTx)
+	if err != nil {
+		t.Error("failed to encode")
+	}
+
+	var expected SubmittedEspressoTx
+	err = rlp.DecodeBytes(b, &expected)
+	if err != nil {
+		t.Error("failed to encode")
+	}
+
+	if submiitedTx.Hash != expected.Hash {
+		t.Error("failed to check hash")
+	}
+
+	if submiitedTx.Pos[0] != expected.Pos[0] {
+		t.Error("failed to check pos")
+	}
+
+	if !bytes.Equal(submiitedTx.Payload, expected.Payload) {
+		t.Error("failed to check payload")
 	}
 }

--- a/arbnode/schema.go
+++ b/arbnode/schema.go
@@ -17,9 +17,7 @@ var (
 	delayedMessageCountKey       []byte = []byte("_delayedMessageCount")      // contains the current delayed message count
 	sequencerBatchCountKey       []byte = []byte("_sequencerBatchCount")      // contains the current sequencer message count
 	dbSchemaVersion              []byte = []byte("_schemaVersion")            // contains a uint64 representing the database schema version
-	espressoSubmittedPos         []byte = []byte("_espressoSubmittedPos")     // contains the current message indices of the last submitted txns
-	espressoSubmittedHash        []byte = []byte("_espressoSubmittedHash")    // contains the hash of the last submitted txn
-	espressoSubmittedPayload     []byte = []byte("_espressoSubmittedPayload") // contains the payload of the last submitted espresso txn
+	espressoSubmittedTxns        []byte = []byte("_espressoSubmittedTxns")    // contains the hash and pos of the submitted transactions
 	espressoPendingTxnsPositions []byte = []byte("_espressoPendingTxnsPos")   // contains the index of the pending txns that need to be submitted to espresso
 	espressoLastConfirmedPos     []byte = []byte("_espressoLastConfirmedPos") // contains the position of the last confirmed message
 )

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1254,22 +1254,20 @@ func (s *TransactionStreamer) executeMessages(ctx context.Context, ignored struc
 // Check if the latest submitted transaction has been finalized on L1 and verify it.
 // Return a bool indicating whether a new transaction can be submitted to HotShot
 func (s *TransactionStreamer) pollSubmittedTransactionForFinality(ctx context.Context) error {
-	submittedTxnPos, err := s.getEspressoSubmittedPos()
+	submittedTxns, err := s.getEspressoSubmittedTxns()
 	if err != nil {
 		return fmt.Errorf("submitted pos not found: %w", err)
 	}
-	if len(submittedTxnPos) == 0 {
+	if len(submittedTxns) == 0 {
 		return nil // no submitted transaction, treated as successful
 	}
 
-	submittedTxHash, err := s.getEspressoSubmittedHash()
-	if err != nil {
-		return fmt.Errorf("submitted hash not found: %w", err)
-	}
+	firstSubmitted := submittedTxns[0]
+	hash := firstSubmitted.Hash
 
-	if submittedTxHash == nil {
-		// this should not happen
-		return errors.New("missing the tx hash while the submitted txn position exists")
+	submittedTxHash, err := tagged_base64.Parse(hash)
+	if err != nil || submittedTxHash == nil {
+		return fmt.Errorf("invalid hotshot tx hash, failed to parse hash %s: %w", hash, err)
 	}
 
 	data, err := s.espressoClient.FetchTransactionByHash(ctx, submittedTxHash)
@@ -1337,11 +1335,7 @@ func (s *TransactionStreamer) pollSubmittedTransactionForFinality(ctx context.Co
 		return fmt.Errorf("error validating namespace proof (height: %d)", height)
 	}
 
-	submittedPayload, err := s.getEspressoSubmittedPayload()
-	if err != nil {
-		return fmt.Errorf("submitted payload not found: %w", err)
-	}
-
+	submittedPayload := firstSubmitted.Payload
 	validated := validateIfPayloadIsInBlock(submittedPayload, resp.Transactions)
 	if !validated {
 		return fmt.Errorf("transactions fetched from HotShot doesn't contain the submitted payload")
@@ -1352,10 +1346,10 @@ func (s *TransactionStreamer) pollSubmittedTransactionForFinality(ctx context.Co
 	defer s.espressoTxnsStateInsertionMutex.Unlock()
 
 	batch := s.db.NewBatch()
-	if err := s.cleanEspressoSubmittedData(batch); err != nil {
-		return err
+	if err := s.setEspressoSubmittedTxns(batch, submittedTxns[0:]); err != nil {
+		return fmt.Errorf("failed to set the espresso submitted txns: %w", err)
 	}
-	lastConfirmedPos := submittedTxnPos[len(submittedTxnPos)-1]
+	lastConfirmedPos := firstSubmitted.Pos[len(firstSubmitted.Pos)-1]
 	if err := s.setEspressoLastConfirmedPos(batch, &lastConfirmedPos); err != nil {
 		return fmt.Errorf("failed to set the last confirmed position (pos: %d): %w", lastConfirmedPos, err)
 	}
@@ -1367,54 +1361,20 @@ func (s *TransactionStreamer) pollSubmittedTransactionForFinality(ctx context.Co
 	return nil
 }
 
-func (s *TransactionStreamer) getEspressoSubmittedPos() ([]arbutil.MessageIndex, error) {
-	posBytes, err := s.db.Get(espressoSubmittedPos)
+func (s *TransactionStreamer) getEspressoSubmittedTxns() ([]SubmittedEspressoTx, error) {
+	posBytes, err := s.db.Get(espressoSubmittedTxns)
 	if err != nil {
 		if dbutil.IsErrNotFound(err) {
 			return nil, nil
 		}
 		return nil, err
 	}
-
-	var pos []arbutil.MessageIndex
-	err = rlp.DecodeBytes(posBytes, &pos)
-
+	var tx []SubmittedEspressoTx
+	err = rlp.DecodeBytes(posBytes, &tx)
 	if err != nil {
 		return nil, err
 	}
-
-	return pos, nil
-}
-
-func (s *TransactionStreamer) getEspressoSubmittedHash() (*espressoTypes.TaggedBase64, error) {
-	posBytes, err := s.db.Get(espressoSubmittedHash)
-	if err != nil {
-		if dbutil.IsErrNotFound(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	var hash string
-	err = rlp.DecodeBytes(posBytes, &hash)
-	if err != nil {
-		return nil, err
-	}
-	hashParsed, err := tagged_base64.Parse(hash)
-	if err != nil || hashParsed == nil {
-		return nil, err
-	}
-	return hashParsed, nil
-}
-
-func (s *TransactionStreamer) getEspressoSubmittedPayload() ([]byte, error) {
-	bytes, err := s.db.Get(espressoSubmittedPayload)
-	if err != nil {
-		if dbutil.IsErrNotFound(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	return bytes, nil
+	return tx, nil
 }
 
 func (s *TransactionStreamer) getLastConfirmedPos() (*arbutil.MessageIndex, error) {
@@ -1450,18 +1410,18 @@ func (s *TransactionStreamer) getEspressoPendingTxnsPos() ([]arbutil.MessageInde
 	return pendingTxnsPos, nil
 }
 
-func (s *TransactionStreamer) setEspressoSubmittedPos(batch ethdb.KeyValueWriter, pos []arbutil.MessageIndex) error {
+func (s *TransactionStreamer) setEspressoSubmittedTxns(batch ethdb.KeyValueWriter, txns []SubmittedEspressoTx) error {
 	// if pos is nil, delete the key
-	if pos == nil {
-		err := batch.Delete(espressoSubmittedPos)
+	if txns == nil {
+		err := batch.Delete(espressoSubmittedTxns)
 		return err
 	}
 
-	posBytes, err := rlp.EncodeToBytes(pos)
+	bytes, err := rlp.EncodeToBytes(txns)
 	if err != nil {
 		return err
 	}
-	err = batch.Put(espressoSubmittedPos, posBytes)
+	err = batch.Put(espressoSubmittedTxns, bytes)
 	if err != nil {
 		return err
 	}
@@ -1483,48 +1443,9 @@ func (s *TransactionStreamer) setEspressoLastConfirmedPos(batch ethdb.KeyValueWr
 }
 
 func (s *TransactionStreamer) cleanEspressoSubmittedData(batch ethdb.Batch) error {
-	if err := s.setEspressoSubmittedPos(batch, nil); err != nil {
+	if err := s.setEspressoSubmittedTxns(batch, nil); err != nil {
 		return fmt.Errorf("failed to set the submitted pos to nil: %w", err)
 	}
-	if err := s.setEspressoSubmittedPayload(batch, nil); err != nil {
-		return fmt.Errorf("failed to set the submitted pos to nil: %w", err)
-	}
-	if err := s.setEspressoSubmittedHash(batch, nil); err != nil {
-		return fmt.Errorf("failed to set the submitted hash to nil: %w", err)
-	}
-	return nil
-
-}
-
-func (s *TransactionStreamer) setEspressoSubmittedPayload(batch ethdb.KeyValueWriter, payload []byte) error {
-	if payload == nil {
-		err := batch.Delete(espressoSubmittedHash)
-		return err
-	}
-	err := batch.Put(espressoSubmittedPayload, payload)
-	if err != nil {
-		return err
-
-	}
-	return nil
-}
-
-func (s *TransactionStreamer) setEspressoSubmittedHash(batch ethdb.KeyValueWriter, hash *espressoTypes.TaggedBase64) error {
-	// if hash is nil, delete the key
-	if hash == nil {
-		err := batch.Delete(espressoSubmittedHash)
-		return err
-	}
-
-	hashBytes, err := rlp.EncodeToBytes(hash.String())
-	if err != nil {
-		return err
-	}
-	err = batch.Put(espressoSubmittedHash, hashBytes)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -1547,13 +1468,18 @@ func (s *TransactionStreamer) setEspressoPendingTxnsPos(batch ethdb.KeyValueWrit
 }
 
 func (s *TransactionStreamer) HasNotSubmitted(pos arbutil.MessageIndex) (bool, error) {
-	submitted, err := s.getEspressoSubmittedPos()
+	submitted, err := s.getEspressoSubmittedTxns()
 	if err != nil {
 		return false, err
 	}
 
-	if len(submitted) > 0 && pos <= submitted[len(submitted)-1] {
-		return false, nil
+	if len(submitted) > 0 {
+		lastSubmittedTx := submitted[len(submitted)-1]
+		lastPos := lastSubmittedTx.Pos[len(lastSubmittedTx.Pos)-1]
+
+		if pos < lastPos {
+			return false, nil
+		}
 	}
 
 	lastConfirmed, err := s.getLastConfirmedPos()
@@ -1658,25 +1584,32 @@ func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) {
 
 		batch := s.db.NewBatch()
 		submittedPos := pendingTxnsPos[:msgCnt]
-		err = s.setEspressoSubmittedPos(batch, submittedPos)
+
+		submittedTxns, err := s.getEspressoSubmittedTxns()
 		if err != nil {
-			log.Error("failed to set the submitted txn pos", "err", err)
+			log.Error("failed to get submitted espresso transaction", "err", err)
 			return
 		}
+		tx := SubmittedEspressoTx{
+			Hash:    hash.String(),
+			Pos:     submittedPos,
+			Payload: payload,
+		}
+		if submittedTxns == nil {
+			submittedTxns = []SubmittedEspressoTx{tx}
+		} else {
+			submittedTxns = append(submittedTxns, tx)
+		}
+
+		if err = s.setEspressoSubmittedTxns(batch, submittedTxns); err != nil {
+			log.Error("failed to set espresso submitted transactions", "err", err)
+			return
+		}
+
 		pendingTxnsPos = pendingTxnsPos[msgCnt:]
 		err = s.setEspressoPendingTxnsPos(batch, pendingTxnsPos)
 		if err != nil {
 			log.Error("failed to set the pending txns", "err", err)
-			return
-		}
-		err = s.setEspressoSubmittedHash(batch, hash)
-		if err != nil {
-			log.Error("failed to set the submitted hash", "err", err)
-			return
-		}
-		err = s.setEspressoSubmittedPayload(batch, payload)
-		if err != nil {
-			log.Error("failed to set the espresso payload", "err", err)
 			return
 		}
 
@@ -1714,7 +1647,7 @@ func (s *TransactionStreamer) checkEspressoLiveness() error {
 	s.EscapeHatchEnabled = true
 
 	// Skip the espresso verification for the submitted messages
-	submitted, err := s.getEspressoSubmittedPos()
+	submitted, err := s.getEspressoSubmittedTxns()
 	if err != nil {
 		return err
 	}
@@ -1774,16 +1707,13 @@ func (s *TransactionStreamer) espressoSwitch(ctx context.Context, ignored struct
 	}
 	espressoMerkleProofEphemeralErrorHandler.Reset()
 
-	shouldSubmit := s.shouldSubmitEspressoTransaction()
-	if shouldSubmit {
-		s.submitEspressoTransactions(ctx)
-		return s.espressoTxnsPollingInterval
-	}
-
 	return s.espressoTxnsPollingInterval
 }
 
 func (s *TransactionStreamer) shouldSubmitEspressoTransaction() bool {
+	if s.espressoClient == nil && s.lightClientReader == nil {
+		return false
+	}
 	return !s.EscapeHatchEnabled
 }
 
@@ -1792,6 +1722,17 @@ func (s *TransactionStreamer) Start(ctxIn context.Context) error {
 
 	if s.lightClientReader != nil && s.espressoClient != nil {
 		err := stopwaiter.CallIterativelyWith[struct{}](&s.StopWaiterSafe, s.espressoSwitch, s.newSovereignTxNotifier)
+		if err != nil {
+			return err
+		}
+
+		err = stopwaiter.CallIterativelyWith[struct{}](&s.StopWaiterSafe, func(ctx context.Context, ignored struct{}) time.Duration {
+			shouldSubmit := s.shouldSubmitEspressoTransaction()
+			if shouldSubmit {
+				s.submitEspressoTransactions(ctx)
+			}
+			return s.espressoTxnsPollingInterval
+		}, s.newSovereignTxNotifier)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Have tried moving the sending action to [`writeMessage`](https://github.com/EspressoSystems/nitro-espresso-integration/blob/020bda4157a0499edec0f8c8366473481df21ab1/arbnode/transaction_streamer.go#L1043) but the E2E test failed with logs [here](https://github.com/EspressoSystems/nitro-espresso-integration/blob/020bda4157a0499edec0f8c8366473481df21ab1/arbnode/transaction_streamer.go#L1275).

It looks like the `espresso-dev-node` receives transactions even before it is ready and then the previous data somehow get lost. Another factor is that `writeMessage` seems used to write the init message, which is not supposed to be added to the batch.
I think sending transactions to HotShot is better to stay in `batch_poster.go`:
- `writeMessage` could be called by other components like `sequencer`
- We have tested it for a long time and get relevant code audited