### PR TITLE
Add delayed transaction in caff node test

### DIFF
--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -145,10 +145,6 @@ var DefaultSequencerConfig = SequencerConfig{
 	EnableProfiling:              false,
 
 	EnableCaffNode: false,
-	CaffNodeConfig: CaffNodeConfig{
-		RetryInterval:          1 * time.Second,
-		HotshotPollingInterval: 250 * time.Millisecond,
-	},
 }
 
 func SequencerConfigAddOptions(prefix string, f *flag.FlagSet) {

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -118,9 +118,11 @@ func (c *SequencerConfig) Validate() error {
 type SequencerConfigFetcher func() *SequencerConfig
 
 type CaffNodeConfig struct {
-	HotShotUrl string `koanf:"hotshot-url"`
-	StartBlock uint64 `koanf:"start-block"`
-	Namespace  uint64 `koanf:"namespace"`
+	HotShotUrl             string        `koanf:"hotshot-url"`
+	StartBlock             uint64        `koanf:"start-block"`
+	Namespace              uint64        `koanf:"namespace"`
+	RetryInterval          time.Duration `koanf:"retry-interval"`
+	HotshotPollingInterval time.Duration `koanf:"hotshot-polling-interval"`
 }
 
 var DefaultSequencerConfig = SequencerConfig{
@@ -143,6 +145,10 @@ var DefaultSequencerConfig = SequencerConfig{
 	EnableProfiling:              false,
 
 	EnableCaffNode: false,
+	CaffNodeConfig: CaffNodeConfig{
+		RetryInterval:          1 * time.Second,
+		HotshotPollingInterval: 250 * time.Millisecond,
+	},
 }
 
 func SequencerConfigAddOptions(prefix string, f *flag.FlagSet) {


### PR DESCRIPTION
### This PR:
- Send delayed transactions in caff node test to see if caff node works correctly. It is.
- Check the balance in caff node test rather than check the amount of blocks.
- Use the existing function to calculate message index, which fixes the case where genesis block is not 0.

