### PR TITLE
Pin cmake version in CI

### DIFF
--- a/.github/workflows/arbitrator-ci.yml
+++ b/.github/workflows/arbitrator-ci.yml
@@ -44,8 +44,13 @@ jobs:
       - name: Install Ubuntu dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y \
-            build-essential cmake lld-14 libudev-dev
+            build-essential lld-14 libudev-dev
           sudo ln -s /usr/bin/wasm-ld-14 /usr/local/bin/wasm-ld
+
+      - name: Install cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.6'
 
       - name: Install go
         uses: actions/setup-go@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,12 @@ jobs:
       - name: Install dependencies
         run: >
           sudo apt update && sudo apt install -y wabt
-          cmake build-essential bison golang clang make wabt
+          build-essential bison golang clang make
+
+      - name: Install cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.6'
 
       - name: Install latest gotestsum
         uses: autero1/action-gotestsum@v2.0.0

--- a/.github/workflows/espresso-e2e.yml
+++ b/.github/workflows/espresso-e2e.yml
@@ -27,7 +27,12 @@ jobs:
       - name: Install dependencies
         run: >
           sudo apt update && sudo apt install -y wabt
-          cmake build-essential bison golang clang make wabt
+          build-essential bison golang clang make
+
+      - name: Install cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.6'
 
       - name: Install latest gotestsum
         uses: autero1/action-gotestsum@v2.0.0


### PR DESCRIPTION
### This PR:
Pin the cmake version in CI. 

We can't fix the CI merely by removing the `apt install cmake` because github runner has also updated it to 4.0.0.

https://github.com/actions/runner-images/issues/11926

It is said that the github runners will be rollbacked and at that time we could just use the builtin cmake, which is [3.31.6](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md). But it is no harm to pin the version for us.

