### PR TITLE
Install pre-commit hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ system_tests/test-data/*
 .configs/
 system_tests/testdata/*
 arbos/testdata/*
+
+/.pre-commit-config.yaml

--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,22 @@
         "type": "github"
       }
     },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -69,6 +85,27 @@
         "type": "github"
       }
     },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1666753130,
@@ -100,6 +137,22 @@
     },
     "nixpkgs_3": {
       "locked": {
+        "lastModified": 1730768919,
+        "narHash": "sha256-8AKquNnnSaJRXZxc5YmF/WfmxiHX6MMZZasRP6RRQkE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
         "lastModified": 1728538411,
         "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
         "owner": "NixOS",
@@ -114,18 +167,39 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1737465171,
+        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "foundry": "foundry",
         "nixpkgs": "nixpkgs_2",
+        "pre-commit-hooks": "pre-commit-hooks",
         "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1731983527,

--- a/flake.nix
+++ b/flake.nix
@@ -7,8 +7,9 @@
   inputs.flake-compat.flake = false;
   inputs.rust-overlay.url = "github:oxalica/rust-overlay";
   inputs.foundry.url = "github:shazow/foundry.nix/monthly";
+  inputs.pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
 
-  outputs = { flake-utils, nixpkgs, foundry, rust-overlay, ... }:
+  outputs = { self, flake-utils, nixpkgs, foundry, rust-overlay, pre-commit-hooks, ... }:
     let
       goVersion = 23; # Change this to update the whole stack
       overlays = [
@@ -66,7 +67,20 @@
           test -f $HOME/.docker/cli-plugins/docker-buildx || ln -sn $(which docker-buildx) $HOME/.docker/cli-plugins
         '';
       in
-      {
+      with pkgs; {
+        checks = {
+          pre-commit-check = pre-commit-hooks.lib.${system}.run {
+            src = ./.;
+            hooks = {
+              golangci-lint = {
+                enable = true;
+                entry = "golangci-lint run --new-from-rev=HEAD --fix";
+                pass_filenames = false;
+                types = [ "go" ];
+              };
+            };
+          };
+        };
         devShells =
           {
             # This shell is only used for one make recipe because the other
@@ -154,6 +168,8 @@
 
                 # provides abigen
                 go-ethereum
+
+                pre-commit
               ] ++ lib.optionals stdenv.isDarwin [
                 apple-sdk_11
               ] ++ lib.optionals (! stdenv.isDarwin) [
@@ -175,7 +191,8 @@
                 + pkgs.lib.optionalString pkgs.stdenv.isDarwin
                 ''
                   export NIX_LDFLAGS="-framework SystemConfiguration $NIX_LDFLAGS"
-                '';
+                ''
+                + self.checks.${system}.pre-commit-check.shellHook;
             };
           };
       });


### PR DESCRIPTION
### This PR:
- Installs `pre-commit` and `pre-commit-hook` via Nix
- Runs `golangci-lint` automatically before committing

### This PR does not:
- Run the custom-linter, which requires analyzing of whole work space.

### How to test this PR:
Modify some .go files randomly(like adding spaces) and commit them.

### `-n` to skip the pre-commit hook
```cmd
git commit -n
```

in cases you need it