### PR TITLE
Log batch posting reason when posting due to max delay.

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -1471,6 +1471,8 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 		// #nosec G115
 		firstUsefulMsgTime = time.Unix(int64(b.building.firstUsefulMsg.Message.Header.Timestamp), 0)
 		if time.Since(firstUsefulMsgTime) >= config.MaxDelay {
+      log.Info("attempting to post batch due to max delay", "firstUsefulMsgTime", firstUsefulMsgTime, "first useful msg timestamp", b.building.firstUsefulMsg.Message.Header.Timestamp)
+      log.Info("Max Delay", "config.MaxDelay", config.MaxDelay)
 			forcePostBatch = true
 		}
 	}
@@ -1502,7 +1504,7 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 	}
 	// If we are checking the validation, set isWaitingForEspressoValidation in the batch segments and re-poll the function until we are ready to post.
   hasBatchBeenValidated:= b.checkEspressoValidation()
-  log.Info("Batch validation status:", "hasBatchBeenValidated", hasBatchBeenValidated)
+  log.Info("Batch validation status:", "hasBatchBeenValidated", hasBatchBeenValidated, "b.building.msgCount", b.building.msgCount)
 	if !hasBatchBeenValidated {
 		return false, nil // We want to return false nil because we if we propegate an error we clear the batch cache when we don't want to
 	}

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -1472,7 +1472,6 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 		firstUsefulMsgTime = time.Unix(int64(b.building.firstUsefulMsg.Message.Header.Timestamp), 0)
 		if time.Since(firstUsefulMsgTime) >= config.MaxDelay {
       log.Info("attempting to post batch due to max delay", "firstUsefulMsgTime", firstUsefulMsgTime, "first useful msg timestamp", b.building.firstUsefulMsg.Message.Header.Timestamp)
-      log.Info("Max Delay", "config.MaxDelay", config.MaxDelay)
 			forcePostBatch = true
 		}
 	}
@@ -1504,7 +1503,7 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 	}
 	// If we are checking the validation, set isWaitingForEspressoValidation in the batch segments and re-poll the function until we are ready to post.
   hasBatchBeenValidated:= b.checkEspressoValidation()
-  log.Info("Batch validation status:", "hasBatchBeenValidated", hasBatchBeenValidated, "b.building.msgCount", b.building.msgCount)
+  log.Info("Batch validation status:", "hasBatchBeenValidated", hasBatchBeenValidated, "b.building.msgCount", b.building.msgCount, "b.building.startMsgCount", b.building.startMsgCount)
 	if !hasBatchBeenValidated {
 		return false, nil // We want to return false nil because we if we propegate an error we clear the batch cache when we don't want to
 	}


### PR DESCRIPTION
### This PR:
Adds more logging statements to the batch poster to better illustrate when it has posted due to the max delay being exceeded.