### PR TITLE
Incorrect messages from the feed should not trigger reorgs

### DIFF
--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -516,6 +516,11 @@ func (s *TransactionStreamer) getMessageWithMetadataAndBlockHash(seqNum arbutil.
 	return &msgWithBlockHash, nil
 }
 
+// A public function used by testing
+func (s *TransactionStreamer) GetMessageWithMetadataAndBlockHash(t *testing.T, seqNum arbutil.MessageIndex) (*arbostypes.MessageWithMetadataAndBlockHash, error) {
+	return s.getMessageWithMetadataAndBlockHash(seqNum)
+}
+
 // Note: if changed to acquire the mutex, some internal users may need to be updated to a non-locking version.
 func (s *TransactionStreamer) GetMessageCount() (arbutil.MessageIndex, error) {
 	posBytes, err := s.db.Get(messageCountKey)

--- a/system_tests/espresso_e2e_test.go
+++ b/system_tests/espresso_e2e_test.go
@@ -182,7 +182,7 @@ func TestEspressoE2E(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	builder, cleanup := createL1AndL2Node(ctx, t, true)
+	builder, cleanup := createL1AndL2Node(ctx, t, true, "")
 	defer cleanup()
 
 	err := waitForL1Node(ctx)

--- a/system_tests/espresso_escape_hatch_test.go
+++ b/system_tests/espresso_escape_hatch_test.go
@@ -19,7 +19,7 @@ func TestEspressoEscapeHatch(t *testing.T) {
 
 	// Disabling the delayed sequencer helps up check the
 	// message count easily
-	builder, cleanup := createL1AndL2Node(ctx, t, false)
+	builder, cleanup := createL1AndL2Node(ctx, t, false, "")
 	defer cleanup()
 
 	err := waitForL1Node(ctx)

--- a/system_tests/espresso_finality_node_test.go
+++ b/system_tests/espresso_finality_node_test.go
@@ -41,7 +41,7 @@ func TestEspressoFinalityNode(t *testing.T) {
 	valNodeCleanup := createValidationNode(ctx, t, true)
 	defer valNodeCleanup()
 
-	builder, cleanup := createL1AndL2Node(ctx, t, true)
+	builder, cleanup := createL1AndL2Node(ctx, t, true, "")
 	defer cleanup()
 
 	err := waitForL1Node(ctx)

--- a/system_tests/espresso_poster_test.go
+++ b/system_tests/espresso_poster_test.go
@@ -3,6 +3,7 @@ package arbtest
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -12,13 +13,14 @@ import (
 	"github.com/offchainlabs/nitro/wsbroadcastserver"
 )
 
-var feedInputUrl = "ws://localhost:54220"
+var extraFeedInputPort = "54220"
 
 func TestEspressoBatchPosterShouldNotReorg(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	builder, cleanup := createL1AndL2Node(ctx, t, false, feedInputUrl)
+	extraFeedInput := fmt.Sprintf("ws://localhost:%s", extraFeedInputPort)
+	builder, cleanup := createL1AndL2Node(ctx, t, false, extraFeedInput)
 	defer cleanup()
 
 	err := waitForL1Node(ctx)

--- a/system_tests/espresso_poster_test.go
+++ b/system_tests/espresso_poster_test.go
@@ -1,0 +1,83 @@
+package arbtest
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/offchainlabs/nitro/arbutil"
+	"github.com/offchainlabs/nitro/broadcaster"
+	"github.com/offchainlabs/nitro/wsbroadcastserver"
+)
+
+var feedInputUrl = "ws://localhost:54220"
+
+func TestEspressoBatchPosterShouldNotReorg(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	builder, cleanup := createL1AndL2Node(ctx, t, false, feedInputUrl)
+	defer cleanup()
+
+	err := waitForL1Node(ctx)
+	Require(t, err)
+
+	cleanEspresso := runEspresso()
+	defer cleanEspresso()
+
+	err = waitForEspressoNode(ctx)
+	Require(t, err)
+
+	config := wsbroadcastserver.DefaultBroadcasterConfig
+	config.Enable = true
+	config.Port = "54220"
+	feedErrChan := make(chan error, 10)
+	b := broadcaster.NewBroadcaster(func() *wsbroadcastserver.BroadcasterConfig { return &config }, builder.chainConfig.ChainID.Uint64(), feedErrChan, nil)
+	Require(t, b.Initialize())
+	Require(t, b.Start(ctx))
+
+	l2Node := builder.L2
+	err = checkTransferTxOnL2(t, ctx, l2Node, "test1", builder.L2Info)
+	Require(t, err)
+	err = checkTransferTxOnL2(t, ctx, l2Node, "test2", builder.L2Info)
+	Require(t, err)
+
+	// Include the initial message
+	expected := arbutil.MessageIndex(3)
+	err = waitForWith(ctx, 5*time.Minute, 10*time.Second, func() bool {
+		msgCnt, err := l2Node.ConsensusNode.TxStreamer.GetMessageCount()
+		if err != nil {
+			panic(err)
+		}
+
+		validatedCnt := l2Node.ConsensusNode.BlockValidator.Validated(t)
+		return msgCnt >= expected && validatedCnt >= expected
+	})
+	Require(t, err)
+	msg1, err := builder.L2.ConsensusNode.TxStreamer.GetMessageWithMetadataAndBlockHash(t, arbutil.MessageIndex(1))
+	Require(t, err)
+
+	msg2, err := builder.L2.ConsensusNode.TxStreamer.GetMessageWithMetadataAndBlockHash(t, arbutil.MessageIndex(2))
+	Require(t, err)
+
+	if b.GetCachedMessageCount() > 0 {
+		t.Fatal("should be 0 before sending any messages")
+	}
+	// Broadcast the message 2 with the position 1
+	b.BroadcastSingle(msg2.MessageWithMeta, arbutil.MessageIndex(1), msg2.BlockHash)
+
+	err = waitFor(ctx, func() bool {
+		return b.GetCachedMessageCount() > 0
+	})
+	Require(t, err)
+
+	msgNew, err := builder.L2.ConsensusNode.TxStreamer.GetMessageWithMetadataAndBlockHash(t, arbutil.MessageIndex(1))
+	Require(t, err)
+
+	if !bytes.Equal(msg1.BlockHash[:], msgNew.BlockHash[:]) {
+		log.Error("block hash should not be modified", "oldMsg1", msg1.BlockHash, "newMsg1", msgNew.BlockHash, "msg2", msg2.BlockHash)
+		t.Fatal("block hash should not be modified")
+	}
+}

--- a/system_tests/espresso_sovereign_sequencer_test.go
+++ b/system_tests/espresso_sovereign_sequencer_test.go
@@ -16,6 +16,7 @@ func createL1AndL2Node(
 	ctx context.Context,
 	t *testing.T,
 	delayedSequencer bool,
+	extraFeedInput string,
 ) (*NodeBuilder, func()) {
 	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
 	builder.useL1StackConfig = true // Do not overwrite the L1 stack config when building
@@ -42,8 +43,6 @@ func createL1AndL2Node(
 	builder.nodeConfig.BlockValidator.Enable = true
 	builder.nodeConfig.BlockValidator.ValidationPoll = 2 * time.Second
 	builder.nodeConfig.BlockValidator.ValidationServer.URL = fmt.Sprintf("ws://127.0.0.1:%d", arbValidationPort)
-	builder.nodeConfig.DelayedSequencer.Enable = delayedSequencer
-	builder.nodeConfig.DelayedSequencer.FinalizeDistance = 1
 
 	// sequencer config
 	builder.nodeConfig.Sequencer = true
@@ -52,6 +51,12 @@ func createL1AndL2Node(
 	builder.execConfig.Sequencer.Enable = true
 	builder.execConfig.Caching.StateScheme = "hash"
 	builder.execConfig.Caching.Archive = true
+	builder.nodeConfig.DelayedSequencer.Enable = delayedSequencer
+	builder.nodeConfig.DelayedSequencer.FinalizeDistance = 1
+
+	if extraFeedInput != "" {
+		builder.nodeConfig.Feed.Input.URL = []string{extraFeedInput}
+	}
 
 	cleanup := builder.Build(t)
 
@@ -70,7 +75,7 @@ func TestEspressoSovereignSequencer(t *testing.T) {
 	valNodeCleanup := createValidationNode(ctx, t, true)
 	defer valNodeCleanup()
 
-	builder, cleanup := createL1AndL2Node(ctx, t, true)
+	builder, cleanup := createL1AndL2Node(ctx, t, true, "")
 	defer cleanup()
 
 	err := waitForL1Node(ctx)


### PR DESCRIPTION
This PR demonstrates that subsequent incorrect messages from the feed will not cause reorganization.

https://github.com/EspressoSystems/nitro-espresso-integration/blob/8ea49df29b11b3aceb8e6cf351a676009922bef5/arbnode/transaction_streamer.go#L651-L654

Adding this test will help us validate one of the fundamental assumptions of our integration design.