### PR TITLE
Add dangerous config to Caff node

### DIFF
--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -2,6 +2,7 @@ package arbnode
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -23,19 +24,28 @@ import (
 )
 
 type EspressoCaffNodeConfig struct {
-	Enable                  bool          `koanf:"enable"`
-	HotShotUrls             []string      `koanf:"hotshot-urls"`
-	NextHotshotBlock        uint64        `koanf:"next-hotshot-block"`
-	Namespace               uint64        `koanf:"namespace"`
-	RetryTime               time.Duration `koanf:"retry-time"`
-	HotshotPollingInterval  time.Duration `koanf:"hotshot-polling-interval"`
-	EspressoTEEVerifierAddr string        `koanf:"espresso-tee-verifier-addr"`
-	BatchPosterAddr         string        `koanf:"batch-poster-addr"`
-	RecordPerformance       bool          `koanf:"record-performance"`
-	WaitForFinalization     bool          `koanf:"wait-for-finalization"`
-	WaitForConfirmations    bool          `koanf:"wait-for-confirmations"`
-	RequiredBlockDepth      uint64        `koanf:"required-block-depth"`
-	BlocksToRead            uint64        `koanf:"blocks-to-read"`
+	Enable                  bool                    `koanf:"enable"`
+	HotShotUrls             []string                `koanf:"hotshot-urls"`
+	NextHotshotBlock        uint64                  `koanf:"next-hotshot-block"`
+	Namespace               uint64                  `koanf:"namespace"`
+	RetryTime               time.Duration           `koanf:"retry-time"`
+	HotshotPollingInterval  time.Duration           `koanf:"hotshot-polling-interval"`
+	EspressoTEEVerifierAddr string                  `koanf:"espresso-tee-verifier-addr"`
+	BatchPosterAddr         string                  `koanf:"batch-poster-addr"`
+	RecordPerformance       bool                    `koanf:"record-performance"`
+	WaitForFinalization     bool                    `koanf:"wait-for-finalization"`
+	WaitForConfirmations    bool                    `koanf:"wait-for-confirmations"`
+	RequiredBlockDepth      uint64                  `koanf:"required-block-depth"`
+	BlocksToRead            uint64                  `koanf:"blocks-to-read"`
+	Dangerous               DangerousCaffNodeConfig `koanf:"dangerous"`
+}
+
+type DangerousCaffNodeConfig struct {
+	IgnoreDatabaseHotshotBlock bool `koanf:"ignore-database-hotshot-block"`
+}
+
+var DefaultDangerousCaffNodeConfig = DangerousCaffNodeConfig{
+	IgnoreDatabaseHotshotBlock: false,
 }
 
 var DefaultEspressoCaffNodeConfig = EspressoCaffNodeConfig{
@@ -52,6 +62,7 @@ var DefaultEspressoCaffNodeConfig = EspressoCaffNodeConfig{
 	WaitForConfirmations:    false,
 	RequiredBlockDepth:      6,
 	BlocksToRead:            100,
+	Dangerous:               DefaultDangerousCaffNodeConfig,
 }
 
 func EspressoCaffNodeConfigAddOptions(prefix string, f *flag.FlagSet) {
@@ -68,6 +79,11 @@ func EspressoCaffNodeConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".wait-for-confirmations", DefaultEspressoCaffNodeConfig.WaitForConfirmations, "Configures the Caff node to only produce blocks from delayed messages if they have atleast requiredBlockDepth confirmations on the parent chain")
 	f.Uint64(prefix+".required-block-depth", DefaultEspressoCaffNodeConfig.RequiredBlockDepth, "Configures the required block depth/number of confirmations on the parent chain that a delayed message is required to have before this Caff node will add it to it's state")
 	f.Uint64(prefix+".blocks-to-read", DefaultEspressoCaffNodeConfig.BlocksToRead, "Configures the number of blocks to read from the parent chain for delayed messages")
+	DangerousCaffNodeConfigAddOptions(prefix+".dangerous", f)
+}
+
+func DangerousCaffNodeConfigAddOptions(prefix string, f *flag.FlagSet) {
+	f.Bool(prefix+".ignore-database-hotshot-block", DefaultDangerousCaffNodeConfig.IgnoreDatabaseHotshotBlock, "Ignores the database hotshot block and starts from the next block specified in the config by the user")
 }
 
 type EspressoCaffNodeConfigFetcher func() *EspressoCaffNodeConfig
@@ -267,17 +283,20 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to convert block number to message index: %w", err)
 	}
-	nextHotshotBlock, err := n.espressoStreamer.ReadNextHotshotBlockFromDb(n.db)
-	if err != nil {
-		log.Crit("failed to read next hotshot block", "err", err)
-		return nil
+	var nextHotshotBlock uint64
+
+	if !n.configFetcher().Dangerous.IgnoreDatabaseHotshotBlock {
+		nextHotshotBlock, err = n.espressoStreamer.ReadNextHotshotBlockFromDb(n.db)
+		if err != nil {
+			return fmt.Errorf("failed to read next hotshot block: %w", err)
+		}
 	}
 
 	if nextHotshotBlock == 0 {
 		// No next hotshot block found, so we need to start from config.CaffNodeConfig.NextHotshotBlock
 		nextHotshotBlock = n.configFetcher().NextHotshotBlock
 		if nextHotshotBlock == 0 {
-			log.Crit("No next hotshot block found in database, and no config.CaffNodeConfig.NextHotshotBlock set")
+			return errors.New("No next hotshot block found in database or dangerous.ignore-database-hotshot-block is set to true, please set config.CaffNodeConfig.NextHotshotBlock")
 		}
 	}
 	// The reason we do the reset here is because database is only initialized after Caff node is initialized

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -428,7 +428,7 @@ func ExpectErr(t *testing.T, err error, expectedError error) {
 }
 
 // This tests that the caff node config validates that known versions of arb sequencers are not enabled if the caff node is.
-func TestCaffNodeConfig(t *testing.T) {
+func TestEspressoCaffNodeConfig(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	builder := createCaffNodeConfig(ctx, t)
@@ -455,7 +455,7 @@ func TestCaffNodeConfig(t *testing.T) {
 
 }
 
-func TestCaffNodeDangerousConfig(t *testing.T) {
+func TestEspressoCaffNodeDangerousConfig(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math/big"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,7 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-func createCaffNode(ctx context.Context, t *testing.T, existing *NodeBuilder) (*NodeBuilder, func()) {
+func createCaffNode(ctx context.Context, t *testing.T, existing *NodeBuilder, dangerous bool) (*NodeBuilder, func(), error) {
 	builder := NewNodeBuilder(ctx).DefaultConfig(t, false)
 	nodeConfig := builder.nodeConfig
 	execConfig := builder.execConfig
@@ -45,8 +46,12 @@ func createCaffNode(ctx context.Context, t *testing.T, existing *NodeBuilder) (*
 	nodeConfig.EspressoCaffNode.HotshotPollingInterval = time.Millisecond * 100
 	nodeConfig.ParentChainReader.Enable = true
 
-	cleanup := builder.BuildEspressoCaffNode(t, existing)
-	return builder, cleanup
+	if dangerous {
+		nodeConfig.EspressoCaffNode.Dangerous.IgnoreDatabaseHotshotBlock = true
+		nodeConfig.EspressoCaffNode.NextHotshotBlock = 0
+	}
+	cleanup, err := builder.BuildEspressoCaffNode(t, existing)
+	return builder, cleanup, err
 }
 
 func createCaffNodeConfig(ctx context.Context, t *testing.T) *NodeBuilder {
@@ -178,7 +183,8 @@ func TestEspressoCaffNode(t *testing.T) {
 	// don't make the caff node wait for finalization during the default test.
 	builder.nodeConfig.EspressoCaffNode.WaitForFinalization = false
 	// start the node
-	builder, cleanupCaffNode := createCaffNode(ctx, t, builder)
+	builder, cleanupCaffNode, err := createCaffNode(ctx, t, builder, false)
+	Require(t, err)
 	builderCaffNode := builder.L2
 	defer cleanupCaffNode()
 
@@ -269,7 +275,8 @@ func TestEspressoCaffNodeDelayedMessagesConfirmations(t *testing.T) {
 
 	// start the node
 	log.Info("Starting the caff node")
-	builder2, cleanupCaffNode := createCaffNode(ctx, t, builder)
+	builder2, cleanupCaffNode, err := createCaffNode(ctx, t, builder, false)
+	Require(t, err)
 	builderCaffNode := builder2.L2
 	defer cleanupCaffNode()
 
@@ -280,7 +287,7 @@ func TestEspressoCaffNodeDelayedMessagesConfirmations(t *testing.T) {
 		WrapL2ForDelayed(t, delayedTx, builder.L1Info, "Faucet", 100000),
 	})
 	// Check the caff node RPC for tx. assert that it is not there.
-	_, _, err := builderCaffNode.Client.TransactionByHash(ctx, tx[0].TxHash)
+	_, _, err = builderCaffNode.Client.TransactionByHash(ctx, tx[0].TxHash)
 	ExpectErr(t, err, ethereum.NotFound)
 
 	// Create the event function closures for the assert statement.
@@ -321,7 +328,8 @@ func TestEspressoCaffNodeDelayedMessagesFinalized(t *testing.T) {
 	builder.nodeConfig.EspressoCaffNode.WaitForFinalization = true
 	// start the node
 	log.Info("Starting the caff node")
-	builder2, cleanupCaffNode := createCaffNode(ctx, t, builder)
+	builder2, cleanupCaffNode, err := createCaffNode(ctx, t, builder, false)
+	Require(t, err)
 	builderCaffNode := builder2.L2
 	defer cleanupCaffNode()
 
@@ -332,7 +340,7 @@ func TestEspressoCaffNodeDelayedMessagesFinalized(t *testing.T) {
 		WrapL2ForDelayed(t, delayedTx, builder.L1Info, "Faucet", 100000),
 	})
 	// Check the caff node RPC for tx. assert that it is not there.
-	_, _, err := builderCaffNode.Client.TransactionByHash(ctx, tx[0].TxHash)
+	_, _, err = builderCaffNode.Client.TransactionByHash(ctx, tx[0].TxHash)
 	ExpectErr(t, err, ethereum.NotFound)
 	// Wait for the tx header to be finalized.
 
@@ -372,7 +380,8 @@ func TestEspressoCaffNodeUnfinalizedDelayedMessages(t *testing.T) {
 
 	// start the node
 	log.Info("Starting the caff node")
-	builder2, cleanupCaffNode := createCaffNode(ctx, t, builder)
+	builder2, cleanupCaffNode, err := createCaffNode(ctx, t, builder, false)
+	Require(t, err)
 	builderCaffNode := builder2.L2
 	defer cleanupCaffNode()
 
@@ -382,7 +391,7 @@ func TestEspressoCaffNodeUnfinalizedDelayedMessages(t *testing.T) {
 		WrapL2ForDelayed(t, delayedTx3, builder.L1Info, "Faucet", 100000),
 	})
 	// Wait for the tx to appear on the caff node
-	err := waitForWith(ctx, 240*time.Second, 10*time.Second, func() bool {
+	err = waitForWith(ctx, 240*time.Second, 10*time.Second, func() bool {
 		balance := builderCaffNode.GetBalance(t, addr)
 		log.Info("waiting for balance", "account", newAccount, "addr", addr, "balance", balance)
 		if balance.Cmp(transferAmount) >= 0 {
@@ -444,4 +453,30 @@ func TestCaffNodeConfig(t *testing.T) {
 	err = builder.nodeConfig.Validate()
 	RequireErr(t, err, expectedErr)
 
+}
+
+func TestCaffNodeDangerousConfig(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	builder, cleanup := createL1AndL2Node(ctx, t, true, false)
+	defer cleanup()
+
+	// start the node
+	_, cleanupCaffNode, err := createCaffNode(ctx, t, builder, true)
+	if cleanupCaffNode != nil {
+		defer cleanupCaffNode()
+	}
+
+	// The actual error is wrapped in an array, so we need to check for that
+	expectedErrMsg := "No next hotshot block found in database or dangerous.ignore-database-hotshot-block is set to true, please set config.CaffNodeConfig.NextHotshotBlock"
+
+	if err == nil {
+		t.Fatal("Expected an error but got nil")
+	}
+
+	// Check if the error contains the expected message (since it might be wrapped)
+	if !strings.Contains(err.Error(), expectedErrMsg) {
+		t.Errorf("Expected error to contain %q, got %q", expectedErrMsg, err.Error())
+	}
 }

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -667,7 +667,7 @@ func (b *NodeBuilder) BuildL2(t *testing.T) func() {
 	return func() { b.L2.cleanup() }
 }
 
-func (b *NodeBuilder) BuildEspressoCaffNode(t *testing.T, existing *NodeBuilder) func() {
+func (b *NodeBuilder) BuildEspressoCaffNode(t *testing.T, existing *NodeBuilder) (func(), error) {
 	b.L2 = NewTestClient(b.ctx)
 	AddValNodeIfNeeded(t, b.ctx, b.nodeConfig, true, "", b.valnodeConfig.Wasm.RootPath)
 
@@ -684,16 +684,22 @@ func (b *NodeBuilder) BuildEspressoCaffNode(t *testing.T, existing *NodeBuilder)
 	execConfig := b.execConfig
 	execConfigFetcher := func() *gethexec.Config { return execConfig }
 	execNode, err := gethexec.CreateExecutionNode(b.ctx, b.L2.Stack, chainDb, blockchain, nil, execConfigFetcher)
-	Require(t, err)
+	if err != nil {
+		return nil, err
+	}
 
 	fatalErrChan := make(chan error, 10)
 	b.L2.ConsensusNode, err = arbnode.CreateNode(
 		b.ctx, b.L2.Stack, execNode, arbDb, NewFetcherFromConfig(b.nodeConfig), blockchain.Config(),
 		l1Client, deployInfo, nil, nil, nil, fatalErrChan, big.NewInt(1337), nil)
-	Require(t, err)
+	if err != nil {
+		return nil, err
+	}
 
 	err = b.L2.ConsensusNode.Start(b.ctx)
-	Require(t, err)
+	if err != nil {
+		return nil, err
+	}
 
 	b.L2.Client = ClientForStack(t, b.L2.Stack)
 
@@ -701,7 +707,7 @@ func (b *NodeBuilder) BuildEspressoCaffNode(t *testing.T, existing *NodeBuilder)
 
 	b.L2.ExecNode = getExecNode(t, b.L2.ConsensusNode)
 	b.L2.cleanup = func() { b.L2.ConsensusNode.StopAndWait() }
-	return func() { b.L2.cleanup() }
+	return func() { b.L2.cleanup() }, nil
 }
 
 // L2 -Only. RestartL2Node shutdowns the existing l2 node and start it again using the same data dir.


### PR DESCRIPTION


### This PR:
Adds a dangrous config to Caff node which allows you to bypass the hotshot block number stored in the database. 
This is useful in the case where database has an outdated value



### Key places to review:
- espresso_caff_node.go

 ### How to test this PR:  
Run the `TestCaffNodeDangerousConfig` test




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210197320051326