### PR TITLE
Keys manager in batch poster

### DIFF
--- a/arbnode/espresso_key_manager.go
+++ b/arbnode/espresso_key_manager.go
@@ -1,0 +1,77 @@
+package arbnode
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type EspressoKeyManagerInterface interface {
+	HasRegistered() bool
+	Registry(hotshotBlock uint64, signFunc func([]byte) ([]byte, error)) error
+	GetCurrentKey() []byte
+	Sign(message []byte) ([]byte, error)
+}
+
+var _ EspressoKeyManagerInterface = &EspressoKeyManager{}
+
+type EspressoKeyManager struct {
+	address common.Address
+	pubKey  []byte
+	privKey *ecdsa.PrivateKey
+
+	hasRegistered bool
+	client        *ethclient.Client
+}
+
+func NewEspressoKeyManager(registryAddr common.Address, client *ethclient.Client) *EspressoKeyManager {
+	privKey, err := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+
+	pubKey, ok := privKey.Public().(*ecdsa.PublicKey)
+	if !ok {
+		panic("failed to get public key")
+	}
+	pubKeyBytes := crypto.CompressPubkey(pubKey)
+
+	return &EspressoKeyManager{
+		address: registryAddr,
+		pubKey:  pubKeyBytes,
+		privKey: privKey,
+		client:  client,
+	}
+}
+
+func (k *EspressoKeyManager) HasRegistered() bool {
+	return k.hasRegistered
+}
+
+func (k *EspressoKeyManager) Registry(hotshotBlock uint64, signFunc func([]byte) ([]byte, error)) error {
+	if k.hasRegistered {
+		log.Info("EspressoKeyManager already registered")
+		return nil
+	}
+
+	_, err := signFunc(k.pubKey)
+	if err != nil {
+		return err
+	}
+
+	k.hasRegistered = true
+	return nil
+}
+
+func (k *EspressoKeyManager) GetCurrentKey() []byte {
+	return k.pubKey
+}
+
+func (k *EspressoKeyManager) Sign(message []byte) ([]byte, error) {
+	hash := crypto.Keccak256Hash(message)
+	return k.privKey.Sign(rand.Reader, hash.Bytes(), nil)
+}

--- a/arbnode/espresso_key_manager.go
+++ b/arbnode/espresso_key_manager.go
@@ -12,7 +12,7 @@ import (
 
 type EspressoKeyManagerInterface interface {
 	HasRegistered() bool
-	Registry(hotshotBlock uint64, signFunc func([]byte) ([]byte, error)) error
+	Registry(signFunc func([]byte) ([]byte, error)) error
 	GetCurrentKey() []byte
 	Sign(message []byte) ([]byte, error)
 }
@@ -52,7 +52,7 @@ func (k *EspressoKeyManager) HasRegistered() bool {
 	return k.hasRegistered
 }
 
-func (k *EspressoKeyManager) Registry(hotshotBlock uint64, signFunc func([]byte) ([]byte, error)) error {
+func (k *EspressoKeyManager) Registry(signFunc func([]byte) ([]byte, error)) error {
 	if k.hasRegistered {
 		log.Info("EspressoKeyManager already registered")
 		return nil

--- a/arbnode/espresso_key_manager_test.go
+++ b/arbnode/espresso_key_manager_test.go
@@ -6,11 +6,12 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type ecdsaSignature struct {

--- a/arbnode/espresso_key_manager_test.go
+++ b/arbnode/espresso_key_manager_test.go
@@ -1,0 +1,101 @@
+package arbnode
+
+import (
+	"crypto/ecdsa"
+	"encoding/asn1"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type ecdsaSignature struct {
+	R, S *big.Int
+}
+
+func TestEspressoKeyManager(t *testing.T) {
+	// Mock Ethereum client
+	mockClient := &ethclient.Client{}
+	registryAddr := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+
+	// Test initialization
+	t.Run("NewEspressoKeyManager", func(t *testing.T) {
+		km := NewEspressoKeyManager(registryAddr, mockClient)
+		require.NotNil(t, km, "Key manager should not be nil")
+		assert.Equal(t, registryAddr, km.address, "Registry address mismatch")
+		assert.NotEmpty(t, km.pubKey, "Public key should be set")
+		assert.NotNil(t, km.privKey, "Private key should be set")
+		assert.False(t, km.HasRegistered(), "Should not be registered initially")
+		assert.Equal(t, mockClient, km.client, "Client mismatch")
+	})
+
+	// Test HasRegistered and Registry
+	t.Run("Registry", func(t *testing.T) {
+		km := NewEspressoKeyManager(registryAddr, mockClient)
+		assert.False(t, km.HasRegistered(), "Should start unregistered")
+
+		// Mock sign function
+		called := false
+		signFunc := func(data []byte) ([]byte, error) {
+			called = true
+			assert.Equal(t, km.pubKey, data, "Sign function should receive public key")
+			return []byte("mock-signature"), nil
+		}
+
+		// First registration
+		err := km.Registry(signFunc)
+		require.NoError(t, err, "Registry should succeed")
+		assert.True(t, called, "Sign function should be called")
+		assert.True(t, km.HasRegistered(), "Should be registered after call")
+
+		// Second call (already registered)
+		called = false
+		err = km.Registry(signFunc)
+		require.NoError(t, err, "Registry should succeed when already registered")
+		assert.False(t, called, "Sign function should not be called again")
+	})
+
+	// Test GetCurrentKey
+	t.Run("GetCurrentKey", func(t *testing.T) {
+		km := NewEspressoKeyManager(registryAddr, mockClient)
+		pubKey := km.GetCurrentKey()
+		assert.NotEmpty(t, pubKey, "Public key should not be empty")
+		assert.Equal(t, km.pubKey, pubKey, "GetCurrentKey should match initialized pubKey")
+
+		// Verify it’s a compressed public key (33 bytes for secp256k1)
+		assert.Equal(t, 33, len(pubKey), "Public key should be compressed (33 bytes)")
+	})
+
+	// Test Sign
+	t.Run("Sign", func(t *testing.T) {
+		km := NewEspressoKeyManager(registryAddr, mockClient)
+		message := []byte("test-message")
+		signature, err := km.Sign(message)
+		require.NoError(t, err, "Sign should succeed")
+		assert.NotEmpty(t, signature, "Signature should not be empty")
+
+		// Check signature length (DER typically 70-72 bytes for secp256k1)
+		assert.GreaterOrEqual(t, len(signature), 70, "Signature should be at least 70 bytes (DER)")
+		assert.LessOrEqual(t, len(signature), 72, "Signature should be at most 72 bytes (DER)")
+
+		// Parse DER signature
+		var sig ecdsaSignature
+		rest, err := asn1.Unmarshal(signature, &sig)
+		require.NoError(t, err, "Should parse DER signature")
+		assert.Empty(t, rest, "Should consume entire signature")
+
+		// Verify r and s are non-zero
+		assert.NotZero(t, sig.R, "r should be non-zero")
+		assert.NotZero(t, sig.S, "s should be non-zero")
+
+		// Verify signature with public key
+		hash := crypto.Keccak256Hash(message)
+		pubKey := &km.privKey.PublicKey
+		valid := ecdsa.Verify(pubKey, hash.Bytes(), sig.R, sig.S)
+		assert.True(t, valid, "Signature should verify with public key")
+	})
+}

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1787,7 +1787,7 @@ func (s *TransactionStreamer) Start(ctxIn context.Context) error {
 	if s.lightClientReader != nil && s.espressoClient != nil {
 		if s.EspressoKeyManager != nil && !s.EspressoKeyManager.HasRegistered() {
 			// TODO: get the current hotshot block number
-			err := s.EspressoKeyManager.Registry(1, s.getAttestationQuote)
+			err := s.EspressoKeyManager.Registry(s.getAttestationQuote)
 			if err != nil {
 				log.Error("failed to register espresso key manager", "err", err)
 				return err

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -91,6 +91,7 @@ type TransactionStreamer struct {
 	// Public these fields for testing
 	EscapeHatchEnabled bool
 	UseEscapeHatch     bool
+	EspressoKeyManager EspressoKeyManagerInterface
 }
 
 type TransactionStreamerConfig struct {
@@ -1568,7 +1569,7 @@ func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) er
 			return fmt.Errorf("failed to build the hotshot transaction: a large message has exceeded the size limit or failed to get a message from storage")
 		}
 
-		payload, err = arbutil.SignHotShotPayload(payload, s.getAttestationQuote)
+		payload, err = arbutil.SignHotShotPayload(payload, s.EspressoKeyManager.Sign)
 		if err != nil {
 			return fmt.Errorf("failed to sign the hotshot payload %w", err)
 		}
@@ -1779,6 +1780,14 @@ func (s *TransactionStreamer) Start(ctxIn context.Context) error {
 	s.StopWaiter.Start(ctxIn, s)
 
 	if s.lightClientReader != nil && s.espressoClient != nil {
+		if s.EspressoKeyManager != nil && !s.EspressoKeyManager.HasRegistered() {
+			// TODO: get the current hotshot block number
+			err := s.EspressoKeyManager.Registry(1, s.getAttestationQuote)
+			if err != nil {
+				log.Error("failed to register espresso key manager", "err", err)
+				return err
+			}
+		}
 		err := stopwaiter.CallIterativelyWith[struct{}](&s.StopWaiterSafe, s.pollSubmittedTransactionForFinality, s.newSovereignTxNotifier)
 		if err != nil {
 			return err

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1569,7 +1569,12 @@ func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) er
 			return fmt.Errorf("failed to build the hotshot transaction: a large message has exceeded the size limit or failed to get a message from storage")
 		}
 
-		payload, err = arbutil.SignHotShotPayload(payload, s.EspressoKeyManager.Sign)
+		signFunc := s.getAttestationQuote
+		if s.EspressoKeyManager != nil {
+			signFunc = s.EspressoKeyManager.Sign
+		}
+
+		payload, err = arbutil.SignHotShotPayload(payload, signFunc)
 		if err != nil {
 			return fmt.Errorf("failed to sign the hotshot payload %w", err)
 		}


### PR DESCRIPTION
# This PR:

- creates a key pair when batch poster creates
- use the private key to sign the hotshot payload