### PR TITLE
nix: fix golangci-lint vendorHash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,14 +20,15 @@
           nodejs = prev.nodejs_18;
           yarn = (prev.yarn.override { inherit nodejs; });
           pnpm = (prev.pnpm.override { inherit nodejs; });
-          golangci-lint = prev.golangci-lint.overrideAttrs (old: {
-            version = "2.0.2";
+          golangci-lint = prev.golangci-lint.overrideAttrs (old: rec {
+            version = "1.64.8";
             src = prev.fetchFromGitHub {
               owner = "golangci";
               repo = "golangci-lint";
-              rev = "v1.64.8";
+              rev = "v${version}";
               sha256 = "sha256-ODnNBwtfILD0Uy2AKDR/e76ZrdyaOGlCktVUcf9ujy8";
             };
+            vendorHash = "sha256-/iq7Ju7c2gS7gZn3n+y0kLtPn2Nn8HY/YdqSDYjtEkI=";
           });
         })
         foundry.overlay


### PR DESCRIPTION
This is hash of all the dependencies and also needs to be updated when we override the package source code.

The version fix isn't strictly required, but why not.
