### PR TITLE
Fix golangci-lint

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,15 @@
           nodejs = prev.nodejs_18;
           yarn = (prev.yarn.override { inherit nodejs; });
           pnpm = (prev.pnpm.override { inherit nodejs; });
+          golangci-lint = prev.golangci-lint.overrideAttrs (old: {
+            version = "2.0.2";
+            src = prev.fetchFromGitHub {
+              owner = "golangci";
+              repo = "golangci-lint";
+              rev = "v1.64.8";
+              sha256 = "sha256-ODnNBwtfILD0Uy2AKDR/e76ZrdyaOGlCktVUcf9ujy8";
+            };
+          });
         })
         foundry.overlay
       ];

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/offchainlabs/nitro
 
-go 1.23.4
+go 1.23.0
 
 replace github.com/VictoriaMetrics/fastcache => ./fastcache
 


### PR DESCRIPTION
Fix the golangci-lint

- The version in `go.mod` was accidentally changed. It doesn't match the nix anymore
- We updated `flake.nix` recently and the version of `golangci-lint` becomes `v2.0.2`, which is only for `go 1.24`. Downgrade it and it should work!