### PR TITLE
[Caff Node] Clean up logs and add a performance recorder

### DIFF
--- a/espressostreamer/espresso_streamer.go
+++ b/espressostreamer/espresso_streamer.go
@@ -251,18 +251,6 @@ func (s *EspressoStreamer) QueueMessagesFromHotshot(
 		return nil
 	}
 
-	if s.PerfRecorder != nil {
-		now := time.Now()
-		timestamp, err := s.getEspressoBlockTimestamp(ctx, s.nextHotshotBlockNum)
-		if err != nil {
-			return fmt.Errorf("unable to fetch header for hotshot block: %w", err)
-		}
-		s.PerfRecorder.SetStartTime(timestamp)
-		s.PerfRecorder.SetEndTime(now, fmt.Sprintf("Fetched header for hotshot block %d", s.nextHotshotBlockNum))
-		// To check the time taken to parse the transactions
-		s.PerfRecorder.SetStartTime(time.Now())
-	}
-
 	for _, tx := range arbTxns.Transactions {
 		messages, err := parseHotShotPayloadFn(tx)
 		if err != nil {
@@ -270,11 +258,6 @@ func (s *EspressoStreamer) QueueMessagesFromHotshot(
 			continue
 		}
 		s.messageWithMetadataAndPos = append(s.messageWithMetadataAndPos, messages...)
-	}
-
-	if s.PerfRecorder != nil {
-		currentTime := time.Now()
-		s.PerfRecorder.SetEndTime(currentTime, fmt.Sprintf("Finished parsing transactions for hotshot block %d", s.nextHotshotBlockNum))
 	}
 
 	s.nextHotshotBlockNum += 1

--- a/espressostreamer/espresso_streamer.go
+++ b/espressostreamer/espresso_streamer.go
@@ -56,6 +56,7 @@ type EspressoStreamer struct {
 func NewEspressoStreamer(
 	namespace uint64,
 	nextHotshotBlockNum uint64,
+	currentPosition uint64,
 	retryTime time.Duration,
 	pollingHotshotPollingInterval time.Duration,
 	espressoTEEVerifierCaller EspressoTEEVerifierInterface,
@@ -71,12 +72,17 @@ func NewEspressoStreamer(
 	return &EspressoStreamer{
 		espressoClient:                espressoClientInterface,
 		nextHotshotBlockNum:           nextHotshotBlockNum,
+		currentMessagePos:             currentPosition,
 		retryTime:                     retryTime,
 		pollingHotshotPollingInterval: pollingHotshotPollingInterval,
 		namespace:                     namespace,
 		espressoTEEVerifierCaller:     espressoTEEVerifierCaller,
 		perfRecorder:                  perfRecorder,
 	}
+}
+
+func (s *EspressoStreamer) GetNextMessagePosAndHotShotBlock() (uint64, uint64) {
+	return s.currentMessagePos, s.nextHotshotBlockNum
 }
 
 func (s *EspressoStreamer) Reset(currentMessagePos uint64, currentHostshotBlock uint64) {

--- a/espressostreamer/espresso_streamer_test.go
+++ b/espressostreamer/espresso_streamer_test.go
@@ -31,7 +31,7 @@ func TestEspressoStreamer(t *testing.T) {
 		// Simulate the call to the tee verifier returning a byte array. To the streamer, this indicates the attestation quote is valid.
 		mockEspressoTEEVerifierClient.On("Verify", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		// create a new streamer object
-		streamer := NewEspressoStreamer(1, 1, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient, false)
+		streamer := NewEspressoStreamer(1, 1, 0, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient, false)
 		streamer.Reset(735805, 1)
 		// Get the data for this test
 		testBlocks := GetTestBlocks()
@@ -64,7 +64,7 @@ func TestEspressoStreamer(t *testing.T) {
 
 		mockEspressoClient.On("FetchTransactionsInBlock", ctx, uint64(6), namespace).Return(espressoClient.TransactionsInBlock{}, errors.New("test error"))
 
-		streamer := NewEspressoStreamer(namespace, 3, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient, false)
+		streamer := NewEspressoStreamer(namespace, 3, 0, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient, false)
 
 		testParseFn := func(tx types.Bytes) ([]*MessageWithMetadataAndPos, error) {
 			return nil, nil
@@ -106,7 +106,7 @@ func TestEspressoStreamer(t *testing.T) {
 			},
 		}, nil)
 
-		streamer := NewEspressoStreamer(namespace, 3, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient, false)
+		streamer := NewEspressoStreamer(namespace, 3, 0, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient, false)
 
 		testParseFn := func(pos uint64, hotshotheight uint64) func(tx types.Bytes) ([]*MessageWithMetadataAndPos, error) {
 

--- a/espressostreamer/espresso_streamer_test.go
+++ b/espressostreamer/espresso_streamer_test.go
@@ -9,6 +9,7 @@ import (
 
 	espressoClient "github.com/EspressoSystems/espresso-sequencer-go/client"
 	"github.com/EspressoSystems/espresso-sequencer-go/types"
+	espressoTypes "github.com/EspressoSystems/espresso-sequencer-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -30,7 +31,7 @@ func TestEspressoStreamer(t *testing.T) {
 		// Simulate the call to the tee verifier returning a byte array. To the streamer, this indicates the attestation quote is valid.
 		mockEspressoTEEVerifierClient.On("Verify", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		// create a new streamer object
-		streamer := NewEspressoStreamer(1, 1, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient)
+		streamer := NewEspressoStreamer(1, 1, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient, false)
 		streamer.Reset(735805, 1)
 		// Get the data for this test
 		testBlocks := GetTestBlocks()
@@ -63,7 +64,7 @@ func TestEspressoStreamer(t *testing.T) {
 
 		mockEspressoClient.On("FetchTransactionsInBlock", ctx, uint64(6), namespace).Return(espressoClient.TransactionsInBlock{}, errors.New("test error"))
 
-		streamer := NewEspressoStreamer(namespace, 3, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient)
+		streamer := NewEspressoStreamer(namespace, 3, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient, false)
 
 		testParseFn := func(tx types.Bytes) ([]*MessageWithMetadataAndPos, error) {
 			return nil, nil
@@ -105,7 +106,7 @@ func TestEspressoStreamer(t *testing.T) {
 			},
 		}, nil)
 
-		streamer := NewEspressoStreamer(namespace, 3, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient)
+		streamer := NewEspressoStreamer(namespace, 3, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient, false)
 
 		testParseFn := func(pos uint64, hotshotheight uint64) func(tx types.Bytes) ([]*MessageWithMetadataAndPos, error) {
 
@@ -169,6 +170,10 @@ func (m *mockEspressoClient) FetchTransactionsInBlock(ctx context.Context, block
 	args := m.Called(ctx, blockHeight, namespace)
 	//nolint:errcheck
 	return args.Get(0).(espressoClient.TransactionsInBlock), args.Error(1)
+}
+
+func (m *mockEspressoClient) FetchHeaderByHeight(ctx context.Context, blockHeight uint64) (espressoTypes.HeaderImpl, error) {
+	panic("not implemented")
 }
 
 // To generate test scripts for the mock clients, we can create a list of test blocks that we can iterate through and set as the call and return values.

--- a/espressostreamer/espresso_streamer_test.go
+++ b/espressostreamer/espresso_streamer_test.go
@@ -31,7 +31,7 @@ func TestEspressoStreamer(t *testing.T) {
 		// Simulate the call to the tee verifier returning a byte array. To the streamer, this indicates the attestation quote is valid.
 		mockEspressoTEEVerifierClient.On("Verify", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		// create a new streamer object
-		streamer := NewEspressoStreamer(1, 1, 0, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient, false)
+		streamer := NewEspressoStreamer(1, 1, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient, false)
 		streamer.Reset(735805, 1)
 		// Get the data for this test
 		testBlocks := GetTestBlocks()
@@ -64,7 +64,7 @@ func TestEspressoStreamer(t *testing.T) {
 
 		mockEspressoClient.On("FetchTransactionsInBlock", ctx, uint64(6), namespace).Return(espressoClient.TransactionsInBlock{}, errors.New("test error"))
 
-		streamer := NewEspressoStreamer(namespace, 3, 0, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient, false)
+		streamer := NewEspressoStreamer(namespace, 3, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient, false)
 
 		testParseFn := func(tx types.Bytes) ([]*MessageWithMetadataAndPos, error) {
 			return nil, nil
@@ -106,7 +106,7 @@ func TestEspressoStreamer(t *testing.T) {
 			},
 		}, nil)
 
-		streamer := NewEspressoStreamer(namespace, 3, 0, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient, false)
+		streamer := NewEspressoStreamer(namespace, 3, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient, false)
 
 		testParseFn := func(pos uint64, hotshotheight uint64) func(tx types.Bytes) ([]*MessageWithMetadataAndPos, error) {
 

--- a/espressostreamer/perf_recorder.go
+++ b/espressostreamer/perf_recorder.go
@@ -22,5 +22,5 @@ func (p *PerfRecorder) SetStartTime(time time.Time) {
 func (p *PerfRecorder) SetEndTime(time time.Time, logMessage string) {
 	p.endTime = time
 	duration := p.endTime.Sub(p.startTime)
-	log.Info(logMessage, "start time", p.startTime, "end time", p.endTime, "duration", duration)
+	log.Debug(logMessage, "start time", p.startTime, "end time", p.endTime, "duration", duration)
 }

--- a/espressostreamer/perf_recorder.go
+++ b/espressostreamer/perf_recorder.go
@@ -1,0 +1,26 @@
+package espressostreamer
+
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type PerfRecorder struct {
+	startTime time.Time
+	endTime   time.Time
+}
+
+func NewPerfRecorder() *PerfRecorder {
+	return &PerfRecorder{}
+}
+
+func (p *PerfRecorder) SetStartTime(time time.Time) {
+	p.startTime = time
+}
+
+func (p *PerfRecorder) SetEndTime(time time.Time, logMessage string) {
+	p.endTime = time
+	duration := p.endTime.Sub(p.startTime)
+	log.Info(logMessage, "start time", p.startTime, "end time", p.endTime, "duration", duration)
+}

--- a/execution/gethexec/caff_node.go
+++ b/execution/gethexec/caff_node.go
@@ -177,7 +177,11 @@ func (n *CaffNode) Start(ctx context.Context) error {
 	}
 	// This is +1 because the current block is the block after the last processed block
 	currentBlockNum := n.executionEngine.bc.CurrentBlock().Number.Uint64() + 1
-	n.espressoStreamer.Reset(currentBlockNum, n.config().CaffNodeConfig.NextHotshotBlock)
+	currentMessagePos, err := n.executionEngine.BlockNumberToMessageIndex(currentBlockNum)
+	if err != nil {
+		return fmt.Errorf("failed to convert block number to message index: %w", err)
+	}
+	n.espressoStreamer.Reset(uint64(currentMessagePos), n.config().CaffNodeConfig.NextHotshotBlock)
 
 	err = n.CallIterativelySafe(func(ctx context.Context) time.Duration {
 		madeBlock := n.createBlock()

--- a/execution/gethexec/caff_node.go
+++ b/execution/gethexec/caff_node.go
@@ -116,6 +116,11 @@ func (n *CaffNode) createBlock() (returnValue bool) {
 		return false
 	}
 
+	if messageWithMetadataAndPos == nil {
+		log.Debug("no message found")
+		return false
+	}
+
 	messageWithMetadata := messageWithMetadataAndPos.MessageWithMeta
 
 	// Get the state of the database at the last block

--- a/execution/gethexec/caff_node.go
+++ b/execution/gethexec/caff_node.go
@@ -87,6 +87,7 @@ func NewCaffNode(configFetcher SequencerConfigFetcher, execEngine *ExecutionEngi
 		config.CaffNodeConfig.HotshotPollingInterval,
 		espressoTEEVerifierCaller,
 		espressoClient.NewMultipleNodesClient(config.CaffNodeConfig.HotShotUrls),
+		config.CaffNodeConfig.RecordPerformance,
 	)
 
 	if espressoStreamer == nil {

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -222,7 +222,7 @@ func CreateExecutionNode(
 		if config.Sequencer.EnableCaffNode {
 			targets := append([]string{config.forwardingTarget}, config.SecondaryForwardingTarget...)
 			txForwarder := NewForwarder(targets, &config.Forwarder)
-			espressoFinalityNode := NewCaffNode(seqConfigFetcher, execEngine, txForwarder)
+			espressoFinalityNode := NewCaffNode(seqConfigFetcher, execEngine, txForwarder, stack)
 			txPublisher = espressoFinalityNode
 		} else if config.Forwarder.RedisUrl != "" {
 			txPublisher = NewRedisTxForwarder(config.forwardingTarget, &config.Forwarder)

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -128,7 +128,8 @@ type CaffNodeConfig struct {
 	EspressoTEEVerifierAddr string              `koanf:"espresso-tee-verifier-addr"`
 	// See how it is used in cmd/nitro/nitro.go
 	// search for "caff-node-config.forwarding"
-	Forwarding bool `koanf:"forwarding"`
+	Forwarding        bool `koanf:"forwarding"`
+	RecordPerformance bool `koanf:"record-performance"`
 }
 
 var DefaultCaffNodeConfig = CaffNodeConfig{
@@ -141,6 +142,7 @@ var DefaultCaffNodeConfig = CaffNodeConfig{
 	ParentChainNodeUrl:      "",
 	EspressoTEEVerifierAddr: "",
 	Forwarding:              true,
+	RecordPerformance:       false,
 }
 
 var DefaultSequencerConfig = SequencerConfig{
@@ -176,6 +178,7 @@ func CaffNodeConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".parent-chain-node-url", DefaultCaffNodeConfig.ParentChainNodeUrl, "the parent chain url")
 	f.String(prefix+".espresso-tee-verifier-addr", "", "tee verifier address")
 	f.Bool(prefix+".forwarding", DefaultCaffNodeConfig.Forwarding, "forward transactions to the sequencer")
+	f.Bool(prefix+".record-performance", DefaultCaffNodeConfig.RecordPerformance, "record performance of the caff node")
 }
 
 func SequencerConfigAddOptions(prefix string, f *flag.FlagSet) {

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -32,6 +32,7 @@ func createCaffNode(ctx context.Context, t *testing.T, existing *NodeBuilder) (*
 	execConfig.Sequencer.CaffNodeConfig.EspressoTEEVerifierAddr = existing.L1Info.GetAddress("EspressoTEEVerifierMock").Hex()
 	execConfig.Sequencer.CaffNodeConfig.ParentChainReader.Enable = true
 	execConfig.Sequencer.CaffNodeConfig.ParentChainReader.UseFinalityData = true
+	execConfig.Sequencer.CaffNodeConfig.RecordPerformance = true
 	// for testing, we can use the same hotshot url for both
 	execConfig.Sequencer.CaffNodeConfig.HotShotUrls = []string{hotShotUrl, hotShotUrl, hotShotUrl, hotShotUrl}
 	execConfig.Sequencer.CaffNodeConfig.RetryTime = time.Second * 1


### PR DESCRIPTION
### This PR:
- Fix the conversion from block number to message index.
    - This is not a concerning issue, but using the way Nitro is using should be safer.
- Use an ephemeral handler in caff node to deal with the fetch transaction error
    - Retruning errors instead of logging errors inside in `QueueMessagesFromHotshot`
    - Thinking maybe we should do the same things to the `createBlock` function
    - I think it is the caller's responsibility to handle errors(simply output them or process them). In this way, if a function returns error, we should not log errors in it.
- Add a flag to calculate the duration from the creation of Espresso blocks to when the Caff node consumes them.
    - Nearly 40 secs in my laptop when running the `TestEspressoCaffNode`
    - We have to fetch the header first, that's why an other flag is used. This way won't affect the performance while setting it to false. 
- Add a dedicated database for caff node 
 
```
INFO [03-05|15:41:23.562] Fetched header for hotshot block 984     "start time"=2025-03-05T15:40:46+0800 "end time"=2025-03-05T15:41:23+0800 duration=37.555907s
```