### PR TITLE
Add caff node test script

### DIFF
--- a/scripts/caff-node-tester.sh
+++ b/scripts/caff-node-tester.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+sequencer_url=""
+caff_node_url=""
+address=""
+time_interval=10
+allow_delay_times=10
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --sequencer) sequencer_url="$2"; shift ;;
+        --caff-node) caff_node_url="$2"; shift ;;
+        --address) address="$2"; shift ;;
+        --interval) time_interval="$2"; shift ;;
+        --allow-delay) allow_delay_times="$2"; shift ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+if [ -z "$sequencer_url" ]; then
+    echo "--sequencer is required"
+    exit 1
+fi
+
+if [ -z "$caff_node_url" ]; then
+    echo "--caff-node is required"
+    exit 1
+fi
+
+if [ -z "$address" ]; then
+    echo "--address is required"
+    exit 1
+fi
+
+delay_count=0
+
+while true; do
+    current_time=$(date +"%Y-%m-%d %H:%M:%S")
+    sequencer_balance=$(cast balance $address --rpc-url $sequencer_url)
+    echo "[$current_time] sequencer_balance: $sequencer_balance"
+
+    caff_node_balance=$(cast balance $address --rpc-url $caff_node_url)
+    echo "[$current_time] caff_node_balance: $caff_node_balance"
+
+    if [ "$sequencer_balance" != "$caff_node_balance" ]; then
+        delay_count=$((delay_count + 1))
+        echo "Warning: Balances do not match! Delay count: $delay_count"
+
+        if [ "$delay_count" -gt "$allow_delay_times" ]; then
+            echo "Error: Allowable delay times exceeded!"
+            exit 1
+        fi
+    else
+        delay_count=0
+    fi
+
+    sleep $time_interval
+done


### PR DESCRIPTION
### This PR:
Add a script to monitor the balance with a given address both from sequencer and caff node.

### How to test this PR:
I tested it by following steps:
- In `nitro-testnode` repo, remove the last line in `smoke-test-caff-node.bash`:

```
--- a/smoke-test-caff-node.bash
+++ b/smoke-test-caff-node.bash
@@ -37,4 +37,4 @@ echo "Sending L2 transaction through caff node"
 ./test-node.bash script send-l2 --ethamount 10 --to $user --l2url $caff_url --wait

 echo "Smoke test succeeded."
-docker compose down
+# docker compose down
```

- run the script in `nitro-testnode`, which will set up the test environment

```
./smoke-test-caff-node.bash
```

- run the monitoring script:

```
./scripts/caff-node-tester.sh --sequencer  ws://127.0.0.1:8548 --caff-node ws://127.0.0.1:8552 --address 0xEEA8EC07A3642769168D40e3Abd05Af5F1c56c44
```

Note: this address represents the `user_l2user`

- send transactions via nitro test node script like this

```
./test-node.bash script send-l2 --ethamount 10 --to user_l2user --wait
```

And I got this output:

```
[2025-03-04 14:49:47] sequencer_balance: 50000000000000000000
[2025-03-04 14:49:47] caff_node_balance: 40000000000000000000
Warning: Balances do not match! Delay count: 1
[2025-03-04 14:49:57] sequencer_balance: 50000000000000000000
[2025-03-04 14:49:57] caff_node_balance: 40000000000000000000
Warning: Balances do not match! Delay count: 2
[2025-03-04 14:50:07] sequencer_balance: 50000000000000000000
[2025-03-04 14:50:07] caff_node_balance: 40000000000000000000
Warning: Balances do not match! Delay count: 3
[2025-03-04 14:50:17] sequencer_balance: 50000000000000000000
[2025-03-04 14:50:17] caff_node_balance: 50000000000000000000
```
