### PR TITLE
Espresso streamer batch poster

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ run:
   timeout: 10m
 
 issues:
+  new: true
   exclude-dirs:
     - go-ethereum
     - fastcache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,1 @@
+/nix/store/xxdlf5l4h4s4aqrw3hxjicsj414bgq4i-pre-commit-config.json

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -32,8 +32,8 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 
-	hotshotClient "github.com/EspressoSystems/espresso-sequencer-go/client"
-	lightclient "github.com/EspressoSystems/espresso-sequencer-go/light-client"
+	hotshotClient "github.com/EspressoSystems/espresso-network-go/client"
+	lightclient "github.com/EspressoSystems/espresso-network-go/light-client"
 
 	"github.com/offchainlabs/nitro/arbnode/dataposter"
 	"github.com/offchainlabs/nitro/arbnode/dataposter/storage"
@@ -123,6 +123,7 @@ type BatchPoster struct {
 
 	accessList func(SequencerInboxAccs, AfterDelayedMessagesRead uint64) types.AccessList
   espressoStreamer *espressostreamer.EspressoStreamer
+  hotshotBlockNumberFromConfigOrRecentMsg uint64
 }
 type l1BlockBound int
 // This enum starts at 1 to avoid the empty initialization of 0 being valid
@@ -596,6 +597,16 @@ var EspressoValidationErr = errors.New("failed to check espresso validation")
 var EspressoFetchTransactionErr = errors.New("failed to fetch the espresso transaction")
 // Adds a block merkle proof to an Espresso justification, providing a proof that a set of transactions
 // hashes to some light client state root.
+
+func (b *BatchPoster) tryGetNextMessageForBatch() *arbostypes.MessageWithMetadata {
+	streamerMsg, err := b.espressoStreamer.Next()
+	if err != nil {
+		log.Info("Espresso Streamer was not able to produce the next message", "err", err)
+		return &arbostypes.MessageWithMetadata{}
+	}
+	return &streamerMsg.MessageWithMeta
+}
+
 func (b *BatchPoster) checkEspressoValidation() bool {
 	b.building.segments.SetWaitingForValidation()
 	if b.streamer.espressoClient == nil && b.streamer.lightClientReader == nil {
@@ -1263,6 +1274,7 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 		return false, fmt.Errorf("attempting to post batch %v, but the local inbox tracker database already has %v batches", batchPosition.NextSeqNum, dbBatchCount)
 	}
 	if b.building == nil || b.building.startMsgCount != batchPosition.MessageCount {
+		b.espressoStreamer.Reset(uint64(batchPosition.MessageCount), b.hotshotBlockNumberFromConfigOrRecentMsg)
 		latestHeader, err := b.l1Reader.LastHeader(ctx)
 		if err != nil {
 			return false, err
@@ -1320,7 +1332,6 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 		// There's nothing after the newest batch, therefore batch posting was not required
 		return false, nil
 	}
-	lastPotentialMsg, err := b.streamer.GetMessage(msgCount - 1)
 	if err != nil {
 
 		return false, err
@@ -1396,12 +1407,23 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 			l1BoundMinTimestampWithBypass = arbmath.SaturatingUSub(timestampWithPadding, arbmath.BigToUintSaturating(maxTimeVariationDelaySeconds))
 		}
 	}
-
-	for b.building.msgCount < msgCount {
-		msg, err := b.streamer.GetMessage(b.building.msgCount)
-		if err != nil {
-			return false, fmt.Errorf("error getting message from streamer: %w", err)
-		}
+  var lastPotentialMsg *arbostypes.MessageWithMetadata
+	for {
+    msg := b.tryGetNextMessageForBatch()
+    lastPotentialMsg = msg
+    if msg == (&arbostypes.MessageWithMetadata{}){
+      if b.building.haveUsefulMessage{
+        // if we have a useful message, break from the batch building loop.
+        // the batcher will then check if the first useful message is older than the max delay.
+        // If it is, we will attempt to post the batch, otherwise, it will re-try this function and potentially add more messages to the batch.
+        break
+      } else {
+        // If we don't have a first useful message, we should wait for a small duration, and poll then espressoStreamer
+        // Till we add a message to the batch. 
+        time.Sleep(time.Second/2) //TODO: make this a configurable polling interval.
+        continue
+      }
+    }	
 
 		if msg.Message.Header.BlockNumber < l1BoundMinBlockNumberWithBypass || msg.Message.Header.Timestamp < l1BoundMinTimestampWithBypass {
 			log.Warn(
@@ -1676,7 +1698,10 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 	} else {
 		b.non4844BatchCount++
 	}
-	unpostedMessages := msgCount - b.building.msgCount
+  // This is roughly equivalent to the amount of messages in the transaction streamer - the number of messages in the batch.
+  // It might be slightly inaccurate compared to nitros default method, but this only affects the batch compression
+  // and gas estimation, so a best effort estimate is fine. 
+	unpostedMessages := b.espressoStreamer.GetMessageCount()
 	messagesPerBatch := b.messagesPerBatch.Average()
 	if messagesPerBatch == 0 {
 		// This should be impossible because we always post at least one message in a batch.
@@ -1733,6 +1758,7 @@ func (b *BatchPoster) GetBacklogEstimate() uint64 {
 	return b.backlog.Load()
 }
 func (b *BatchPoster) Start(ctxIn context.Context) {
+	b.hotshotBlockNumberFromConfigOrRecentMsg = b.config().HotShotBlock
 	b.dataPoster.Start(ctxIn)
 	b.redisLock.Start(ctxIn)
 	b.StopWaiter.Start(ctxIn, b)

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -1,8 +1,6 @@
 // Copyright 2021-2022, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
-
 package arbnode
-
 import (
 	"bytes"
 	"context"
@@ -58,7 +56,6 @@ import (
 	"github.com/offchainlabs/nitro/util/signature"
 	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
-
 var (
 	batchPosterWalletBalance      = metrics.NewRegisteredGaugeFloat64("arb/batchposter/wallet/eth", nil)
 	batchPosterGasRefunderBalance = metrics.NewRegisteredGaugeFloat64("arb/batchposter/gasrefunder/eth", nil)
@@ -80,7 +77,6 @@ var (
 	usableBytesInBlob    = big.NewInt(int64(len(kzg4844.Blob{}) * 31 / 32))
 	blobTxBlobGasPerBlob = big.NewInt(params.BlobTxBlobGasPerBlob)
 )
-
 const (
 	batchPosterSimpleRedisLockKey = "node.batch-poster.redis-lock.simple-lock-key"
 	// oldSequencerBatchPostMethodName uses automatically generated solidity function
@@ -90,13 +86,11 @@ const (
 	sequencerBatchPostWithBlobsMethodName = "addSequencerL2BatchFromBlobs"
 	espressoTransactionSizeLimit          = 900 * 1024
 )
-
 type batchPosterPosition struct {
 	MessageCount        arbutil.MessageIndex
 	DelayedMessageCount uint64
 	NextSeqNum          uint64
 }
-
 type BatchPoster struct {
 	stopwaiter.StopWaiter
 	l1Reader           *headerreader.HeaderReader
@@ -130,9 +124,7 @@ type BatchPoster struct {
 	accessList func(SequencerInboxAccs, AfterDelayedMessagesRead uint64) types.AccessList
   espressoStreamer *espressostreamer.EspressoStreamer
 }
-
 type l1BlockBound int
-
 // This enum starts at 1 to avoid the empty initialization of 0 being valid
 const (
 	// Default is Safe if the L1 reader has finality data enabled, otherwise Latest
@@ -142,11 +134,9 @@ const (
 	l1BlockBoundLatest
 	l1BlockBoundIgnore
 )
-
 type BatchPosterDangerousConfig struct {
 	AllowPostingFirstBatchWhenSequencerMessageCountMismatch bool `koanf:"allow-posting-first-batch-when-sequencer-message-count-mismatch"`
 }
-
 type BatchPosterConfig struct {
 	Enable                             bool `koanf:"enable"`
 	DisableDapFallbackStoreDataOnChain bool `koanf:"disable-dap-fallback-store-data-on-chain" reload:"hot"`
@@ -185,7 +175,6 @@ type BatchPosterConfig struct {
 	// Espresso specific flags
 	EspressoTeeVerifierAddress  string        `koanf:"espresso-tee-verifier-address"`
 	LightClientAddress          string        `koanf:"light-client-address"`
-	EspressoTEEVerifierAddr     string        `koanf:"espresso-tee-verifier-address"`
 	HotShotUrls                 []string      `koanf:"hotshot-urls"`
 	HotShotBlock                uint64        `koanf:"hotshot-block"`
 	UseEscapeHatch              bool          `koanf:"use-escape-hatch"`
@@ -198,7 +187,6 @@ type BatchPosterConfig struct {
 	// Default: 350 blocks (~1 hour at 12s block time)
 	MaxBlockLagBeforeEscapeHatch uint64 `koanf:"max-block-lag-before-escape-hatch"`
 }
-
 func (c *BatchPosterConfig) Validate() error {
 	if len(c.HotShotUrls) == 0 {
 		return errors.New("HotShotUrls must not be empty")
@@ -237,13 +225,10 @@ func (c *BatchPosterConfig) Validate() error {
 	}
 	return nil
 }
-
 type BatchPosterConfigFetcher func() *BatchPosterConfig
-
 func DangerousBatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Bool(prefix+".allow-posting-first-batch-when-sequencer-message-count-mismatch", DefaultBatchPosterConfig.Dangerous.AllowPostingFirstBatchWhenSequencerMessageCountMismatch, "allow posting the first batch even if sequence number doesn't match chain (useful after force-inclusion)")
 }
-
 func BatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Bool(prefix+".enable", DefaultBatchPosterConfig.Enable, "enable posting batches to l1")
 	f.Bool(prefix+".disable-dap-fallback-store-data-on-chain", DefaultBatchPosterConfig.DisableDapFallbackStoreDataOnChain, "If unable to batch to DA provider, disable fallback storing data on chain")
@@ -266,7 +251,6 @@ func BatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.String(prefix+".espresso-tee-verifier-address", DefaultBatchPosterConfig.EspressoTeeVerifierAddress, "The Espresso TEE Verifier contract address")
 	f.StringArray(prefix+".hotshot-urls", DefaultBatchPosterConfig.HotShotUrls, "specifies the hotshot urls if we are batching in espresso mode")
 	f.String(prefix+".light-client-address", DefaultBatchPosterConfig.LightClientAddress, "specifies the hotshot light client address if we are batching in espresso mode")
-	f.String(prefix+".espresso-tee-verifier-address", DefaultBatchPosterConfig.EspressoTEEVerifierAddr, "specifies the address of the espresso tee verifier contract that is used to verify messages read by the espresso streamer")
 	f.Uint64(prefix+".gas-estimate-base-fee-multiple-bips", uint64(DefaultBatchPosterConfig.GasEstimateBaseFeeMultipleBips), "for gas estimation, use this multiple of the basefee (measured in basis points) as the max fee per gas")
 	f.Duration(prefix+".reorg-resistance-margin", DefaultBatchPosterConfig.ReorgResistanceMargin, "do not post batch if its within this duration from layer 1 minimum bounds. Requires l1-block-bound option not be set to \"ignore\"")
 	f.Bool(prefix+".check-batch-correctness", DefaultBatchPosterConfig.CheckBatchCorrectness, "setting this to true will run the batch against an inbox multiplexer and verifies that it produces the correct set of messages")
@@ -280,13 +264,12 @@ func BatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	genericconf.WalletConfigAddOptions(prefix+".parent-chain-wallet", f, DefaultBatchPosterConfig.ParentChainWallet.Pathname)
 	DangerousBatchPosterConfigAddOptions(prefix+".dangerous", f)
 }
-
 var DefaultBatchPosterConfig = BatchPosterConfig{
 	Enable:                             false,
 	DisableDapFallbackStoreDataOnChain: false,
-	// This default is overridden for L3 chains in applyChainParameters in cmd/nitro/nitro.go
+	// This default is overridden for L3 chains in applyChainParameters in cmd/nitro/nitro.go,
 	MaxSize: 100000,
-	// Try to fill 3 blobs per batch
+	// Try to fill 3 blobs per batch,
 	Max4844BatchSize:               blobs.BlobEncodableData*(params.MaxBlobGasPerBlock/params.BlobTxBlobGasPerBlob)/2 - 2000,
 	PollInterval:                   time.Second * 10,
 	ErrorDelay:                     time.Second * 10,
@@ -314,8 +297,10 @@ var DefaultBatchPosterConfig = BatchPosterConfig{
 	LightClientAddress:             "",
 	HotShotUrls:                    []string{""},
 	MaxEmptyBatchDelay:             3 * 24 * time.Hour,
+	// This default is overridden for L3 chains in applyChainParameters in cmd/nitro/nitro.go,
+	// Try to fill 3 blobs per batch,
+	HotShotBlock: 1,
 }
-
 var DefaultBatchPosterL1WalletConfig = genericconf.WalletConfig{
 	Pathname:      "batch-poster-wallet",
 	Password:      genericconf.WalletConfigDefault.Password,
@@ -323,7 +308,6 @@ var DefaultBatchPosterL1WalletConfig = genericconf.WalletConfig{
 	Account:       genericconf.WalletConfigDefault.Account,
 	OnlyCreateKey: genericconf.WalletConfigDefault.OnlyCreateKey,
 }
-
 var TestBatchPosterConfig = BatchPosterConfig{
 	Enable:                         true,
 	MaxSize:                        100000,
@@ -352,7 +336,6 @@ var TestBatchPosterConfig = BatchPosterConfig{
 	HotShotUrls:                    []string{""},
 	ResubmitEspressoTxDeadline:     10 * time.Second,
 }
-
 type BatchPosterOpts struct {
 	DataPosterDB  ethdb.Database
 	L1Reader      *headerreader.HeaderReader
@@ -370,7 +353,6 @@ type BatchPosterOpts struct {
 
 	DataSigner signature.DataSignerFunc
 }
-
 func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, error) {
 	seqInbox, err := bridgegen.NewSequencerInbox(opts.DeployInfo.SequencerInbox, opts.L1Reader.Client())
 	if err != nil {
@@ -422,7 +404,8 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 		opts.Streamer.resubmitEspressoTxDeadline = opts.Config().ResubmitEspressoTxDeadline
 	}
 
-	if opts.Config().EspressoTeeVerifierAddress != "" {
+	var espressoStreamer *espressostreamer.EspressoStreamer
+	if opts.Config().EspressoTeeVerifierAddress != "" && opts.Streamer.espressoClient != nil {
 		espressoTeeVerifierAddress := common.HexToAddress(opts.Config().EspressoTeeVerifierAddress)
 		// TODO: remove this once we have a real espresso verifier
 		espressoMock, err := mocksgen.NewEspressoTEEVerifierMock(
@@ -431,8 +414,24 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 		if err != nil {
 			return nil, err
 		}
+
 		verifier := NewEspressoTEEVerifier(espressoMock, opts.L1Reader.Client())
 		opts.Streamer.EspressoKeyManager = NewEspressoKeyManager(verifier, opts)
+
+		espressoTEEVerifierCaller, err := bridgegen.NewEspressoTEEVerifier(
+			common.HexToAddress(opts.Config().EspressoTeeVerifierAddress),
+			opts.L1Reader.Client())
+		if err != nil {
+			return nil, err
+		}
+		espressoStreamer = espressostreamer.NewEspressoStreamer(
+			opts.ChainID,
+			opts.Config().HotShotBlock,
+			opts.Config().ResubmitEspressoTxDeadline,
+			opts.Streamer.espressoTxnsPollingInterval,
+			espressoTEEVerifierCaller,
+			opts.Streamer.espressoClient,
+		)
 	}
 
 	b := &BatchPoster{
@@ -493,17 +492,13 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 	}
 	return b, nil
 }
-
 type simulatedBlobReader struct {
 	blobs []kzg4844.Blob
 }
-
 func (b *simulatedBlobReader) GetBlobs(ctx context.Context, batchBlockHash common.Hash, versionedHashes []common.Hash) ([]kzg4844.Blob, error) {
 	return b.blobs, nil
 }
-
 func (b *simulatedBlobReader) Initialize(ctx context.Context) error { return nil }
-
 type simulatedMuxBackend struct {
 	batchSeqNum           uint64
 	positionWithinMessage uint64
@@ -512,16 +507,13 @@ type simulatedMuxBackend struct {
 	delayedInboxStart     uint64
 	delayedInbox          []*arbostypes.MessageWithMetadata
 }
-
 func (b *simulatedMuxBackend) PeekSequencerInbox() ([]byte, common.Hash, error) {
 	return b.seqMsg, common.Hash{}, nil
 }
-
 func (b *simulatedMuxBackend) GetSequencerInboxPosition() uint64   { return b.batchSeqNum }
 func (b *simulatedMuxBackend) AdvanceSequencerInbox()              {}
 func (b *simulatedMuxBackend) GetPositionWithinMessage() uint64    { return b.positionWithinMessage }
 func (b *simulatedMuxBackend) SetPositionWithinMessage(pos uint64) { b.positionWithinMessage = pos }
-
 func (b *simulatedMuxBackend) ReadDelayedInbox(seqNum uint64) (*arbostypes.L1IncomingMessage, error) {
 	pos := arbmath.SaturatingUSub(seqNum, b.delayedInboxStart)
 	if pos < uint64(len(b.delayedInbox)) {
@@ -529,7 +521,6 @@ func (b *simulatedMuxBackend) ReadDelayedInbox(seqNum uint64) (*arbostypes.L1Inc
 	}
 	return nil, fmt.Errorf("error serving ReadDelayedInbox, all delayed messages were read. Requested delayed message position:%d, Total delayed messages: %d", pos, len(b.delayedInbox))
 }
-
 type AccessListOpts struct {
 	SequencerInboxAddr       common.Address
 	BridgeAddr               common.Address
@@ -538,7 +529,6 @@ type AccessListOpts struct {
 	SequencerInboxAccs       uint64
 	AfterDelayedMessagesRead uint64
 }
-
 // AccessList returns access list (contracts, storage slots) for batchposter.
 func AccessList(opts *AccessListOpts) types.AccessList {
 	l := types.AccessList{
@@ -602,10 +592,8 @@ func AccessList(opts *AccessListOpts) types.AccessList {
 	}
 	return l
 }
-
 var EspressoValidationErr = errors.New("failed to check espresso validation")
 var EspressoFetchTransactionErr = errors.New("failed to fetch the espresso transaction")
-
 // Adds a block merkle proof to an Espresso justification, providing a proof that a set of transactions
 // hashes to some light client state root.
 func (b *BatchPoster) checkEspressoValidation() bool {
@@ -632,7 +620,6 @@ func (b *BatchPoster) checkEspressoValidation() bool {
 	// If we aren't skipping validation for this batch, or we can't validate the proofs, we need to retry.
 	return false
 }
-
 type txInfo struct {
 	Hash      common.Hash       `json:"hash"`
 	Nonce     hexutil.Uint64    `json:"nonce"`
@@ -646,7 +633,6 @@ type txInfo struct {
 	Value     *hexutil.Big      `json:"value"`
 	Accesses  *types.AccessList `json:"accessList,omitempty"`
 }
-
 // getTxsInfoByBlock fetches all the transactions inside block of id 'number' using json rpc
 // and returns an array of txInfo which has fields that are necessary in checking for batch reverts
 func (b *BatchPoster) getTxsInfoByBlock(ctx context.Context, number int64) ([]txInfo, error) {
@@ -661,7 +647,6 @@ func (b *BatchPoster) getTxsInfoByBlock(ctx context.Context, number int64) ([]tx
 	}
 	return blk.Transactions, nil
 }
-
 // checkRevert checks blocks with number in range [from, to] whether they
 // contain reverted batch_poster transaction.
 // It returns true if it finds batch posting needs to halt, which is true if a batch reverts
@@ -710,7 +695,6 @@ func (b *BatchPoster) checkReverts(ctx context.Context, to int64) (bool, error) 
 	}
 	return false, nil
 }
-
 func (b *BatchPoster) pollForL1PriceData(ctx context.Context) {
 	headerCh, unsubscribe := b.l1Reader.Subscribe(false)
 	defer unsubscribe()
@@ -755,7 +739,6 @@ func (b *BatchPoster) pollForL1PriceData(ctx context.Context) {
 		}
 	}
 }
-
 // pollForReverts runs a gouroutine that listens to l1 block headers, checks
 // if any transaction made by batch poster was reverted.
 func (b *BatchPoster) pollForReverts(ctx context.Context) {
@@ -807,7 +790,6 @@ func (b *BatchPoster) pollForReverts(ctx context.Context) {
 		}
 	}
 }
-
 func (b *BatchPoster) getBatchPosterPosition(ctx context.Context, blockNum *big.Int) ([]byte, error) {
 	bigInboxBatchCount, err := b.seqInbox.BatchCount(&bind.CallOpts{Context: ctx, BlockNumber: blockNum})
 	if err != nil {
@@ -828,9 +810,7 @@ func (b *BatchPoster) getBatchPosterPosition(ctx context.Context, blockNum *big.
 		NextSeqNum:          inboxBatchCount,
 	})
 }
-
 var errBatchAlreadyClosed = errors.New("batch segments already closed")
-
 type batchSegments struct {
 	compressedBuffer               *bytes.Buffer
 	compressedWriter               *brotli.Writer
@@ -847,7 +827,6 @@ type batchSegments struct {
 	isDone                         bool
 	isWaitingForEspressoValidation bool // We are waiting for the entirety of the batch to be validated by espresso. Should be false by default
 }
-
 type buildingBatch struct {
 	segments           *batchSegments
 	startMsgCount      arbutil.MessageIndex
@@ -858,7 +837,6 @@ type buildingBatch struct {
 	firstNonDelayedMsg *arbostypes.MessageWithMetadata
 	firstUsefulMsg     *arbostypes.MessageWithMetadata
 }
-
 func newBatchSegments(firstDelayed uint64, config *BatchPosterConfig, backlog uint64, use4844 bool) *batchSegments {
 	maxSize := config.MaxSize
 	if use4844 {
@@ -899,7 +877,6 @@ func newBatchSegments(firstDelayed uint64, config *BatchPosterConfig, backlog ui
 		delayedMsg:         firstDelayed,
 	}
 }
-
 func (s *batchSegments) recompressAll() error {
 	s.compressedBuffer = bytes.NewBuffer(make([]byte, 0, s.sizeLimit*2))
 	s.compressedWriter = brotli.NewWriterLevel(s.compressedBuffer, s.recompressionLevel)
@@ -919,7 +896,6 @@ func (s *batchSegments) recompressAll() error {
 	}
 	return nil
 }
-
 func (s *batchSegments) testForOverflow(isHeader bool) (bool, error) {
 	// we've reached the max decompressed size
 	if s.totalUncompressedSize > arbstate.MaxDecompressedLen {
@@ -948,7 +924,6 @@ func (s *batchSegments) testForOverflow(isHeader bool) (bool, error) {
 	}
 	return false, nil
 }
-
 func (s *batchSegments) close() error {
 	s.rawSegments = s.rawSegments[:len(s.rawSegments)-s.trailingHeaders]
 	s.trailingHeaders = 0
@@ -959,7 +934,6 @@ func (s *batchSegments) close() error {
 	s.isDone = true
 	return nil
 }
-
 func (s *batchSegments) addSegmentToCompressed(segment []byte) error {
 	encoded, err := rlp.EncodeToBytes(segment)
 	if err != nil {
@@ -970,7 +944,6 @@ func (s *batchSegments) addSegmentToCompressed(segment []byte) error {
 	s.totalUncompressedSize += lenWritten
 	return err
 }
-
 // returns false if segment was too large, error in case of real error
 func (s *batchSegments) addSegment(segment []byte, isHeader bool) (bool, error) {
 	if s.isDone {
@@ -996,14 +969,12 @@ func (s *batchSegments) addSegment(segment []byte, isHeader bool) (bool, error) 
 	}
 	return true, nil
 }
-
 func (s *batchSegments) addL2Msg(l2msg []byte) (bool, error) {
 	segment := make([]byte, 1, len(l2msg)+1)
 	segment[0] = arbstate.BatchSegmentKindL2Message
 	segment = append(segment, l2msg...)
 	return s.addSegment(segment, false)
 }
-
 func (s *batchSegments) prepareIntSegment(val uint64, segmentHeader byte) ([]byte, error) {
 	segment := make([]byte, 1, 16)
 	segment[0] = segmentHeader
@@ -1013,7 +984,6 @@ func (s *batchSegments) prepareIntSegment(val uint64, segmentHeader byte) ([]byt
 	}
 	return append(segment, enc...), nil
 }
-
 func (s *batchSegments) maybeAddDiffSegment(base *uint64, newVal uint64, segmentHeader byte) (bool, error) {
 	if newVal == *base {
 		return true, nil
@@ -1029,7 +999,6 @@ func (s *batchSegments) maybeAddDiffSegment(base *uint64, newVal uint64, segment
 	}
 	return success, err
 }
-
 func (s *batchSegments) addDelayedMessage() (bool, error) {
 	segment := []byte{arbstate.BatchSegmentKindDelayedMessages}
 	success, err := s.addSegment(segment, false)
@@ -1038,7 +1007,6 @@ func (s *batchSegments) addDelayedMessage() (bool, error) {
 	}
 	return success, err
 }
-
 func (s *batchSegments) AddMessage(msg *arbostypes.MessageWithMetadata) (bool, error) {
 
 	if s.isWaitingForEspressoValidation {
@@ -1065,11 +1033,9 @@ func (s *batchSegments) AddMessage(msg *arbostypes.MessageWithMetadata) (bool, e
 	}
 	return s.addL2Msg(msg.Message.L2msg)
 }
-
 func (s *batchSegments) IsDone() bool {
 	return s.isDone
 }
-
 // Returns nil (as opposed to []byte{}) if there's no segments to put in the batch
 func (s *batchSegments) CloseAndGetBytes() ([]byte, error) {
 	if !s.isDone {
@@ -1091,7 +1057,6 @@ func (s *batchSegments) CloseAndGetBytes() ([]byte, error) {
 	fullMsg = append(fullMsg, compressedBytes...)
 	return fullMsg, nil
 }
-
 // Make the batch wait for validation Add this so we don't need to export the structs state to set it as we shouldn't need to set it to false again.
 func (s *batchSegments) SetWaitingForValidation() {
 	if !s.isWaitingForEspressoValidation {
@@ -1184,9 +1149,7 @@ func (b *BatchPoster) encodeAddBatch(
 
 	return fullCalldata, kzgBlobs, nil
 }
-
 var ErrNormalGasEstimationFailed = errors.New("normal gas estimation failed")
-
 type estimateGasParams struct {
 	From         common.Address   `json:"from"`
 	To           *common.Address  `json:"to"`
@@ -1195,13 +1158,11 @@ type estimateGasParams struct {
 	AccessList   types.AccessList `json:"accessList"`
 	BlobHashes   []common.Hash    `json:"blobVersionedHashes,omitempty"`
 }
-
 func estimateGas(client rpc.ClientInterface, ctx context.Context, params estimateGasParams) (uint64, error) {
 	var gas hexutil.Uint64
 	err := client.CallContext(ctx, &gas, "eth_estimateGas", params)
 	return uint64(gas), err
 }
-
 func (b *BatchPoster) estimateGas(ctx context.Context, sequencerMessage []byte, delayedMessages uint64, realData []byte, realBlobs []kzg4844.Blob, realNonce uint64, realAccessList types.AccessList) (uint64, error) {
 	config := b.config()
 	rpcClient := b.l1Reader.Client()
@@ -1278,11 +1239,8 @@ func (b *BatchPoster) estimateGas(ctx context.Context, sequencerMessage []byte, 
 	}
 	return gas + config.ExtraBatchGas, nil
 }
-
 const ethPosBlockTime = 12 * time.Second
-
 var errAttemptLockFailed = errors.New("failed to acquire lock; either another batch poster posted a batch or this node fell behind")
-
 func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error) {
 	if b.batchReverted.Load() {
 		return false, fmt.Errorf("batch was reverted, not posting any more batches")
@@ -1771,11 +1729,9 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 
 	return true, nil
 }
-
 func (b *BatchPoster) GetBacklogEstimate() uint64 {
 	return b.backlog.Load()
 }
-
 func (b *BatchPoster) Start(ctxIn context.Context) {
 	b.dataPoster.Start(ctxIn)
 	b.redisLock.Start(ctxIn)
@@ -1858,24 +1814,20 @@ func (b *BatchPoster) Start(ctxIn context.Context) {
 		}
 	})
 }
-
 func (b *BatchPoster) StopAndWait() {
 	b.StopWaiter.StopAndWait()
 	b.dataPoster.StopAndWait()
 	b.redisLock.StopAndWait()
 }
-
 type BoolRing struct {
 	buffer         []bool
 	bufferPosition int
 }
-
 func NewBoolRing(size int) *BoolRing {
 	return &BoolRing{
 		buffer: make([]bool, 0, size),
 	}
 }
-
 func (b *BoolRing) Update(value bool) {
 	period := cap(b.buffer)
 	if period == 0 {
@@ -1888,11 +1840,9 @@ func (b *BoolRing) Update(value bool) {
 	}
 	b.bufferPosition = (b.bufferPosition + 1) % period
 }
-
 func (b *BoolRing) Empty() bool {
 	return len(b.buffer) == 0
 }
-
 // Peek returns the most recently inserted value.
 // Assumes not empty, check Empty() first
 func (b *BoolRing) Peek() bool {
@@ -1904,7 +1854,6 @@ func (b *BoolRing) Peek() bool {
 	}
 	return b.buffer[lastPosition]
 }
-
 // All returns true if the BoolRing is full and all values equal value.
 func (b *BoolRing) All(value bool) bool {
 	if len(b.buffer) < cap(b.buffer) {

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -46,6 +46,7 @@ import (
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/cmd/chaininfo"
 	"github.com/offchainlabs/nitro/cmd/genericconf"
+	"github.com/offchainlabs/nitro/espressostreamer"
 	"github.com/offchainlabs/nitro/execution"
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
 	"github.com/offchainlabs/nitro/solgen/go/mocksgen"
@@ -127,6 +128,7 @@ type BatchPoster struct {
 	postedFirstBatch     bool        // indicates if batch poster has posted the first batch
 
 	accessList func(SequencerInboxAccs, AfterDelayedMessagesRead uint64) types.AccessList
+  espressoStreamer *espressostreamer.EspressoStreamer
 }
 
 type l1BlockBound int
@@ -183,7 +185,9 @@ type BatchPosterConfig struct {
 	// Espresso specific flags
 	EspressoTeeVerifierAddress  string        `koanf:"espresso-tee-verifier-address"`
 	LightClientAddress          string        `koanf:"light-client-address"`
+	EspressoTEEVerifierAddr     string        `koanf:"espresso-tee-verifier-address"`
 	HotShotUrls                 []string      `koanf:"hotshot-urls"`
+	HotShotBlock                uint64        `koanf:"hotshot-block"`
 	UseEscapeHatch              bool          `koanf:"use-escape-hatch"`
 	EspressoTxnsPollingInterval time.Duration `koanf:"espresso-txns-polling-interval"`
 	ResubmitEspressoTxDeadline  time.Duration `koanf:"resubmit-espresso-tx-deadline"`
@@ -262,6 +266,7 @@ func BatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.String(prefix+".espresso-tee-verifier-address", DefaultBatchPosterConfig.EspressoTeeVerifierAddress, "The Espresso TEE Verifier contract address")
 	f.StringArray(prefix+".hotshot-urls", DefaultBatchPosterConfig.HotShotUrls, "specifies the hotshot urls if we are batching in espresso mode")
 	f.String(prefix+".light-client-address", DefaultBatchPosterConfig.LightClientAddress, "specifies the hotshot light client address if we are batching in espresso mode")
+	f.String(prefix+".espresso-tee-verifier-address", DefaultBatchPosterConfig.EspressoTEEVerifierAddr, "specifies the address of the espresso tee verifier contract that is used to verify messages read by the espresso streamer")
 	f.Uint64(prefix+".gas-estimate-base-fee-multiple-bips", uint64(DefaultBatchPosterConfig.GasEstimateBaseFeeMultipleBips), "for gas estimation, use this multiple of the basefee (measured in basis points) as the max fee per gas")
 	f.Duration(prefix+".reorg-resistance-margin", DefaultBatchPosterConfig.ReorgResistanceMargin, "do not post batch if its within this duration from layer 1 minimum bounds. Requires l1-block-bound option not be set to \"ignore\"")
 	f.Bool(prefix+".check-batch-correctness", DefaultBatchPosterConfig.CheckBatchCorrectness, "setting this to true will run the batch against an inbox multiplexer and verifies that it produces the correct set of messages")
@@ -360,6 +365,7 @@ type BatchPosterOpts struct {
 	TransactOpts  *bind.TransactOpts
 	DAPWriters    []daprovider.Writer
 	ParentChainID *big.Int
+	ChainID       uint64
 	DAPReaders    []daprovider.Reader
 
 	DataSigner signature.DataSignerFunc
@@ -430,21 +436,22 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 	}
 
 	b := &BatchPoster{
-		l1Reader:           opts.L1Reader,
-		inbox:              opts.Inbox,
-		streamer:           opts.Streamer,
-		arbOSVersionGetter: opts.VersionGetter,
-		syncMonitor:        opts.SyncMonitor,
-		config:             opts.Config,
-		seqInbox:           seqInbox,
-		seqInboxABI:        seqInboxABI,
-		seqInboxAddr:       opts.DeployInfo.SequencerInbox,
-		gasRefunderAddr:    opts.Config().gasRefunder,
-		bridgeAddr:         opts.DeployInfo.Bridge,
-		dapWriters:         opts.DAPWriters,
-		redisLock:          redisLock,
-		dapReaders:         opts.DAPReaders,
-	}
+	l1Reader:           opts.L1Reader,
+	inbox:              opts.Inbox,
+	streamer:           opts.Streamer,
+	arbOSVersionGetter: opts.VersionGetter,
+	syncMonitor:        opts.SyncMonitor,
+	config:             opts.Config,
+	seqInbox:           seqInbox,
+	seqInboxABI:        seqInboxABI,
+	seqInboxAddr:       opts.DeployInfo.SequencerInbox,
+	gasRefunderAddr:    opts.Config().gasRefunder,
+	bridgeAddr:         opts.DeployInfo.Bridge,
+	dapWriters:         opts.DAPWriters,
+	redisLock:          redisLock,
+	dapReaders:         opts.DAPReaders,
+	espressoStreamer:   espressoStreamer,
+}
 	b.messagesPerBatch, err = arbmath.NewMovingAverage[uint64](20)
 	if err != nil {
 		return nil, err

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -768,6 +768,7 @@ func createNodeImpl(
 			TransactOpts:  txOptsBatchPoster,
 			DAPWriters:    dapWriters,
 			ParentChainID: parentChainID,
+			ChainID:       l2ChainId,
 			DAPReaders:    dapReaders,
 
 			DataSigner: dataSigner,

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -19,10 +19,10 @@ import (
 	"testing"
 	"time"
 
-	espressoClient "github.com/EspressoSystems/espresso-sequencer-go/client"
-	lightclient "github.com/EspressoSystems/espresso-sequencer-go/light-client"
-	tagged_base64 "github.com/EspressoSystems/espresso-sequencer-go/tagged-base64"
-	espressoTypes "github.com/EspressoSystems/espresso-sequencer-go/types"
+	espressoClient "github.com/EspressoSystems/espresso-network-go/client"
+	lightclient "github.com/EspressoSystems/espresso-network-go/light-client"
+	tagged_base64 "github.com/EspressoSystems/espresso-network-go/tagged-base64"
+	espressoTypes "github.com/EspressoSystems/espresso-network-go/types"
 	"github.com/ccoveille/go-safecast"
 	flag "github.com/spf13/pflag"
 

--- a/arbutil/espresso_utils.go
+++ b/arbutil/espresso_utils.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"time"
 
-	espressoTypes "github.com/EspressoSystems/espresso-sequencer-go/types"
+	espressoTypes "github.com/EspressoSystems/espresso-network-go/types"
 	"github.com/ccoveille/go-safecast"
 
 	"github.com/ethereum/go-ethereum/crypto"

--- a/espressostreamer/espresso_streamer.go
+++ b/espressostreamer/espresso_streamer.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
-	espressoClient "github.com/EspressoSystems/espresso-sequencer-go/client"
-	espressoTypes "github.com/EspressoSystems/espresso-sequencer-go/types"
+	espressoClient "github.com/EspressoSystems/espresso-network-go/client"
+	espressoTypes "github.com/EspressoSystems/espresso-network-go/types"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/log"
@@ -22,11 +22,6 @@ type EspressoTEEVerifierInterface interface {
 	Verify(opts *bind.CallOpts, rawQuote []byte, reportDataHash [32]byte) error
 }
 
-type EspressoClientInterface interface {
-	FetchLatestBlockHeight(ctx context.Context) (uint64, error)
-	FetchTransactionsInBlock(ctx context.Context, blockHeight uint64, namespace uint64) (espressoClient.TransactionsInBlock, error)
-}
-
 type MessageWithMetadataAndPos struct {
 	MessageWithMeta arbostypes.MessageWithMetadata
 	Pos             uint64
@@ -35,7 +30,7 @@ type MessageWithMetadataAndPos struct {
 
 type EspressoStreamer struct {
 	stopwaiter.StopWaiter
-	espressoClient                EspressoClientInterface
+	espressoClient                espressoClient.EspressoClient
 	nextHotshotBlockNum           uint64
 	currentMessagePos             uint64
 	namespace                     uint64
@@ -52,7 +47,7 @@ func NewEspressoStreamer(namespace uint64,
 	retryTime time.Duration,
 	pollingHotshotPollingInterval time.Duration,
 	espressoTEEVerifierCaller EspressoTEEVerifierInterface,
-	espressoClientInterface EspressoClientInterface,
+	espressoClientInterface espressoClient.EspressoClient,
 ) *EspressoStreamer {
 
 	return &EspressoStreamer{
@@ -64,7 +59,15 @@ func NewEspressoStreamer(namespace uint64,
 		espressoTEEVerifierCaller:     espressoTEEVerifierCaller,
 	}
 }
-
+// GetMessageCount
+// This function will use the CountUniqueMessage to count the unique messages present in it's buffer.
+// Parameters:
+//  None
+// Return value:
+//  a uint64 representing the count of unique messages in the EspressoStreamer's internal buffer.
+func (s *EspressoStreamer) GetMessageCount() uint64 {
+  return CountUniqueEntries(&s.messageWithMetadataAndPos)
+}
 func (s *EspressoStreamer) Reset(currentMessagePos uint64, currentHostshotBlock uint64) {
 	s.messageMutex.Lock()
 	defer s.messageMutex.Unlock()

--- a/espressostreamer/utils.go
+++ b/espressostreamer/utils.go
@@ -33,3 +33,19 @@ func FilterAndFind[T any](arr *[]T, compareFunc func(T) int) (T, bool) {
 	*arr = (*arr)[:j]
 	return found, hasFound
 }
+// CountUniqueEntries iterates over an array with potential duplicate values and counts the unique entries.
+// returns a Uint that represents the number of unique entries.
+// @Dev:
+func CountUniqueEntries[T any](arr *[]T) uint64 {
+	var uniqueCount uint64 // Declare the variable before assignment so the compiler doesn't infer it as an int.
+	entriesMap := make(map[any]bool)
+	uniqueCount = 0
+	for _, entry := range *arr {
+		if !entriesMap[entry] {
+			uniqueCount += 1
+			entriesMap[entry] = true
+		}
+
+	}
+	return uniqueCount
+}

--- a/espressostreamer/utils_test.go
+++ b/espressostreamer/utils_test.go
@@ -192,3 +192,42 @@ func TestFilterAndFindWithStruct(t *testing.T) {
 		})
 	}
 }
+
+// TestCountUniqueEntries tests the CountUniqueEntries function in espressostreamer/utils.go
+// It tests that the function works for arbitrary types of array inputs, and properly de-duplicates counting the entries in the list.
+// in practice the queue that the espressostreamer maintains might be a bit less
+func TestCountUniqueEntries(t *testing.T) {
+	strList1 := []string{"One", "Two", "Three"}                  // Should return 3
+	strList2 := []string{"One", "Two", "Three", "Three"}         // Should return 3
+	strList3 := []string{"One", "Two", "Three", "Three", "Four"} // Should return 4
+	intList1 := []uint64{1, 2, 3, 4}                             // should return 4
+	intList2 := []uint64{1, 2, 3, 3, 4}                          // should return 4
+	intList3 := []uint64{1, 2, 3, 4, 2, 3, 5}                    // should return 5
+
+	// get results from all of the inputs.
+	result1 := CountUniqueEntries(&strList1)
+	result2 := CountUniqueEntries(&strList2)
+	result3 := CountUniqueEntries(&strList3)
+	result4 := CountUniqueEntries(&intList1)
+	result5 := CountUniqueEntries(&intList2)
+	result6 := CountUniqueEntries(&intList3)
+
+	if result1 != 3 {
+		t.Errorf("Expected result of 3 for , but got %v", result1)
+	}
+	if result2 != 3 {
+		t.Errorf("Expected result of 3 for , but got %v", result1)
+	}
+	if result3 != 4 {
+		t.Errorf("Expected result of 4 for , but got %v", result1)
+	}
+	if result4 != 4 {
+		t.Errorf("Expected result of 4 for , but got %v", result1)
+	}
+	if result5 != 4 {
+		t.Errorf("Expected result of 4 for , but got %v", result1)
+	}
+	if result6 != 5 {
+		t.Errorf("Expected result of 5 for , but got %v", result1)
+	}
+}

--- a/execution/gethexec/caff_node.go
+++ b/execution/gethexec/caff_node.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	espressoClient "github.com/EspressoSystems/espresso-sequencer-go/client"
+	espressoClient "github.com/EspressoSystems/espresso-network-go/client"
 
 	"github.com/ethereum/go-ethereum/arbitrum_types"
 	"github.com/ethereum/go-ethereum/common"

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ replace github.com/offchainlabs/bold => ./bold
 
 require (
 	cloud.google.com/go/storage v1.43.0
+	github.com/EspressoSystems/espresso-network-go v0.0.34
 	github.com/EspressoSystems/espresso-sequencer-go v0.0.33
 	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible
 	github.com/Shopify/toxiproxy v2.1.4+incompatible


### PR DESCRIPTION
Closes #TBD
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
Integrates the espresso streamer with the batch poster.

### This PR does not:
This PR currently does not implement behavior to fetch the most recent hotshot height from a recently posted batch. This should be done before the PR is merged.

This PR doesn't implement an intelligent strategy to start the espresso streamer when starting a network from scratch. That is, how should we determine what the first hotshot block to look for is?

### Key places to review:
`arbnode/batch_poster.go`
`espressostreamer/espresso_streamer.go`

### How to test this PR:
go test -run ^TestEspressoE2E github.com/offchainlabs/nitro/system_tests -v

### Things tested:
Currently the E2E test doesn't pass because the espresso streamer takes time to synchronize with hotshot and enqueue any potential messages. If the streamer is polling blocks too fast, it may pass over the hotshot block for the first messages.

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209815012916770