### PR TITLE
[Caff Node] Clean up logs and add a performance recorder (#517)

### DIFF
--- a/espressostreamer/espresso_streamer_test.go
+++ b/espressostreamer/espresso_streamer_test.go
@@ -9,6 +9,7 @@ import (
 
 	espressoClient "github.com/EspressoSystems/espresso-sequencer-go/client"
 	"github.com/EspressoSystems/espresso-sequencer-go/types"
+	espressoTypes "github.com/EspressoSystems/espresso-sequencer-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -30,7 +31,7 @@ func TestEspressoStreamer(t *testing.T) {
 		// Simulate the call to the tee verifier returning a byte array. To the streamer, this indicates the attestation quote is valid.
 		mockEspressoTEEVerifierClient.On("Verify", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		// create a new streamer object
-		streamer := NewEspressoStreamer(1, 1, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient)
+		streamer := NewEspressoStreamer(1, 1, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient, false)
 		streamer.Reset(735805, 1)
 		// Get the data for this test
 		testBlocks := GetTestBlocks()
@@ -63,7 +64,7 @@ func TestEspressoStreamer(t *testing.T) {
 
 		mockEspressoClient.On("FetchTransactionsInBlock", ctx, uint64(6), namespace).Return(espressoClient.TransactionsInBlock{}, errors.New("test error"))
 
-		streamer := NewEspressoStreamer(namespace, 3, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient)
+		streamer := NewEspressoStreamer(namespace, 3, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient, false)
 
 		testParseFn := func(tx types.Bytes) ([]*MessageWithMetadataAndPos, error) {
 			return nil, nil
@@ -105,7 +106,7 @@ func TestEspressoStreamer(t *testing.T) {
 			},
 		}, nil)
 
-		streamer := NewEspressoStreamer(namespace, 3, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient)
+		streamer := NewEspressoStreamer(namespace, 3, time.Millisecond, time.Millisecond, mockEspressoTEEVerifierClient, mockEspressoClient, false)
 
 		testParseFn := func(pos uint64, hotshotheight uint64) func(tx types.Bytes) ([]*MessageWithMetadataAndPos, error) {
 
@@ -169,6 +170,10 @@ func (m *mockEspressoClient) FetchTransactionsInBlock(ctx context.Context, block
 	args := m.Called(ctx, blockHeight, namespace)
 	//nolint:errcheck
 	return args.Get(0).(espressoClient.TransactionsInBlock), args.Error(1)
+}
+
+func (m *mockEspressoClient) FetchHeaderByHeight(ctx context.Context, blockHeight uint64) (espressoTypes.HeaderImpl, error) {
+	panic("not implemented")
 }
 
 // To generate test scripts for the mock clients, we can create a list of test blocks that we can iterate through and set as the call and return values.

--- a/espressostreamer/perf_recorder.go
+++ b/espressostreamer/perf_recorder.go
@@ -1,0 +1,26 @@
+package espressostreamer
+
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type PerfRecorder struct {
+	startTime time.Time
+	endTime   time.Time
+}
+
+func NewPerfRecorder() *PerfRecorder {
+	return &PerfRecorder{}
+}
+
+func (p *PerfRecorder) SetStartTime(time time.Time) {
+	p.startTime = time
+}
+
+func (p *PerfRecorder) SetEndTime(time time.Time, logMessage string) {
+	p.endTime = time
+	duration := p.endTime.Sub(p.startTime)
+	log.Debug(logMessage, "start time", p.startTime, "end time", p.endTime, "duration", duration)
+}

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -222,7 +222,7 @@ func CreateExecutionNode(
 		if config.Sequencer.EnableCaffNode {
 			targets := append([]string{config.forwardingTarget}, config.SecondaryForwardingTarget...)
 			txForwarder := NewForwarder(targets, &config.Forwarder)
-			espressoFinalityNode := NewCaffNode(seqConfigFetcher, execEngine, txForwarder)
+			espressoFinalityNode := NewCaffNode(seqConfigFetcher, execEngine, txForwarder, stack)
 			txPublisher = espressoFinalityNode
 		} else if config.Forwarder.RedisUrl != "" {
 			txPublisher = NewRedisTxForwarder(config.forwardingTarget, &config.Forwarder)

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -128,7 +128,8 @@ type CaffNodeConfig struct {
 	EspressoTEEVerifierAddr string              `koanf:"espresso-tee-verifier-addr"`
 	// See how it is used in cmd/nitro/nitro.go
 	// search for "caff-node-config.forwarding"
-	Forwarding bool `koanf:"forwarding"`
+	Forwarding        bool `koanf:"forwarding"`
+	RecordPerformance bool `koanf:"record-performance"`
 }
 
 var DefaultCaffNodeConfig = CaffNodeConfig{
@@ -141,6 +142,7 @@ var DefaultCaffNodeConfig = CaffNodeConfig{
 	ParentChainNodeUrl:      "",
 	EspressoTEEVerifierAddr: "",
 	Forwarding:              true,
+	RecordPerformance:       false,
 }
 
 var DefaultSequencerConfig = SequencerConfig{
@@ -176,6 +178,7 @@ func CaffNodeConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".parent-chain-node-url", DefaultCaffNodeConfig.ParentChainNodeUrl, "the parent chain url")
 	f.String(prefix+".espresso-tee-verifier-addr", "", "tee verifier address")
 	f.Bool(prefix+".forwarding", DefaultCaffNodeConfig.Forwarding, "forward transactions to the sequencer")
+	f.Bool(prefix+".record-performance", DefaultCaffNodeConfig.RecordPerformance, "record performance of the caff node")
 }
 
 func SequencerConfigAddOptions(prefix string, f *flag.FlagSet) {

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -32,6 +32,7 @@ func createCaffNode(ctx context.Context, t *testing.T, existing *NodeBuilder) (*
 	execConfig.Sequencer.CaffNodeConfig.EspressoTEEVerifierAddr = existing.L1Info.GetAddress("EspressoTEEVerifierMock").Hex()
 	execConfig.Sequencer.CaffNodeConfig.ParentChainReader.Enable = true
 	execConfig.Sequencer.CaffNodeConfig.ParentChainReader.UseFinalityData = true
+	execConfig.Sequencer.CaffNodeConfig.RecordPerformance = true
 	// for testing, we can use the same hotshot url for both
 	execConfig.Sequencer.CaffNodeConfig.HotShotUrls = []string{hotShotUrl, hotShotUrl, hotShotUrl, hotShotUrl}
 	execConfig.Sequencer.CaffNodeConfig.RetryTime = time.Second * 1


### PR DESCRIPTION
* Use existing function to convert block number to message index

* Clean up logs

* Add perf recorder to check the performance of the caff node

* Persist hotshot number and current position

* small fixes

* cleanup