### PR TITLE
espresso-network: 20250410 -> 20250412

### DIFF
--- a/espressocrypto/lib/espresso-crypto-helper/Cargo.lock
+++ b/espressocrypto/lib/espresso-crypto-helper/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
 [[package]]
 name = "alloy-compat"
 version = "0.1.0"
-source = "git+https://github.com/espressosystems/espresso-network?tag=20250410-dev-node-pos-preview#e3e07e02ee0d5f772d912523543caa61f5c6469f"
+source = "git+https://github.com/espressosystems/espresso-network?tag=20250412-dev-node-pos-preview#ca0ff2ef4aad6c1a442b40d63fd17711c667c20a"
 dependencies = [
  "alloy",
  "ethers-core",
@@ -3478,7 +3478,7 @@ source = "git+https://github.com/espressosystems/espresso-systems-common?tag=0.4
 [[package]]
 name = "espresso-types"
 version = "0.1.0"
-source = "git+https://github.com/espressosystems/espresso-network?tag=20250410-dev-node-pos-preview#e3e07e02ee0d5f772d912523543caa61f5c6469f"
+source = "git+https://github.com/espressosystems/espresso-network?tag=20250412-dev-node-pos-preview#ca0ff2ef4aad6c1a442b40d63fd17711c667c20a"
 dependencies = [
  "alloy",
  "alloy-compat",
@@ -4687,7 +4687,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.1.0"
-source = "git+https://github.com/espressosystems/espresso-network?tag=20250410-dev-node-pos-preview#e3e07e02ee0d5f772d912523543caa61f5c6469f"
+source = "git+https://github.com/espressosystems/espresso-network?tag=20250412-dev-node-pos-preview#ca0ff2ef4aad6c1a442b40d63fd17711c667c20a"
 dependencies = [
  "alloy",
  "anyhow",
@@ -4731,7 +4731,7 @@ dependencies = [
 [[package]]
 name = "hotshot-builder-api"
 version = "0.1.7"
-source = "git+https://github.com/espressosystems/espresso-network?tag=20250410-dev-node-pos-preview#e3e07e02ee0d5f772d912523543caa61f5c6469f"
+source = "git+https://github.com/espressosystems/espresso-network?tag=20250412-dev-node-pos-preview#ca0ff2ef4aad6c1a442b40d63fd17711c667c20a"
 dependencies = [
  "async-trait",
  "clap",
@@ -4751,7 +4751,7 @@ dependencies = [
 [[package]]
 name = "hotshot-contract-adapter"
 version = "0.1.0"
-source = "git+https://github.com/espressosystems/espresso-network?tag=20250410-dev-node-pos-preview#e3e07e02ee0d5f772d912523543caa61f5c6469f"
+source = "git+https://github.com/espressosystems/espresso-network?tag=20250412-dev-node-pos-preview#ca0ff2ef4aad6c1a442b40d63fd17711c667c20a"
 dependencies = [
  "alloy",
  "anyhow",
@@ -4775,7 +4775,7 @@ dependencies = [
 [[package]]
 name = "hotshot-example-types"
 version = "0.1.0"
-source = "git+https://github.com/espressosystems/espresso-network?tag=20250410-dev-node-pos-preview#e3e07e02ee0d5f772d912523543caa61f5c6469f"
+source = "git+https://github.com/espressosystems/espresso-network?tag=20250412-dev-node-pos-preview#ca0ff2ef4aad6c1a442b40d63fd17711c667c20a"
 dependencies = [
  "anyhow",
  "async-lock 3.4.0",
@@ -4801,7 +4801,7 @@ dependencies = [
 [[package]]
 name = "hotshot-fakeapi"
 version = "0.1.0"
-source = "git+https://github.com/espressosystems/espresso-network?tag=20250410-dev-node-pos-preview#e3e07e02ee0d5f772d912523543caa61f5c6469f"
+source = "git+https://github.com/espressosystems/espresso-network?tag=20250412-dev-node-pos-preview#ca0ff2ef4aad6c1a442b40d63fd17711c667c20a"
 dependencies = [
  "anyhow",
  "async-lock 3.4.0",
@@ -4820,7 +4820,7 @@ dependencies = [
 [[package]]
 name = "hotshot-libp2p-networking"
 version = "0.1.0"
-source = "git+https://github.com/espressosystems/espresso-network?tag=20250410-dev-node-pos-preview#e3e07e02ee0d5f772d912523543caa61f5c6469f"
+source = "git+https://github.com/espressosystems/espresso-network?tag=20250412-dev-node-pos-preview#ca0ff2ef4aad6c1a442b40d63fd17711c667c20a"
 dependencies = [
  "alloy",
  "anyhow",
@@ -4850,7 +4850,7 @@ dependencies = [
 [[package]]
 name = "hotshot-macros"
 version = "0.1.0"
-source = "git+https://github.com/espressosystems/espresso-network?tag=20250410-dev-node-pos-preview#e3e07e02ee0d5f772d912523543caa61f5c6469f"
+source = "git+https://github.com/espressosystems/espresso-network?tag=20250412-dev-node-pos-preview#ca0ff2ef4aad6c1a442b40d63fd17711c667c20a"
 dependencies = [
  "derive_builder",
  "proc-macro2",
@@ -4862,7 +4862,7 @@ dependencies = [
 [[package]]
 name = "hotshot-query-service"
 version = "0.1.76"
-source = "git+https://github.com/espressosystems/espresso-network?tag=20250410-dev-node-pos-preview#e3e07e02ee0d5f772d912523543caa61f5c6469f"
+source = "git+https://github.com/espressosystems/espresso-network?tag=20250412-dev-node-pos-preview#ca0ff2ef4aad6c1a442b40d63fd17711c667c20a"
 dependencies = [
  "alloy",
  "anyhow",
@@ -4914,7 +4914,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.1.0"
-source = "git+https://github.com/espressosystems/espresso-network?tag=20250410-dev-node-pos-preview#e3e07e02ee0d5f772d912523543caa61f5c6469f"
+source = "git+https://github.com/espressosystems/espresso-network?tag=20250412-dev-node-pos-preview#ca0ff2ef4aad6c1a442b40d63fd17711c667c20a"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4928,7 +4928,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.1.0"
-source = "git+https://github.com/espressosystems/espresso-network?tag=20250410-dev-node-pos-preview#e3e07e02ee0d5f772d912523543caa61f5c6469f"
+source = "git+https://github.com/espressosystems/espresso-network?tag=20250412-dev-node-pos-preview#ca0ff2ef4aad6c1a442b40d63fd17711c667c20a"
 dependencies = [
  "alloy",
  "anyhow",
@@ -4964,7 +4964,7 @@ dependencies = [
 [[package]]
 name = "hotshot-testing"
 version = "0.1.0"
-source = "git+https://github.com/espressosystems/espresso-network?tag=20250410-dev-node-pos-preview#e3e07e02ee0d5f772d912523543caa61f5c6469f"
+source = "git+https://github.com/espressosystems/espresso-network?tag=20250412-dev-node-pos-preview#ca0ff2ef4aad6c1a442b40d63fd17711c667c20a"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5007,7 +5007,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.11"
-source = "git+https://github.com/espressosystems/espresso-network?tag=20250410-dev-node-pos-preview#e3e07e02ee0d5f772d912523543caa61f5c6469f"
+source = "git+https://github.com/espressosystems/espresso-network?tag=20250412-dev-node-pos-preview#ca0ff2ef4aad6c1a442b40d63fd17711c667c20a"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5067,7 +5067,7 @@ dependencies = [
 [[package]]
 name = "hotshot-utils"
 version = "0.1.0"
-source = "git+https://github.com/espressosystems/espresso-network?tag=20250410-dev-node-pos-preview#e3e07e02ee0d5f772d912523543caa61f5c6469f"
+source = "git+https://github.com/espressosystems/espresso-network?tag=20250412-dev-node-pos-preview#ca0ff2ef4aad6c1a442b40d63fd17711c667c20a"
 dependencies = [
  "tracing",
  "workspace-hack",
@@ -9211,7 +9211,7 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 [[package]]
 name = "sequencer-utils"
 version = "0.1.0"
-source = "git+https://github.com/espressosystems/espresso-network?tag=20250410-dev-node-pos-preview#e3e07e02ee0d5f772d912523543caa61f5c6469f"
+source = "git+https://github.com/espressosystems/espresso-network?tag=20250412-dev-node-pos-preview#ca0ff2ef4aad6c1a442b40d63fd17711c667c20a"
 dependencies = [
  "alloy",
  "anyhow",
@@ -11301,7 +11301,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vid"
 version = "0.1.0"
-source = "git+https://github.com/espressosystems/espresso-network?tag=20250410-dev-node-pos-preview#e3e07e02ee0d5f772d912523543caa61f5c6469f"
+source = "git+https://github.com/espressosystems/espresso-network?tag=20250412-dev-node-pos-preview#ca0ff2ef4aad6c1a442b40d63fd17711c667c20a"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -11974,7 +11974,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/espressosystems/espresso-network?tag=20250410-dev-node-pos-preview#e3e07e02ee0d5f772d912523543caa61f5c6469f"
+source = "git+https://github.com/espressosystems/espresso-network?tag=20250412-dev-node-pos-preview#ca0ff2ef4aad6c1a442b40d63fd17711c667c20a"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",

--- a/espressocrypto/lib/espresso-crypto-helper/Cargo.toml
+++ b/espressocrypto/lib/espresso-crypto-helper/Cargo.toml
@@ -27,9 +27,9 @@ jf-rescue = { version = "0.1.0", git = "https://github.com/EspressoSystems/jelly
   "std",
 ], default-features = false }
 
-hotshot-types = { git = "https://github.com/EspressoSystems/espresso-network", default-features = false, tag = "20250410-dev-node-pos-preview" }
-hotshot-query-service = { git = "https://github.com/espressosystems/espresso-network", tag = "20250410-dev-node-pos-preview" }
-espresso-types = { git = "https://github.com/espressosystems/espresso-network", tag = "20250410-dev-node-pos-preview" }
+hotshot-types = { git = "https://github.com/EspressoSystems/espresso-network", default-features = false, tag = "20250412-dev-node-pos-preview" }
+hotshot-query-service = { git = "https://github.com/espressosystems/espresso-network", tag = "20250412-dev-node-pos-preview" }
+espresso-types = { git = "https://github.com/espressosystems/espresso-network", tag = "20250412-dev-node-pos-preview" }
 
 # https://tikv.github.io/doc/openssl/index.html
 openssl = { version = "0.10", features = ["vendored"] }

--- a/system_tests/espresso-e2e/docker-compose.yaml
+++ b/system_tests/espresso-e2e/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   espresso-dev-node:
-    image: ghcr.io/espressosystems/espresso-sequencer/espresso-dev-node:20250410-dev-node-pos-preview
+    image: ghcr.io/espressosystems/espresso-sequencer/espresso-dev-node:20250412-dev-node-pos-preview
     ports:
       - "$ESPRESSO_SEQUENCER_API_PORT:$ESPRESSO_SEQUENCER_API_PORT"
       - "$ESPRESSO_BUILDER_PORT:$ESPRESSO_BUILDER_PORT"


### PR DESCRIPTION
CI will have to be retried when https://github.com/EspressoSystems/espresso-network/actions/runs/14417749807 is done building.

Edit: retried E2E run here https://github.com/EspressoSystems/nitro-espresso-integration/actions/runs/14417831623/job/40436874460?pr=563