### PR TITLE
Keys manager in batch poster

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,7 +10,7 @@
 [submodule "contracts"]
 	path = contracts
 	url = https://github.com/EspressoSystems/nitro-contracts.git
-	branch = celestia-integration
+	branch = celestia-feat-stateless-batcher
 [submodule "arbitrator/wasm-testsuite/testsuite"]
 	path = arbitrator/wasm-testsuite/testsuite
 	url = https://github.com/WebAssembly/testsuite.git

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -1147,7 +1147,7 @@ func (b *BatchPoster) encodeAddBatch(
 			return nil, nil, fmt.Errorf("failed to pack calldata without attestation quote: %w", err)
 		}
 
-		attestationQuote, err := b.streamer.EspressoKeyManager.SignBatch(calldata)
+		attestationQuote, err := b.streamer.getAttestationQuote(calldata)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get attestation quote: %w", err)
 		}

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -396,6 +396,14 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 		opts.Streamer.resubmitEspressoTxDeadline = opts.Config().ResubmitEspressoTxDeadline
 	}
 
+	espressoTEEVerifierCaller, err := bridgegen.NewEspressoTEEVerifier(
+		opts.DeployInfo.SequencerInbox,
+		opts.L1Reader.Client())
+	if err != nil {
+		return nil, err
+	}
+	opts.Streamer.EspressoKeyManager = NewEspressoKeyManager(espressoTEEVerifierCaller)
+
 	b := &BatchPoster{
 		l1Reader:           opts.L1Reader,
 		inbox:              opts.Inbox,

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -402,7 +402,7 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 	if err != nil {
 		return nil, err
 	}
-	opts.Streamer.EspressoKeyManager = NewEspressoKeyManager(espressoTEEVerifierCaller)
+	opts.Streamer.EspressoKeyManager = NewEspressoKeyManager(espressoTEEVerifierCaller, opts.Config().ParentChainWallet.PrivateKey)
 
 	b := &BatchPoster{
 		l1Reader:           opts.L1Reader,

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -402,7 +402,8 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 
 	// TODO: remove this once we have a real espresso verifier
 	espressoMock, err := mocksgen.NewEspressoTEEVerifierMock(
-		opts.DeployInfo.SequencerInbox,
+		// Fix here. Find out the TEEVerifier address
+		common.HexToAddress("0xA46C59ce2FCaF445F96f66F0411e06A94D34BF45"),
 		opts.L1Reader.Client())
 	if err != nil {
 		return nil, err

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -54,6 +54,7 @@ import (
 	"github.com/offchainlabs/nitro/util/blobs"
 	"github.com/offchainlabs/nitro/util/headerreader"
 	"github.com/offchainlabs/nitro/util/redisutil"
+	"github.com/offchainlabs/nitro/util/signature"
 	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
 
@@ -347,6 +348,8 @@ type BatchPosterOpts struct {
 	DAPWriters    []daprovider.Writer
 	ParentChainID *big.Int
 	DAPReaders    []daprovider.Reader
+
+	DataSigner signature.DataSignerFunc
 }
 
 func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, error) {

--- a/arbnode/espresso_key_manager.go
+++ b/arbnode/espresso_key_manager.go
@@ -94,8 +94,7 @@ func NewEspressoKeyManager(espressoTEEVerifierCaller EspressoTEEVerifierInterfac
 	}
 
 	if opts.DataSigner == nil {
-		// TODO: Fix this for tests
-		// panic("DataSigner is nil")
+		panic("DataSigner is nil")
 	}
 
 	return &EspressoKeyManager{

--- a/arbnode/espresso_key_manager.go
+++ b/arbnode/espresso_key_manager.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/offchainlabs/nitro/cmd/util"
 	"github.com/offchainlabs/nitro/solgen/go/mocksgen"
 	"github.com/offchainlabs/nitro/util/signature"
 )
@@ -90,21 +89,12 @@ func NewEspressoKeyManager(espressoTEEVerifierCaller EspressoTEEVerifierInterfac
 	}
 	pubKeyBytes := crypto.FromECDSAPub(pubKey)
 
-	wallet := opts.Config().ParentChainWallet
-
-	// We open the wallet again because we want to get the signer function, which isn't included in the batch poster opts.
-	l1TransactionOpts, dataSigner, err := util.OpenWallet("l1-batch-poster", &wallet, opts.ParentChainID)
-
-	if err != nil {
-		panic(err)
-	}
-
 	return &EspressoKeyManager{
 		pubKey:                    pubKeyBytes,
 		privKey:                   privKey,
-		batchPosterSigner:         dataSigner,
+		batchPosterSigner:         opts.DataSigner,
 		espressoTEEVerifierCaller: espressoTEEVerifierCaller,
-		batchPosterOpts:           l1TransactionOpts,
+		batchPosterOpts:           opts.TransactOpts,
 	}
 }
 

--- a/arbnode/espresso_key_manager.go
+++ b/arbnode/espresso_key_manager.go
@@ -1,0 +1,95 @@
+package arbnode
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type EspressoKeyManagerInterface interface {
+	HasRegistered() bool
+	Register(signFunc func([]byte) ([]byte, error)) error
+	GetCurrentKey() []byte
+	Sign(message []byte) ([]byte, error)
+}
+
+var _ EspressoKeyManagerInterface = &EspressoKeyManager{}
+
+type EspressoTEEVerifierInterface interface {
+	Verify(opts *bind.CallOpts, rawQuote []byte, reportDataHash [32]byte) error
+}
+
+type EspressoKeyManager struct {
+	espressoTEEVerifierCaller EspressoTEEVerifierInterface
+	pubKey                    []byte
+	privKey                   *ecdsa.PrivateKey
+
+	hasRegistered bool
+}
+
+func NewEspressoKeyManager(espressoTEEVerifierCaller EspressoTEEVerifierInterface) *EspressoKeyManager {
+	privKey, err := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+
+	pubKey, ok := privKey.Public().(*ecdsa.PublicKey)
+	if !ok {
+		panic("failed to get public key")
+	}
+	pubKeyBytes := crypto.CompressPubkey(pubKey)
+
+	return &EspressoKeyManager{
+		pubKey:                    pubKeyBytes,
+		privKey:                   privKey,
+		espressoTEEVerifierCaller: espressoTEEVerifierCaller,
+	}
+}
+
+func (k *EspressoKeyManager) HasRegistered() bool {
+	// TODO:
+	// signerAddr := crypto.PubkeyToAddress(*pubKey)
+	// err := k.espressoTEEVerifierCaller.registeredSigners(&bind.CallOpts{}, signerAddr, sgx)
+	return k.hasRegistered
+}
+
+func (k *EspressoKeyManager) Register(signFunc func([]byte) ([]byte, error)) error {
+	if k.hasRegistered {
+		log.Info("EspressoKeyManager already registered")
+		return nil
+	}
+
+	// TODO:
+	// pubKey, ok := k.privKey.Public().(*ecdsa.PublicKey)
+	// if !ok {
+	// 	panic("failed to get public key")
+	// }
+	// signerAddr := crypto.PubkeyToAddress(*pubKey)
+	// err := k.espressoTEEVerifierCaller.registerSigner(&bind.CallOpts{}, attestation, signerAddr, sgx)
+	var quote []byte
+	var hash [32]byte
+	err := k.espressoTEEVerifierCaller.Verify(&bind.CallOpts{}, quote, hash)
+	if err != nil {
+		return err
+	}
+
+	_, err1 := signFunc(k.pubKey)
+	if err1 != nil {
+		return err1
+	}
+
+	k.hasRegistered = true
+	return nil
+}
+
+func (k *EspressoKeyManager) GetCurrentKey() []byte {
+	return k.pubKey
+}
+
+func (k *EspressoKeyManager) Sign(message []byte) ([]byte, error) {
+	hash := crypto.Keccak256Hash(message)
+	return k.privKey.Sign(rand.Reader, hash.Bytes(), nil)
+}

--- a/arbnode/espresso_key_manager.go
+++ b/arbnode/espresso_key_manager.go
@@ -57,7 +57,7 @@ func (e *EspressoTEEVerifier) RegisterSigner(opts *bind.TransactOpts, attestatio
 		return errors.New("transaction failed")
 	}
 
-	log.Info("Register signer tx succeeded", "tx", tx.Hash())
+	log.Info("Register signer tx succeeded", "signer address", addr, "tx", tx.Hash())
 
 	return nil
 }

--- a/arbnode/espresso_key_manager_test.go
+++ b/arbnode/espresso_key_manager_test.go
@@ -1,0 +1,110 @@
+package arbnode
+
+import (
+	"crypto/ecdsa"
+	"encoding/asn1"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+type ecdsaSignature struct {
+	R, S *big.Int
+}
+
+type mockEspressoTEEVerifier struct {
+	mock.Mock
+}
+
+func (m *mockEspressoTEEVerifier) Verify(opts *bind.CallOpts, rawQuote []byte, reportDataHash [32]byte) error {
+	args := m.Called(opts, rawQuote, reportDataHash)
+	return args.Error(0)
+}
+
+func TestEspressoKeyManager(t *testing.T) {
+	mockEspressoTEEVerifierClient := new(mockEspressoTEEVerifier)
+	mockEspressoTEEVerifierClient.On("Verify", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	// mockVerifier, err := bridgegen.NewEspressoTEEVerifier(common.HexToAddress("0x0"), mockClient)
+	// assert.Equal(t, err, nil, "Mock should be created")
+
+	// Test initialization
+	t.Run("NewEspressoKeyManager", func(t *testing.T) {
+		km := NewEspressoKeyManager(mockEspressoTEEVerifierClient)
+		require.NotNil(t, km, "Key manager should not be nil")
+		assert.NotEmpty(t, km.pubKey, "Public key should be set")
+		assert.NotNil(t, km.privKey, "Private key should be set")
+		assert.False(t, km.HasRegistered(), "Should not be registered initially")
+	})
+
+	// Test HasRegistered and Registry
+	t.Run("Registry", func(t *testing.T) {
+		km := NewEspressoKeyManager(mockEspressoTEEVerifierClient)
+		assert.False(t, km.HasRegistered(), "Should start unregistered")
+
+		// Mock sign function
+		called := false
+		signFunc := func(data []byte) ([]byte, error) {
+			called = true
+			assert.Equal(t, km.pubKey, data, "Sign function should receive public key")
+			return []byte("mock-signature"), nil
+		}
+
+		// First registration
+		err := km.Register(signFunc)
+		require.NoError(t, err, "Registry should succeed")
+		assert.True(t, called, "Sign function should be called")
+		assert.True(t, km.HasRegistered(), "Should be registered after call")
+
+		// Second call (already registered)
+		called = false
+		err = km.Register(signFunc)
+		require.NoError(t, err, "Registry should succeed when already registered")
+		assert.False(t, called, "Sign function should not be called again")
+	})
+
+	// Test GetCurrentKey
+	t.Run("GetCurrentKey", func(t *testing.T) {
+		km := NewEspressoKeyManager(mockEspressoTEEVerifierClient)
+		pubKey := km.GetCurrentKey()
+		assert.NotEmpty(t, pubKey, "Public key should not be empty")
+		assert.Equal(t, km.pubKey, pubKey, "GetCurrentKey should match initialized pubKey")
+
+		// Verify it’s a compressed public key (33 bytes for secp256k1)
+		assert.Equal(t, 33, len(pubKey), "Public key should be compressed (33 bytes)")
+	})
+
+	// Test Sign
+	t.Run("Sign", func(t *testing.T) {
+		km := NewEspressoKeyManager(mockEspressoTEEVerifierClient)
+		message := []byte("test-message")
+		signature, err := km.Sign(message)
+		require.NoError(t, err, "Sign should succeed")
+		assert.NotEmpty(t, signature, "Signature should not be empty")
+
+		// Check signature length (DER typically 70-72 bytes for secp256k1)
+		assert.GreaterOrEqual(t, len(signature), 70, "Signature should be at least 70 bytes (DER)")
+		assert.LessOrEqual(t, len(signature), 72, "Signature should be at most 72 bytes (DER)")
+
+		// Parse DER signature
+		var sig ecdsaSignature
+		rest, err := asn1.Unmarshal(signature, &sig)
+		require.NoError(t, err, "Should parse DER signature")
+		assert.Empty(t, rest, "Should consume entire signature")
+
+		// Verify r and s are non-zero
+		assert.NotZero(t, sig.R, "r should be non-zero")
+		assert.NotZero(t, sig.S, "s should be non-zero")
+
+		// Verify signature with public key
+		hash := crypto.Keccak256Hash(message)
+		pubKey := &km.privKey.PublicKey
+		valid := ecdsa.Verify(pubKey, hash.Bytes(), sig.R, sig.S)
+		assert.True(t, valid, "Signature should verify with public key")
+	})
+}

--- a/arbnode/espresso_key_manager_test.go
+++ b/arbnode/espresso_key_manager_test.go
@@ -30,7 +30,7 @@ func (m *mockEspressoTEEVerifier) RegisterSigner(opts *bind.TransactOpts, attest
 func TestEspressoKeyManager(t *testing.T) {
 	privKey := "1234567890abcdef1234567890abcdef12345678000000000000000000000000"
 	mockEspressoTEEVerifierClient := new(mockEspressoTEEVerifier)
-	mockEspressoTEEVerifierClient.On("Verify", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockEspressoTEEVerifierClient.On("RegisterSigner", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	wallet := DefaultBatchPosterL1WalletConfig
 	wallet.PrivateKey = privKey
 	opts := &BatchPosterOpts{
@@ -44,7 +44,7 @@ func TestEspressoKeyManager(t *testing.T) {
 
 	// Test initialization
 	t.Run("NewEspressoKeyManager", func(t *testing.T) {
-		km := NewEspressoKeyManager(mockEspressoTEEVerifierClient, nil)
+		km := NewEspressoKeyManager(mockEspressoTEEVerifierClient, opts)
 		require.NotNil(t, km, "Key manager should not be nil")
 		assert.NotEmpty(t, km.pubKey, "Public key should be set")
 		assert.NotNil(t, km.privKey, "Private key should be set")
@@ -53,7 +53,7 @@ func TestEspressoKeyManager(t *testing.T) {
 
 	// Test HasRegistered and Registry
 	t.Run("Registry", func(t *testing.T) {
-		km := NewEspressoKeyManager(mockEspressoTEEVerifierClient, nil)
+		km := NewEspressoKeyManager(mockEspressoTEEVerifierClient, opts)
 		assert.False(t, km.HasRegistered(), "Should start unregistered")
 
 		// Mock sign function
@@ -84,8 +84,7 @@ func TestEspressoKeyManager(t *testing.T) {
 		assert.NotEmpty(t, pubKey, "Public key should not be empty")
 		assert.Equal(t, km.pubKey, pubKey, "GetCurrentKey should match initialized pubKey")
 
-		// Verify it’s a compressed public key (33 bytes for secp256k1)
-		assert.Equal(t, 33, len(pubKey), "Public key should be compressed (33 bytes)")
+		assert.Equal(t, 65, len(pubKey), "Public key should be 65 bytes")
 	})
 
 	// Test Sign

--- a/arbnode/espresso_key_manager_test.go
+++ b/arbnode/espresso_key_manager_test.go
@@ -28,14 +28,13 @@ func (m *mockEspressoTEEVerifier) Verify(opts *bind.CallOpts, rawQuote []byte, r
 }
 
 func TestEspressoKeyManager(t *testing.T) {
+	privKey := "1234567890abcdef1234567890abcdef12345678000000000000000000000000"
 	mockEspressoTEEVerifierClient := new(mockEspressoTEEVerifier)
 	mockEspressoTEEVerifierClient.On("Verify", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	// mockVerifier, err := bridgegen.NewEspressoTEEVerifier(common.HexToAddress("0x0"), mockClient)
-	// assert.Equal(t, err, nil, "Mock should be created")
 
 	// Test initialization
 	t.Run("NewEspressoKeyManager", func(t *testing.T) {
-		km := NewEspressoKeyManager(mockEspressoTEEVerifierClient)
+		km := NewEspressoKeyManager(mockEspressoTEEVerifierClient, privKey)
 		require.NotNil(t, km, "Key manager should not be nil")
 		assert.NotEmpty(t, km.pubKey, "Public key should be set")
 		assert.NotNil(t, km.privKey, "Private key should be set")
@@ -44,7 +43,7 @@ func TestEspressoKeyManager(t *testing.T) {
 
 	// Test HasRegistered and Registry
 	t.Run("Registry", func(t *testing.T) {
-		km := NewEspressoKeyManager(mockEspressoTEEVerifierClient)
+		km := NewEspressoKeyManager(mockEspressoTEEVerifierClient, privKey)
 		assert.False(t, km.HasRegistered(), "Should start unregistered")
 
 		// Mock sign function
@@ -70,7 +69,7 @@ func TestEspressoKeyManager(t *testing.T) {
 
 	// Test GetCurrentKey
 	t.Run("GetCurrentKey", func(t *testing.T) {
-		km := NewEspressoKeyManager(mockEspressoTEEVerifierClient)
+		km := NewEspressoKeyManager(mockEspressoTEEVerifierClient, privKey)
 		pubKey := km.GetCurrentKey()
 		assert.NotEmpty(t, pubKey, "Public key should not be empty")
 		assert.Equal(t, km.pubKey, pubKey, "GetCurrentKey should match initialized pubKey")
@@ -81,7 +80,7 @@ func TestEspressoKeyManager(t *testing.T) {
 
 	// Test Sign
 	t.Run("Sign", func(t *testing.T) {
-		km := NewEspressoKeyManager(mockEspressoTEEVerifierClient)
+		km := NewEspressoKeyManager(mockEspressoTEEVerifierClient, privKey)
 		message := []byte("test-message")
 		signature, err := km.Sign(message)
 		require.NoError(t, err, "Sign should succeed")
@@ -103,7 +102,7 @@ func TestEspressoKeyManager(t *testing.T) {
 
 		// Verify signature with public key
 		hash := crypto.Keccak256Hash(message)
-		pubKey := &km.privKey.PublicKey
+		pubKey := &km.batchPosterPrivKey.PublicKey
 		valid := ecdsa.Verify(pubKey, hash.Bytes(), sig.R, sig.S)
 		assert.True(t, valid, "Signature should verify with public key")
 	})

--- a/arbnode/espresso_key_manager_test.go
+++ b/arbnode/espresso_key_manager_test.go
@@ -60,7 +60,7 @@ func TestEspressoKeyManager(t *testing.T) {
 	t.Run("Registry", func(t *testing.T) {
 		mockEspressoTEEVerifierClient := new(mockEspressoTEEVerifier)
 		mockEspressoTEEVerifierClient.On("RegisterSigner", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockEspressoTEEVerifierClient.On("RegisteredSigners", mock.Anything, mock.Anything).Return(false, nil).Twice()
+		mockEspressoTEEVerifierClient.On("RegisteredSigners", mock.Anything, mock.Anything).Return(false, nil).Once()
 		mockEspressoTEEVerifierClient.On("RegisteredSigners", mock.Anything, mock.Anything).Return(true, nil).Maybe()
 		km := NewEspressoKeyManager(mockEspressoTEEVerifierClient, opts)
 		registered, _ := km.HasRegistered()
@@ -72,9 +72,7 @@ func TestEspressoKeyManager(t *testing.T) {
 			called = true
 			addr := crypto.PubkeyToAddress(*km.pubKey)
 			addrBytes := addr.Bytes()
-			var addrBytes32 [32]byte
-			copy(addrBytes32[:], addrBytes)
-			assert.Equal(t, addrBytes32[:], data, "Sign function should receive public key")
+			assert.Equal(t, addrBytes, data, "Sign function should receive public key")
 			return []byte("mock-signature"), nil
 		}
 

--- a/arbnode/espresso_key_manager_test.go
+++ b/arbnode/espresso_key_manager_test.go
@@ -15,10 +15,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-type ecdsaSignature struct {
-	R, S *big.Int
-}
-
 type mockEspressoTEEVerifier struct {
 	mock.Mock
 }

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -769,6 +769,8 @@ func createNodeImpl(
 			DAPWriters:    dapWriters,
 			ParentChainID: parentChainID,
 			DAPReaders:    dapReaders,
+
+			DataSigner: dataSigner,
 		})
 		if err != nil {
 			return nil, err

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1781,6 +1781,8 @@ func (s *TransactionStreamer) Start(ctxIn context.Context) error {
 
 	if s.lightClientReader != nil && s.espressoClient != nil {
 		err := stopwaiter.CallIterativelyWith[struct{}](&s.StopWaiterSafe, func(ctx context.Context, ignored struct{}) time.Duration {
+			// Find a better way to do this
+			// Not sure why if we don't wrap it in `call iteratively`, an error occurs in the e2e test
 			if !s.EspressoKeyManager.HasRegistered() {
 				err := s.EspressoKeyManager.Register(s.getAttestationQuote)
 				if err != nil {

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1780,19 +1780,9 @@ func (s *TransactionStreamer) Start(ctxIn context.Context) error {
 	s.StopWaiter.Start(ctxIn, s)
 
 	if s.lightClientReader != nil && s.espressoClient != nil {
-		err := stopwaiter.CallIterativelyWith[struct{}](&s.StopWaiterSafe, func(ctx context.Context, ignored struct{}) time.Duration {
-			// Find a better way to do this
-			// Not sure why if we don't wrap it in `call iteratively`, an error occurs in the e2e test
-			if !s.EspressoKeyManager.HasRegistered() {
-				err := s.EspressoKeyManager.Register(s.getAttestationQuote)
-				if err != nil {
-					log.Error("failed to register espresso key manager", "err", err)
-					return 10 * time.Second
-				}
-			}
-			return 100 * 24 * time.Hour
-		}, s.newSovereignTxNotifier)
+		err := s.EspressoKeyManager.Register(s.getAttestationQuote)
 		if err != nil {
+			log.Error("failed to register espresso key manager", "err", err)
 			return err
 		}
 		err = stopwaiter.CallIterativelyWith[struct{}](&s.StopWaiterSafe, s.pollSubmittedTransactionForFinality, s.newSovereignTxNotifier)

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -91,6 +91,7 @@ type TransactionStreamer struct {
 	// Public these fields for testing
 	EscapeHatchEnabled bool
 	UseEscapeHatch     bool
+	EspressoKeyManager EspressoKeyManagerInterface
 }
 
 type TransactionStreamerConfig struct {
@@ -1568,7 +1569,7 @@ func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) er
 			return fmt.Errorf("failed to build the hotshot transaction: a large message has exceeded the size limit or failed to get a message from storage")
 		}
 
-		payload, err = arbutil.SignHotShotPayload(payload, s.getAttestationQuote)
+		payload, err = arbutil.SignHotShotPayload(payload, s.EspressoKeyManager.Sign)
 		if err != nil {
 			return fmt.Errorf("failed to sign the hotshot payload %w", err)
 		}
@@ -1779,6 +1780,14 @@ func (s *TransactionStreamer) Start(ctxIn context.Context) error {
 	s.StopWaiter.Start(ctxIn, s)
 
 	if s.lightClientReader != nil && s.espressoClient != nil {
+		if !s.EspressoKeyManager.HasRegistered() {
+			// TODO: get the current hotshot block number
+			err := s.EspressoKeyManager.Register(s.getAttestationQuote)
+			if err != nil {
+				log.Error("failed to register espresso key manager", "err", err)
+				return err
+			}
+		}
 		err := stopwaiter.CallIterativelyWith[struct{}](&s.StopWaiterSafe, s.pollSubmittedTransactionForFinality, s.newSovereignTxNotifier)
 		if err != nil {
 			return err

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1569,7 +1569,7 @@ func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) er
 			return fmt.Errorf("failed to build the hotshot transaction: a large message has exceeded the size limit or failed to get a message from storage")
 		}
 
-		payload, err = arbutil.SignHotShotPayload(payload, s.EspressoKeyManager.Sign)
+		payload, err = arbutil.SignHotShotPayload(payload, s.EspressoKeyManager.SignHotShotPayload)
 		if err != nil {
 			return fmt.Errorf("failed to sign the hotshot payload %w", err)
 		}
@@ -1781,7 +1781,6 @@ func (s *TransactionStreamer) Start(ctxIn context.Context) error {
 
 	if s.lightClientReader != nil && s.espressoClient != nil {
 		if !s.EspressoKeyManager.HasRegistered() {
-			// TODO: get the current hotshot block number
 			err := s.EspressoKeyManager.Register(s.getAttestationQuote)
 			if err != nil {
 				log.Error("failed to register espresso key manager", "err", err)

--- a/system_tests/espresso_sovereign_sequencer_test.go
+++ b/system_tests/espresso_sovereign_sequencer_test.go
@@ -40,6 +40,7 @@ func createL1AndL2Node(
 	builder.nodeConfig.BatchPoster.LightClientAddress = lightClientAddress
 	builder.nodeConfig.BatchPoster.HotShotUrl = hotShotUrl
 	builder.nodeConfig.BatchPoster.UseEscapeHatch = false
+	builder.nodeConfig.BatchPoster.EspressoTeeVerifierAddress = "0xA46C59ce2FCaF445F96f66F0411e06A94D34BF45"
 
 	// validator config
 	builder.nodeConfig.BlockValidator.Enable = true


### PR DESCRIPTION
[Task](https://app.asana.com/1/1208976916964769/project/1209446932824128/task/1209479693847647)

### This PR:
- Signs the hotshot payload with batch poster's private key
- Registers ephemeral keys to L1, which will be used to sign batches
- Unit tests for the key manager
