### PR TITLE
Remove sequencer URL from caff node config and automate forwarding target

### DIFF
--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -931,7 +931,10 @@ func applyChainParameters(k *koanf.Koanf, chainId uint64, chainName string, l2Ch
 		chainDefaults["execution.forwarding-target"] = chainInfo.SequencerUrl
 	}
 	// If espresso caff node is enabled, use the sequencer url as the forwarding target
-	if k.Bool("execution.sequencer.enable") && chainInfo.SequencerUrl != "" && k.Bool("execution.sequencer.enable-caff-node") {
+	if k.Bool("execution.sequencer.enable") &&
+		chainInfo.SequencerUrl != "" &&
+		k.Bool("execution.sequencer.enable-caff-node") &&
+		k.Bool("execution.sequencer.caff-node-config.forwarding") {
 		chainDefaults["execution.forwarding-target"] = chainInfo.SequencerUrl
 	}
 	if chainInfo.SecondaryForwardingTarget != "" {

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -930,6 +930,10 @@ func applyChainParameters(k *koanf.Koanf, chainId uint64, chainName string, l2Ch
 	if !k.Bool("execution.sequencer.enable") && chainInfo.SequencerUrl != "" {
 		chainDefaults["execution.forwarding-target"] = chainInfo.SequencerUrl
 	}
+	// If espresso caff node is enabled, use the sequencer url as the forwarding target
+	if k.Bool("execution.sequencer.enable") && chainInfo.SequencerUrl != "" && k.Bool("execution.sequencer.enable-caff-node") {
+		chainDefaults["execution.forwarding-target"] = chainInfo.SequencerUrl
+	}
 	if chainInfo.SecondaryForwardingTarget != "" {
 		chainDefaults["execution.secondary-forwarding-target"] = strings.Split(chainInfo.SecondaryForwardingTarget, ",")
 	}

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -930,13 +930,6 @@ func applyChainParameters(k *koanf.Koanf, chainId uint64, chainName string, l2Ch
 	if !k.Bool("execution.sequencer.enable") && chainInfo.SequencerUrl != "" {
 		chainDefaults["execution.forwarding-target"] = chainInfo.SequencerUrl
 	}
-	// If espresso caff node is enabled, use the sequencer url as the forwarding target
-	if k.Bool("execution.sequencer.enable") &&
-		chainInfo.SequencerUrl != "" &&
-		k.Bool("execution.sequencer.enable-caff-node") &&
-		k.Bool("execution.sequencer.caff-node-config.forwarding") {
-		chainDefaults["execution.forwarding-target"] = chainInfo.SequencerUrl
-	}
 	if chainInfo.SecondaryForwardingTarget != "" {
 		chainDefaults["execution.secondary-forwarding-target"] = strings.Split(chainInfo.SecondaryForwardingTarget, ",")
 	}

--- a/execution/gethexec/caff_node.go
+++ b/execution/gethexec/caff_node.go
@@ -29,9 +29,10 @@ type CaffNode struct {
 	config           SequencerConfigFetcher
 	executionEngine  *ExecutionEngine
 	espressoStreamer *espressostreamer.EspressoStreamer
+	txForwarder      TransactionPublisher
 }
 
-func NewCaffNode(configFetcher SequencerConfigFetcher, execEngine *ExecutionEngine) *CaffNode {
+func NewCaffNode(configFetcher SequencerConfigFetcher, execEngine *ExecutionEngine, txForwarder TransactionPublisher) *CaffNode {
 	config := configFetcher()
 	if err := config.Validate(); err != nil {
 		log.Crit("Failed to validate caff  node config", "err", err)
@@ -94,6 +95,7 @@ func NewCaffNode(configFetcher SequencerConfigFetcher, execEngine *ExecutionEngi
 		config:           configFetcher,
 		executionEngine:  execEngine,
 		espressoStreamer: espressoStreamer,
+		txForwarder:      txForwarder,
 	}
 }
 
@@ -189,13 +191,13 @@ func (n *CaffNode) Start(ctx context.Context) error {
 }
 
 func (n *CaffNode) PublishTransaction(ctx context.Context, tx *types.Transaction, options *arbitrum_types.ConditionalOptions) error {
-	return nil
+	return n.txForwarder.PublishTransaction(ctx, tx, options)
 }
 
 func (n *CaffNode) CheckHealth(ctx context.Context) error {
-	return nil
+	return n.txForwarder.CheckHealth(ctx)
 }
 
 func (n *CaffNode) Initialize(ctx context.Context) error {
-	return nil
+	return n.txForwarder.Initialize(ctx)
 }

--- a/execution/gethexec/caff_node.go
+++ b/execution/gethexec/caff_node.go
@@ -29,7 +29,6 @@ type CaffNode struct {
 	config           SequencerConfigFetcher
 	executionEngine  *ExecutionEngine
 	espressoStreamer *espressostreamer.EspressoStreamer
-	l2Client         *ethclient.Client
 }
 
 func NewCaffNode(configFetcher SequencerConfigFetcher, execEngine *ExecutionEngine) *CaffNode {
@@ -91,20 +90,10 @@ func NewCaffNode(configFetcher SequencerConfigFetcher, execEngine *ExecutionEngi
 		log.Crit("Failed to create espresso streamer")
 	}
 
-	var l2Client *ethclient.Client
-	if config.CaffNodeConfig.SequencerUrl != "" {
-		ethClient, err := ethclient.Dial(config.CaffNodeConfig.SequencerUrl)
-		if err != nil {
-			log.Crit("Failed to connect to Ethereum client: %v", err)
-		}
-		l2Client = ethClient
-	}
-
 	return &CaffNode{
 		config:           configFetcher,
 		executionEngine:  execEngine,
 		espressoStreamer: espressoStreamer,
-		l2Client:         l2Client,
 	}
 }
 
@@ -200,13 +189,6 @@ func (n *CaffNode) Start(ctx context.Context) error {
 }
 
 func (n *CaffNode) PublishTransaction(ctx context.Context, tx *types.Transaction, options *arbitrum_types.ConditionalOptions) error {
-	if n.l2Client != nil {
-		err := n.l2Client.SendTransaction(ctx, tx)
-		if err != nil {
-			log.Error("failed to publish transaction", "err", err)
-			return err
-		}
-	}
 	return nil
 }
 

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -211,21 +211,20 @@ func CreateExecutionNode(
 		log.Warn("sequencer enabled without l1 client")
 	}
 
+	seqConfigFetcher := func() *SequencerConfig { return &configFetcher().Sequencer }
 	if config.Sequencer.Enable {
-		seqConfigFetcher := func() *SequencerConfig { return &configFetcher().Sequencer }
 		sequencer, err = NewSequencer(execEngine, parentChainReader, seqConfigFetcher)
 		if err != nil {
 			return nil, err
 		}
-
-		if config.Sequencer.EnableCaffNode {
-			espressoFinalityNode := NewCaffNode(seqConfigFetcher, execEngine)
-			txPublisher = espressoFinalityNode
-		} else {
-			txPublisher = sequencer
-		}
+		txPublisher = sequencer
 	} else {
-		if config.Forwarder.RedisUrl != "" {
+		if config.Sequencer.EnableCaffNode {
+			targets := append([]string{config.forwardingTarget}, config.SecondaryForwardingTarget...)
+			txForwarder := NewForwarder(targets, &config.Forwarder)
+			espressoFinalityNode := NewCaffNode(seqConfigFetcher, execEngine, txForwarder)
+			txPublisher = espressoFinalityNode
+		} else if config.Forwarder.RedisUrl != "" {
 			txPublisher = NewRedisTxForwarder(config.forwardingTarget, &config.Forwarder)
 		} else if config.forwardingTarget == "" {
 			txPublisher = NewTxDropper()

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -126,7 +126,6 @@ type CaffNodeConfig struct {
 	ParentChainReader       headerreader.Config `koanf:"parent-chain-reader" reload:"hot"`
 	ParentChainNodeUrl      string              `koanf:"parent-chain-node-url"`
 	EspressoTEEVerifierAddr string              `koanf:"espresso-tee-verifier-addr"`
-	SequencerUrl            string              `koanf:"sequencer-url"`
 }
 
 var DefaultCaffNodeConfig = CaffNodeConfig{
@@ -138,7 +137,6 @@ var DefaultCaffNodeConfig = CaffNodeConfig{
 	ParentChainReader:       headerreader.DefaultConfig,
 	ParentChainNodeUrl:      "",
 	EspressoTEEVerifierAddr: "",
-	SequencerUrl:            "",
 }
 
 var DefaultSequencerConfig = SequencerConfig{
@@ -171,7 +169,6 @@ func CaffNodeConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Duration(prefix+".retry-time", DefaultCaffNodeConfig.RetryTime, "retry time after a failure")
 	f.Duration(prefix+".hotshot-polling-interval", DefaultCaffNodeConfig.HotshotPollingInterval, "time after a success")
 	headerreader.AddOptions(prefix+".parent-chain-reader", f)
-	f.String(prefix+".sequencer-url", DefaultCaffNodeConfig.SequencerUrl, "the sequencer url")
 	f.String(prefix+".parent-chain-node-url", DefaultCaffNodeConfig.ParentChainNodeUrl, "the parent chain url")
 	f.String(prefix+".espresso-tee-verifier-addr", "", "tee verifier address")
 }

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -126,6 +126,9 @@ type CaffNodeConfig struct {
 	ParentChainReader       headerreader.Config `koanf:"parent-chain-reader" reload:"hot"`
 	ParentChainNodeUrl      string              `koanf:"parent-chain-node-url"`
 	EspressoTEEVerifierAddr string              `koanf:"espresso-tee-verifier-addr"`
+	// See how it is used in cmd/nitro/nitro.go
+	// search for "caff-node-config.forwarding"
+	Forwarding bool `koanf:"forwarding"`
 }
 
 var DefaultCaffNodeConfig = CaffNodeConfig{
@@ -137,6 +140,7 @@ var DefaultCaffNodeConfig = CaffNodeConfig{
 	ParentChainReader:       headerreader.DefaultConfig,
 	ParentChainNodeUrl:      "",
 	EspressoTEEVerifierAddr: "",
+	Forwarding:              true,
 }
 
 var DefaultSequencerConfig = SequencerConfig{
@@ -171,6 +175,7 @@ func CaffNodeConfigAddOptions(prefix string, f *flag.FlagSet) {
 	headerreader.AddOptions(prefix+".parent-chain-reader", f)
 	f.String(prefix+".parent-chain-node-url", DefaultCaffNodeConfig.ParentChainNodeUrl, "the parent chain url")
 	f.String(prefix+".espresso-tee-verifier-addr", "", "tee verifier address")
+	f.Bool(prefix+".forwarding", DefaultCaffNodeConfig.Forwarding, "forward transactions to the sequencer")
 }
 
 func SequencerConfigAddOptions(prefix string, f *flag.FlagSet) {

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -2,7 +2,6 @@ package arbtest
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -29,7 +28,6 @@ func createCaffNode(ctx context.Context, t *testing.T, existing *NodeBuilder) (*
 	execConfig.Sequencer.CaffNodeConfig.NextHotshotBlock = 1
 	execConfig.Sequencer.CaffNodeConfig.ParentChainNodeUrl = "http://0.0.0.0:8545"
 	execConfig.Sequencer.CaffNodeConfig.EspressoTEEVerifierAddr = existing.L1Info.GetAddress("EspressoTEEVerifierMock").Hex()
-	execConfig.Sequencer.CaffNodeConfig.SequencerUrl = fmt.Sprintf("http://localhost:%d", existing.l2StackConfig.HTTPPort)
 	execConfig.Sequencer.CaffNodeConfig.ParentChainReader.Enable = true
 	execConfig.Sequencer.CaffNodeConfig.ParentChainReader.UseFinalityData = true
 	// for testing, we can use the same hotshot url for both

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -20,10 +20,12 @@ func createCaffNode(ctx context.Context, t *testing.T, existing *NodeBuilder) (*
 	nodeConfig.BlockValidator.Enable = false
 	nodeConfig.DelayedSequencer.Enable = false
 	nodeConfig.DelayedSequencer.FinalizeDistance = 1
-	nodeConfig.Sequencer = true
+	nodeConfig.Sequencer = false
 	nodeConfig.Dangerous.NoSequencerCoordinator = true
-	execConfig.Sequencer.Enable = true
+	execConfig.Sequencer.Enable = false
 	execConfig.Sequencer.EnableCaffNode = true
+	execConfig.ForwardingTarget = existing.l2StackConfig.IPCPath
+	execConfig.SecondaryForwardingTarget = []string{}
 	execConfig.Sequencer.CaffNodeConfig.Namespace = builder.chainConfig.ChainID.Uint64()
 	execConfig.Sequencer.CaffNodeConfig.NextHotshotBlock = 1
 	execConfig.Sequencer.CaffNodeConfig.ParentChainNodeUrl = "http://0.0.0.0:8545"
@@ -98,6 +100,9 @@ func TestEspressoCaffNode(t *testing.T) {
 	err = waitForWith(ctx, 240*time.Second, 10*time.Second, func() bool {
 		balance := builderCaffNode.GetBalance(t, addr)
 		log.Info("waiting for balance", "account", newAccount, "addr", addr, "balance", balance)
+		if balance.Cmp(transferAmount) >= 0 {
+			log.Info("Balance has entered account", "balance", balance, "account", newAccount)
+		}
 		return balance.Cmp(transferAmount) >= 0
 	})
 	Require(t, err)

--- a/system_tests/espresso_e2e_test.go
+++ b/system_tests/espresso_e2e_test.go
@@ -359,7 +359,8 @@ func checkTransferTxOnL2(
 		log.Info("waiting for balance", "account", account, "addr", addr, "balance", balance)
 		if balance.Cmp(transferAmount) >= 0 {
 			log.Info("target balance reached", "account", account, "addr", addr, "balance", balance)
+			return true
 		}
-		return true
+		return false
 	})
 }

--- a/system_tests/espresso_sovereign_sequencer_test.go
+++ b/system_tests/espresso_sovereign_sequencer_test.go
@@ -28,6 +28,7 @@ func createL1AndL2Node(
 	builder.l1StackConfig.WSModules = append(builder.l1StackConfig.WSModules, "eth")
 	builder.l2StackConfig.HTTPPort = 8945
 	builder.l2StackConfig.HTTPHost = "0.0.0.0"
+	builder.l2StackConfig.IPCPath = tmpPath(t, "test.ipc")
 
 	// poster config
 	builder.nodeConfig.BatchPoster.Enable = true


### PR DESCRIPTION
## Context
The forwarding target can not be set via `--execution.forwarding-target` as a restriction here

https://github.com/EspressoSystems/nitro-espresso-integration/blob/dd72cf25c7b3abeb09346b8913e8e1d1ee12c2c6/execution/gethexec/node.go#L122-L124

## What does this PR do?

This PR removes the sequencer URL from the caff node configuration. Instead, the forwarding target is now set automatically.

A new flag (enabled by default) has been introduced to indicate whether caff node should forward transactions directly to the sequencer.

While it's unlikely that anyone would disable this feature, keeping the flag makes caff node's behavior more explicit. Hiding this logic deep in the code would add unnecessary complexity, making debugging more difficult.

