### PR TITLE
Multi node client batcher

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -193,8 +193,8 @@ type BatchPosterConfig struct {
 }
 
 func (c *BatchPosterConfig) Validate() error {
-	if (c.LightClientAddress == "") != (len(c.HotShotUrls) == 0) {
-		return errors.New("light client address and hotshot URL must both be set together, or both left unset")
+	if len(c.HotShotUrls) == 0 {
+		return errors.New("HotShotUrls must not be empty")
 
 	}
 	if len(c.GasRefunderAddress) > 0 && !common.IsHexAddress(c.GasRefunderAddress) {

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -180,7 +180,7 @@ type BatchPosterConfig struct {
 	l1BlockBound                   l1BlockBound
 	// Espresso specific flags
 	LightClientAddress          string        `koanf:"light-client-address"`
-	HotShotUrls                 []string        `koanf:"hotshot-urls"`
+	HotShotUrls                 []string      `koanf:"hotshot-urls"`
 	UseEscapeHatch              bool          `koanf:"use-escape-hatch"`
 	EspressoTxnsPollingInterval time.Duration `koanf:"espresso-txns-polling-interval"`
 	ResubmitEspressoTxDeadline  time.Duration `koanf:"resubmit-espresso-tx-deadline"`
@@ -378,7 +378,7 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 	hotShotUrls := opts.Config().HotShotUrls
 	lightClientAddr := opts.Config().LightClientAddress
 
-	if len(hotShotUrls) == 0 {
+	if len(hotShotUrls) != 0 {
 		hotShotClient := hotshotClient.NewMultipleNodesClient(hotShotUrls)
 		opts.Streamer.espressoClient = hotShotClient
 	}

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -196,6 +196,14 @@ func (c *BatchPosterConfig) Validate() error {
 	if len(c.HotShotUrls) == 0 {
 		return errors.New("HotShotUrls must not be empty")
 
+	} else {
+		urlsSlice := c.HotShotUrls[1:] // Slice off the first index as it is valid to leave that an empty string
+		// in the first position to avoid constructing an espressoClient in the batch poster.
+		for _, url := range urlsSlice {
+			if url == ("") {
+				return errors.New("An empty address (\"\") was used as a Hotshot url")
+			}
+		}
 	}
 	if len(c.GasRefunderAddress) > 0 && !common.IsHexAddress(c.GasRefunderAddress) {
 		return fmt.Errorf("invalid gas refunder address \"%v\"", c.GasRefunderAddress)

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -377,8 +377,11 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 
 	hotShotUrls := opts.Config().HotShotUrls
 	lightClientAddr := opts.Config().LightClientAddress
+	hotShotUrlsLen := len(hotShotUrls)
 
-	if len(hotShotUrls) != 0 {
+	// If the length of the hotshot urls is greater than zero, and it's not length 1 with an empty string, create the espresso multiple nodes client.
+
+	if hotShotUrlsLen != 0 && !(hotShotUrls[0] == "" && hotShotUrlsLen == 1) {
 		hotShotClient := hotshotClient.NewMultipleNodesClient(hotShotUrls)
 		opts.Streamer.espressoClient = hotShotClient
 	}

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -245,7 +245,7 @@ func BatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.String(prefix+".l1-block-bound", DefaultBatchPosterConfig.L1BlockBound, "only post messages to batches when they're within the max future block/timestamp as of this L1 block tag (\"safe\", \"finalized\", \"latest\", or \"ignore\" to ignore this check)")
 	f.Duration(prefix+".l1-block-bound-bypass", DefaultBatchPosterConfig.L1BlockBoundBypass, "post batches even if not within the layer 1 future bounds if we're within this margin of the max delay")
 	f.Bool(prefix+".use-access-lists", DefaultBatchPosterConfig.UseAccessLists, "post batches with access lists to reduce gas usage (disabled for L3s)")
-	f.StringArray(prefix+".hotshot-url", DefaultBatchPosterConfig.HotShotUrls, "specifies the hotshot url if we are batching in espresso mode")
+	f.StringArray(prefix+".hotshot-urls", DefaultBatchPosterConfig.HotShotUrls, "specifies the hotshot urls if we are batching in espresso mode")
 	f.String(prefix+".light-client-address", DefaultBatchPosterConfig.LightClientAddress, "specifies the hotshot light client address if we are batching in espresso mode")
 	f.Uint64(prefix+".gas-estimate-base-fee-multiple-bips", uint64(DefaultBatchPosterConfig.GasEstimateBaseFeeMultipleBips), "for gas estimation, use this multiple of the basefee (measured in basis points) as the max fee per gas")
 	f.Duration(prefix+".reorg-resistance-margin", DefaultBatchPosterConfig.ReorgResistanceMargin, "do not post batch if its within this duration from layer 1 minimum bounds. Requires l1-block-bound option not be set to \"ignore\"")

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1324,7 +1324,7 @@ func (s *TransactionStreamer) checkSubmittedTransactionForFinality(ctx context.C
 	err = json.Unmarshal(jsonHeader, &header)
 	if err != nil {
 		return fmt.Errorf("could not unmarshal header from bytes (height: %d): %w", height, err)
-	}	
+	}
 
 	resp, err := s.espressoClient.FetchTransactionsInBlock(ctx, height, s.chainConfig.ChainID.Uint64())
 	if err != nil {
@@ -1650,7 +1650,8 @@ func (s *TransactionStreamer) pollSubmittedTransactionForFinality(ctx context.Co
  * Submits the transactions to espresso if the escape hatch is not enabled
  */
 func (s *TransactionStreamer) submitTransactionsToEspresso(ctx context.Context, ignored struct{}) time.Duration {
-	retryRate := s.espressoTxnsPollingInterval * 50
+	// When encountering an error during the initial attempt at submitting a transaction, double the amount of our polling interval and try again.
+	retryRate := s.espressoTxnsPollingInterval * 2
 	shouldSubmit := s.shouldSubmitEspressoTransaction()
 	// Only submit the transaction if escape hatch is not enabled
 	if shouldSubmit {

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -81,7 +81,7 @@ type TransactionStreamer struct {
 	delayedBridge   *DelayedBridge
 
 	// Espresso specific fields. These fields are set from batch poster
-	espressoClient               *espressoClient.Client
+	espressoClient               *espressoClient.EspressoClient
 	lightClientReader            lightclient.LightClientReaderInterface
 	espressoTxnsPollingInterval  time.Duration
 	maxBlockLagBeforeEscapeHatch uint64

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -37,7 +37,6 @@ import (
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/broadcaster"
 	m "github.com/offchainlabs/nitro/broadcaster/message"
-	"github.com/offchainlabs/nitro/espressocrypto"
 	"github.com/offchainlabs/nitro/execution"
 	"github.com/offchainlabs/nitro/staker"
 	"github.com/offchainlabs/nitro/util"
@@ -1325,23 +1324,9 @@ func (s *TransactionStreamer) checkSubmittedTransactionForFinality(ctx context.C
 		return fmt.Errorf("could not unmarshal header from bytes (height: %d): %w", height, err)
 	}	
 
-	// Verify the namespace proof
 	resp, err := s.espressoClient.FetchTransactionsInBlock(ctx, height, s.chainConfig.ChainID.Uint64())
 	if err != nil {
 		return fmt.Errorf("failed to fetch the transactions in block (height: %d): %w", height, err)
-	}
-
-	namespaceOk := espressocrypto.VerifyNamespace(
-		s.chainConfig.ChainID.Uint64(),
-		resp.Proof,
-		*header.Header.GetPayloadCommitment(),
-		*header.Header.GetNsTable(),
-		resp.Transactions,
-		resp.VidCommon,
-	)
-
-	if !namespaceOk {
-		return fmt.Errorf("error validating namespace proof (height: %d)", height)
 	}
 
 	submittedPayload := firstSubmitted.Payload

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ replace github.com/offchainlabs/bold => ./bold
 
 require (
 	cloud.google.com/go/storage v1.43.0
-	github.com/EspressoSystems/espresso-sequencer-go v0.0.31
+	github.com/EspressoSystems/espresso-sequencer-go v0.0.33
 	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible
 	github.com/Shopify/toxiproxy v2.1.4+incompatible
 	github.com/alicebob/miniredis/v2 v2.32.1
@@ -48,7 +48,7 @@ require (
 	github.com/r3labs/diff/v3 v3.0.1
 	github.com/redis/go-redis/v9 v9.6.1
 	github.com/rivo/tview v0.0.0-20240307173318-e804876934a1
-	github.com/spf13/pflag v1.0.5
+	github.com/spf13/pflag v1.0.6
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/tendermint/tendermint v0.35.9
 	github.com/wealdtech/go-merkletree v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
-github.com/EspressoSystems/espresso-sequencer-go v0.0.31 h1:DdAzlGiHlfosbUsg0G8C/r1pb9aMyv10yukYi+aW/Ks=
-github.com/EspressoSystems/espresso-sequencer-go v0.0.31/go.mod h1:zWS7ohpSPm2QLVb5jXbSjqszFr1UtJO/8txwqSWOppQ=
+github.com/EspressoSystems/espresso-sequencer-go v0.0.33 h1:iuJSQUPUOFTlj9pRWJZD/Y7qOGFEB6SULn4L8+9ldd4=
+github.com/EspressoSystems/espresso-sequencer-go v0.0.33/go.mod h1:fOdDZXErynF8vjrNs4fEylieL0982/GX8aXCDPlRwFg=
 github.com/GaijinEntertainment/go-exhaustruct/v2 v2.2.0/go.mod h1:n/vLeA7V+QY84iYAGwMkkUUp9ooeuftMEvaDrSVch+Q=
 github.com/HdrHistogram/hdrhistogram-go v1.1.0/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
@@ -1216,8 +1216,9 @@ github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb6
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.10.0/go.mod h1:SoyBPwAtKDzypXNDFKN5kzH7ppppbGZtls1UpIy5AsM=
 github.com/spf13/viper v1.12.0/go.mod h1:b6COn30jlNxbm/V2IqWiNWkJ+vZNiMNksliPCiuKtSI=

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -17,6 +17,8 @@ func createCaffNode(ctx context.Context, t *testing.T, existing *NodeBuilder) (*
 
 	// Disable the batch poster because it requires redis if enabled on the 2nd node
 	nodeConfig.BatchPoster.Enable = false
+	// Set the light client addr so that config validation passes even though we aren't using the batch poster in this case.
+	nodeConfig.BatchPoster.LightClientAddress = existing.nodeConfig.BatchPoster.LightClientAddress
 	nodeConfig.BlockValidator.Enable = false
 	nodeConfig.DelayedSequencer.Enable = false
 	nodeConfig.DelayedSequencer.FinalizeDistance = 1

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -17,8 +17,6 @@ func createCaffNode(ctx context.Context, t *testing.T, existing *NodeBuilder) (*
 
 	// Disable the batch poster because it requires redis if enabled on the 2nd node
 	nodeConfig.BatchPoster.Enable = false
-	// Set the light client addr so that config validation passes even though we aren't using the batch poster in this case.
-	nodeConfig.BatchPoster.LightClientAddress = existing.nodeConfig.BatchPoster.LightClientAddress
 	nodeConfig.BlockValidator.Enable = false
 	nodeConfig.DelayedSequencer.Enable = false
 	nodeConfig.DelayedSequencer.FinalizeDistance = 1

--- a/system_tests/espresso_sovereign_sequencer_test.go
+++ b/system_tests/espresso_sovereign_sequencer_test.go
@@ -38,7 +38,7 @@ func createL1AndL2Node(
 	builder.nodeConfig.BatchPoster.PollInterval = 10 * time.Second
 	builder.nodeConfig.BatchPoster.MaxDelay = -1000 * time.Hour
 	builder.nodeConfig.BatchPoster.LightClientAddress = lightClientAddress
-	builder.nodeConfig.BatchPoster.HotShotUrl = hotShotUrl
+	builder.nodeConfig.BatchPoster.HotShotUrls = []string{hotShotUrl}
 	builder.nodeConfig.BatchPoster.UseEscapeHatch = false
 
 	// validator config


### PR DESCRIPTION
Closes #[514 ](https://github.com/EspressoSystems/nitro-espresso-integration/issues/514)

Asana issue https://app.asana.com/0/home/1209393650288774/1209479693847655

### This PR:
Uses the multiple node client in the stateless batcher to handle performing fetching of data from Espresso via a quorum of the query nodes.

Currently this PR will not build as it is blocked by the merge of #[68](https://github.com/EspressoSystems/espresso-sequencer-go/pull/68/files) in `espresso-sequencer-go`
