### PR TITLE
Debug

### DIFF
--- a/espressostreamer/espresso_streamer.go
+++ b/espressostreamer/espresso_streamer.go
@@ -182,11 +182,13 @@ func (s *EspressoStreamer) ReadNextHotshotBlockFromDb(db ethdb.Database) (uint64
 			return 0, fmt.Errorf("failed to decode next hotshot block: %w", err)
 		}
 	}
+	log.Info("Reading next hotshot block from db", "nextHotshotBlock", nextHotshotBlock)
 
 	return nextHotshotBlock, nil
 }
 
 func (s *EspressoStreamer) StoreHotshotBlock(db ethdb.Database, nextHotshotBlock uint64) error {
+	log.Info("Storing hotshot block", "nextHotshotBlock", nextHotshotBlock)
 	nextHotshotBytes, err := rlp.EncodeToBytes(nextHotshotBlock)
 	if err != nil {
 		return fmt.Errorf("failed to encode next hotshot block: %w", err)

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -14,6 +14,7 @@ func createCaffNode(ctx context.Context, t *testing.T, existing *NodeBuilder) (*
 	builder := NewNodeBuilder(ctx).DefaultConfig(t, false)
 	nodeConfig := builder.nodeConfig
 	execConfig := builder.execConfig
+	builder.dataDir = "./caffnode"
 
 	// Disable the batch poster because it requires redis if enabled on the 2nd node
 	nodeConfig.BatchPoster.Enable = false
@@ -44,12 +45,14 @@ func createCaffNode(ctx context.Context, t *testing.T, existing *NodeBuilder) (*
 }
 
 func TestEspressoCaffNode(t *testing.T) {
+	log.Info("?????")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	valNodeCleanup := createValidationNode(ctx, t, true)
 	defer valNodeCleanup()
 
+	log.Info("hhhhhhhhhhhh")
 	builder, cleanup := createL1AndL2Node(ctx, t, true)
 	defer cleanup()
 
@@ -59,9 +62,12 @@ func TestEspressoCaffNode(t *testing.T) {
 	cleanEspresso := runEspresso()
 	defer cleanEspresso()
 
+	log.Info("???????????")
 	// wait for the builder
 	err = waitForEspressoNode(ctx)
 	Require(t, err)
+
+	log.Info("??????????? Waiting for 10 seconds")
 
 	err = checkTransferTxOnL2(t, ctx, builder.L2, "User14", builder.L2Info)
 	Require(t, err)

--- a/system_tests/espresso-e2e/docker-compose.yaml
+++ b/system_tests/espresso-e2e/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   espresso-dev-node:
-    image: ghcr.io/espressosystems/espresso-sequencer/espresso-dev-node:latest
+    image: ghcr.io/espressosystems/espresso-sequencer/espresso-dev-node:main
     ports:
       - "$ESPRESSO_SEQUENCER_API_PORT:$ESPRESSO_SEQUENCER_API_PORT"
       - "$ESPRESSO_BUILDER_PORT:$ESPRESSO_BUILDER_PORT"

--- a/system_tests/espresso_e2e_test.go
+++ b/system_tests/espresso_e2e_test.go
@@ -140,6 +140,7 @@ func waitForEspressoNode(ctx context.Context) error {
 			log.Warn("retry to check the espresso dev node", "err", err)
 			return false
 		}
+		log.Info("out", "out", string(out))
 		return len(out) > 0
 	})
 }
@@ -164,6 +165,7 @@ func waitForL1Node(ctx context.Context) error {
 			"{'jsonrpc':'2.0','id':45678,'method':'eth_chainId','params':[]}",
 			"http://localhost:8545",
 		).Run(); e != nil {
+			log.Info("err", "err", e)
 			return false
 		}
 		return true


### PR DESCRIPTION
- With these changes, run caff node test:

```
go test -v -count=1 -timeout 25m -run ^TestEspressoCaffNode$ github.com/offchainlabs/nitro/system_tests
```

When it is finsihed, you will see logs like:
```
Storing hotshot block 
```

You can also see the data dir is `./system_tests/caffnode`

Run it again(we just want to restart the caff node) and from the log you can see the caff node read next hotshot block from db