### PR TITLE
Pin go lint version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: latest
+          version: v1.63
           skip-pkg-cache: true
       - name: Custom Lint
         run: |


### PR DESCRIPTION
Currently, the CI is failing due to the recent update of `golint-ci`.

The failures are caused by issues in upstream files. Fixing these errors locally would make the next synchronization with upstream more difficult. Instead, we will keep the current version pinned for now and plan to unpin it during the next sync if the upstream has resolved these issues.