### PR TITLE
[Celestia] Add dangerous config to Caff node

### DIFF
--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -2,6 +2,7 @@ package arbnode
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -23,19 +24,28 @@ import (
 )
 
 type EspressoCaffNodeConfig struct {
-	Enable                  bool          `koanf:"enable"`
-	HotShotUrls             []string      `koanf:"hotshot-urls"`
-	NextHotshotBlock        uint64        `koanf:"next-hotshot-block"`
-	Namespace               uint64        `koanf:"namespace"`
-	RetryTime               time.Duration `koanf:"retry-time"`
-	HotshotPollingInterval  time.Duration `koanf:"hotshot-polling-interval"`
-	EspressoTEEVerifierAddr string        `koanf:"espresso-tee-verifier-addr"`
-	BatchPosterAddr         string        `koanf:"batch-poster-addr"`
-	RecordPerformance       bool          `koanf:"record-performance"`
-	WaitForFinalization     bool          `koanf:"wait-for-finalization"`
-	WaitForConfirmations    bool          `koanf:"wait-for-confirmations"`
-	RequiredBlockDepth      uint64        `koanf:"required-block-depth"`
-	BlocksToRead            uint64        `koanf:"blocks-to-read"`
+	Enable                  bool                    `koanf:"enable"`
+	HotShotUrls             []string                `koanf:"hotshot-urls"`
+	NextHotshotBlock        uint64                  `koanf:"next-hotshot-block"`
+	Namespace               uint64                  `koanf:"namespace"`
+	RetryTime               time.Duration           `koanf:"retry-time"`
+	HotshotPollingInterval  time.Duration           `koanf:"hotshot-polling-interval"`
+	EspressoTEEVerifierAddr string                  `koanf:"espresso-tee-verifier-addr"`
+	BatchPosterAddr         string                  `koanf:"batch-poster-addr"`
+	RecordPerformance       bool                    `koanf:"record-performance"`
+	WaitForFinalization     bool                    `koanf:"wait-for-finalization"`
+	WaitForConfirmations    bool                    `koanf:"wait-for-confirmations"`
+	RequiredBlockDepth      uint64                  `koanf:"required-block-depth"`
+	BlocksToRead            uint64                  `koanf:"blocks-to-read"`
+	Dangerous               DangerousCaffNodeConfig `koanf:"dangerous"`
+}
+
+type DangerousCaffNodeConfig struct {
+	IgnoreDatabaseHotshotBlock bool `koanf:"ignore-database-hotshot-block"`
+}
+
+var DefaultDangerousCaffNodeConfig = DangerousCaffNodeConfig{
+	IgnoreDatabaseHotshotBlock: false,
 }
 
 var DefaultEspressoCaffNodeConfig = EspressoCaffNodeConfig{
@@ -52,6 +62,7 @@ var DefaultEspressoCaffNodeConfig = EspressoCaffNodeConfig{
 	WaitForConfirmations:    false,
 	RequiredBlockDepth:      6,
 	BlocksToRead:            100,
+	Dangerous:               DefaultDangerousCaffNodeConfig,
 }
 
 func EspressoCaffNodeConfigAddOptions(prefix string, f *flag.FlagSet) {
@@ -68,6 +79,11 @@ func EspressoCaffNodeConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".wait-for-confirmations", DefaultEspressoCaffNodeConfig.WaitForConfirmations, "Configures the Caff node to only produce blocks from delayed messages if they have atleast requiredBlockDepth confirmations on the parent chain")
 	f.Uint64(prefix+".required-block-depth", DefaultEspressoCaffNodeConfig.RequiredBlockDepth, "Configures the required block depth/number of confirmations on the parent chain that a delayed message is required to have before this Caff node will add it to it's state")
 	f.Uint64(prefix+".blocks-to-read", DefaultEspressoCaffNodeConfig.BlocksToRead, "Configures the number of blocks to read from the parent chain for delayed messages")
+	DangerousCaffNodeConfigAddOptions(prefix+".dangerous", f)
+}
+
+func DangerousCaffNodeConfigAddOptions(prefix string, f *flag.FlagSet) {
+	f.Bool(prefix+".ignore-database-hotshot-block", DefaultDangerousCaffNodeConfig.IgnoreDatabaseHotshotBlock, "Ignores the database hotshot block and starts from the next block specified in the config by the user")
 }
 
 type EspressoCaffNodeConfigFetcher func() *EspressoCaffNodeConfig
@@ -267,17 +283,20 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to convert block number to message index: %w", err)
 	}
-	nextHotshotBlock, err := n.espressoStreamer.ReadNextHotshotBlockFromDb(n.db)
-	if err != nil {
-		log.Crit("failed to read next hotshot block", "err", err)
-		return nil
+	var nextHotshotBlock uint64
+
+	if !n.configFetcher().Dangerous.IgnoreDatabaseHotshotBlock {
+		nextHotshotBlock, err = n.espressoStreamer.ReadNextHotshotBlockFromDb(n.db)
+		if err != nil {
+			return fmt.Errorf("failed to read next hotshot block: %w", err)
+		}
 	}
 
 	if nextHotshotBlock == 0 {
 		// No next hotshot block found, so we need to start from config.CaffNodeConfig.NextHotshotBlock
 		nextHotshotBlock = n.configFetcher().NextHotshotBlock
 		if nextHotshotBlock == 0 {
-			log.Crit("No next hotshot block found in database, and no config.CaffNodeConfig.NextHotshotBlock set")
+			return errors.New("No next hotshot block found in database or dangerous.ignore-database-hotshot-block is set to true, please set config.CaffNodeConfig.NextHotshotBlock")
 		}
 	}
 	// The reason we do the reset here is because database is only initialized after Caff node is initialized

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -2,15 +2,21 @@ package arbtest
 
 import (
 	"context"
+	"errors"
+	"math/big"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
-func createCaffNode(ctx context.Context, t *testing.T, existing *NodeBuilder) (*TestClient, func()) {
+func createCaffNode(ctx context.Context, t *testing.T, existing *NodeBuilder, dangerous bool) (*NodeBuilder, func(), error) {
 	builder := NewNodeBuilder(ctx).DefaultConfig(t, false)
 	nodeConfig := builder.nodeConfig
 	execConfig := builder.execConfig
@@ -37,8 +43,94 @@ func createCaffNode(ctx context.Context, t *testing.T, existing *NodeBuilder) (*
 
 	nodeConfig.ParentChainReader.Enable = true
 
-	cleanup := builder.BuildEspressoCaffNode(t, existing)
-	return builder.L2, cleanup
+	if dangerous {
+		nodeConfig.EspressoCaffNode.Dangerous.IgnoreDatabaseHotshotBlock = true
+		nodeConfig.EspressoCaffNode.NextHotshotBlock = 0
+	}
+	cleanup, err := builder.BuildEspressoCaffNode(t, existing)
+	return builder, cleanup, err
+}
+
+func createCaffNodeConfig(ctx context.Context, t *testing.T) *NodeBuilder {
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
+	nodeConfig := builder.nodeConfig
+	execConfig := builder.execConfig
+
+	// Disable the batch poster because it requires redis if enabled on the 2nd node
+	nodeConfig.BatchPoster.Enable = false
+	nodeConfig.BlockValidator.Enable = false
+	nodeConfig.DelayedSequencer.Enable = false
+	nodeConfig.DelayedSequencer.FinalizeDistance = 1
+	nodeConfig.Sequencer = false
+	nodeConfig.Dangerous.NoSequencerCoordinator = true
+	execConfig.Sequencer.Enable = false
+	execConfig.SecondaryForwardingTarget = []string{}
+	nodeConfig.EspressoCaffNode.Enable = true
+	nodeConfig.EspressoCaffNode.Namespace = builder.chainConfig.ChainID.Uint64()
+	nodeConfig.EspressoCaffNode.NextHotshotBlock = 1
+
+	// for testing, we can use the same hotshot url for both
+	nodeConfig.EspressoCaffNode.HotShotUrls = []string{hotShotUrl, hotShotUrl, hotShotUrl, hotShotUrl}
+	nodeConfig.EspressoCaffNode.RetryTime = time.Second * 1
+	nodeConfig.EspressoCaffNode.HotshotPollingInterval = time.Millisecond * 100
+
+	nodeConfig.ParentChainReader.Enable = true
+
+	return builder
+}
+
+// assertEventOrderingHelper is a simple helper fuction that assists in converting the errors presented by the event functions to booleans and passing them back over the channel
+func assertEventOrderingHelper(channel chan bool, eventFunc func() error) {
+	err := eventFunc()
+	if err != nil {
+		channel <- false
+	} else {
+		channel <- true
+	}
+}
+
+// AssertEventOrdering:
+// This function is responsible for asserting that 2 concurrent events happen in a specific order.
+//
+// Semantics:
+// This function will assert that each event can happen only once and will either succeed or fail.
+// The only way this function does not fail is if both events succeed in the correct order.
+// This would be relatively easy to change to asserting that the second event can fail before the first event succeeds.
+//
+// Parameters:
+// firstEventFunc: A function that can be executed as a goroutine and has an error condition that can be mapped to success vs failure. This should capture the event that should happen first
+// secondEventFunc: A function that can be executed as a goroutine and has an error condition that can be mapped to success vs failure. This should capture the event that should happen second
+func AssertEventOrdering(t *testing.T, firstEventFunc func() error, secondEventFunc func() error) {
+	var firstEventSuccess bool
+	var eventOrderSuccess bool
+	firstEvent := make(chan bool)
+	secondEvent := make(chan bool)
+	go assertEventOrderingHelper(firstEvent, firstEventFunc)
+	go assertEventOrderingHelper(secondEvent, secondEventFunc)
+	for {
+		select {
+		case success := <-firstEvent:
+			if success {
+				firstEventSuccess = true
+			} else {
+				t.Fatal("First event in ordered assert did not succeed")
+			}
+		case success := <-secondEvent:
+			if !success {
+				t.Fatal("Second event in ordered assert did not succeed")
+			}
+			if !firstEventSuccess {
+				t.Fatal("Events occurred in an incorrect order according to the assertion")
+			} else {
+				eventOrderSuccess = true
+				break
+			}
+
+		}
+		if eventOrderSuccess {
+			break
+		}
+	}
 }
 
 func TestEspressoCaffNode(t *testing.T) {
@@ -86,7 +178,9 @@ func TestEspressoCaffNode(t *testing.T) {
 
 	log.Info("Starting the caff node")
 	// start the node
-	builderCaffNode, cleanupCaffNode := createCaffNode(ctx, t, builder)
+	builder, cleanupCaffNode, err := createCaffNode(ctx, t, builder, false)
+	Require(t, err)
+	builderCaffNode := builder.L2
 	defer cleanupCaffNode()
 
 	err = waitForWith(ctx, 10*time.Minute, 10*time.Second, func() bool {
@@ -138,4 +232,246 @@ func TestEspressoCaffNode(t *testing.T) {
 	// Send transaction to CaffNode and it should works later
 	err = checkTransferTxOnL2(t, ctx, builderCaffNode, "User17", builder.L2Info)
 	Require(t, err)
+}
+
+func Setup(t *testing.T) (context.Context, common.Address, info, string, context.CancelFunc, func(), *NodeBuilder, func(), func()) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	valNodeCleanup := createValidationNode(ctx, t, true)
+
+	builder, cleanup := createL1AndL2Node(ctx, t, true)
+
+	err := waitForL1Node(ctx)
+	Require(t, err)
+
+	cleanEspresso := runEspresso()
+
+	// wait for the builder
+	err = waitForEspressoNode(ctx)
+	Require(t, err)
+
+	newAccount := "User16"
+	l2Info := builder.L2Info
+	l2Info.GenerateAccount(newAccount)
+	addr := l2Info.GetAddress(newAccount)
+	return ctx, addr, l2Info, newAccount, cancel, valNodeCleanup, builder, cleanup, cleanEspresso
+}
+
+func TestEspressoCaffNodeDelayedMessagesConfirmations(t *testing.T) {
+	ctx, addr, l2Info, newAccount, cancel, valNodeCleanup, builder, cleanup, cleanEspresso := Setup(t)
+	defer cancel()
+	defer valNodeCleanup()
+	defer cleanup()
+	defer cleanEspresso()
+	// Set caff node config variables
+	builder.nodeConfig.EspressoCaffNode.WaitForConfirmations = true
+	builder.nodeConfig.EspressoCaffNode.RequiredBlockDepth = 6
+	builder.nodeConfig.EspressoCaffNode.WaitForFinalization = false
+
+	// start the node
+	log.Info("Starting the caff node")
+	builder2, cleanupCaffNode, err := createCaffNode(ctx, t, builder, false)
+	Require(t, err)
+	builderCaffNode := builder2.L2
+	defer cleanupCaffNode()
+
+	// Transfer via the delayed inbox
+	delayedTx := l2Info.PrepareTx("Owner", newAccount, 3e7, transferAmount, nil)
+	log.Info("Delayed tx", "delayedtx", delayedTx)
+	tx := builder.L1.SendWaitTestTransactions(t, []*types.Transaction{
+		WrapL2ForDelayed(t, delayedTx, builder.L1Info, "Faucet", 100000),
+	})
+	// Check the caff node RPC for tx. assert that it is not there.
+	_, _, err = builderCaffNode.Client.TransactionByHash(ctx, tx[0].TxHash)
+	ExpectErr(t, err, ethereum.NotFound)
+
+	// Create the event function closures for the assert statement.
+	firstEvent := func() error {
+		err := waitForWith(ctx, 240*time.Second, 1*time.Second, func() bool {
+			header, err := builder.L1.Client.HeaderByNumber(ctx, nil) // get the latest header to check tx block depth
+			Require(t, err)
+			return header.Number.Uint64() >= tx[0].BlockNumber.Uint64()+builder.nodeConfig.EspressoCaffNode.RequiredBlockDepth // check that the tx is at least RequiredBlockDepth blocks deep in the parent chains state.
+		})
+		return err
+	}
+	secondEvent := func() error {
+		err := waitForWith(ctx, 240*time.Second, 10*time.Second, func() bool {
+			balance := builderCaffNode.GetBalance(t, addr)
+			log.Info("waiting for balance", "account", newAccount, "addr", addr, "balance", balance)
+			if balance.Cmp(transferAmount) >= 0 {
+				log.Info("Balance has entered account", "balance", balance, "account", newAccount)
+			}
+			return balance.Cmp(transferAmount) >= 0
+		})
+		return err
+	}
+	// Assert that the delayed message should reach the required block depth before the balance appears on the caff node.
+	AssertEventOrdering(t, firstEvent, secondEvent)
+	log.Info("Concurrent events finished in the correct order!")
+}
+
+func TestEspressoCaffNodeDelayedMessagesFinalized(t *testing.T) {
+	ctx, addr, l2Info, newAccount, cancel, valNodeCleanup, builder, cleanup, cleanEspresso := Setup(t)
+	defer cancel()
+	defer valNodeCleanup()
+	defer cleanup()
+	defer cleanEspresso()
+
+	// Set caff node config vars
+	builder.nodeConfig.EspressoCaffNode.WaitForConfirmations = false
+	builder.nodeConfig.EspressoCaffNode.RequiredBlockDepth = 6
+	builder.nodeConfig.EspressoCaffNode.WaitForFinalization = true
+	// start the node
+	log.Info("Starting the caff node")
+	builder2, cleanupCaffNode, err := createCaffNode(ctx, t, builder, false)
+	Require(t, err)
+	builderCaffNode := builder2.L2
+	defer cleanupCaffNode()
+
+	// Transfer via the delayed inbox
+	delayedTx := l2Info.PrepareTx("Owner", newAccount, 3e7, transferAmount, nil)
+	log.Info("Delayed tx", "delayedtx", delayedTx)
+	tx := builder.L1.SendWaitTestTransactions(t, []*types.Transaction{
+		WrapL2ForDelayed(t, delayedTx, builder.L1Info, "Faucet", 100000),
+	})
+	// Check the caff node RPC for tx. assert that it is not there.
+	_, _, err = builderCaffNode.Client.TransactionByHash(ctx, tx[0].TxHash)
+	ExpectErr(t, err, ethereum.NotFound)
+	// Wait for the tx header to be finalized.
+
+	firstEvent := func() error {
+		err := waitForWith(ctx, 240*time.Second, 1*time.Second, func() bool {
+			header, err := builder.L1.Client.HeaderByNumber(ctx, big.NewInt(rpc.FinalizedBlockNumber.Int64()))
+			Require(t, err)
+			return header.Number.Int64() >= tx[0].BlockNumber.Int64()
+		})
+		return err
+	}
+	secondEvent := func() error {
+		err := waitForWith(ctx, 240*time.Second, 10*time.Second, func() bool {
+			balance := builderCaffNode.GetBalance(t, addr)
+			log.Info("waiting for balance", "account", newAccount, "addr", addr, "balance", balance)
+			if balance.Cmp(transferAmount) >= 0 {
+				log.Info("Balance has entered account", "balance", balance, "account", newAccount)
+			}
+			return balance.Cmp(transferAmount) >= 0
+		})
+		return err
+	}
+	AssertEventOrdering(t, firstEvent, secondEvent)
+	log.Info("Concurrent events finished in the correct order!")
+}
+
+func TestEspressoCaffNodeUnfinalizedDelayedMessages(t *testing.T) {
+	ctx, addr, l2Info, newAccount, cancel, valNodeCleanup, builder, cleanup, cleanEspresso := Setup(t)
+	defer cancel()
+	defer valNodeCleanup()
+	defer cleanup()
+	defer cleanEspresso()
+	// set caff node config vars
+	builder.nodeConfig.EspressoCaffNode.WaitForConfirmations = false
+	builder.nodeConfig.EspressoCaffNode.RequiredBlockDepth = 6
+	builder.nodeConfig.EspressoCaffNode.WaitForFinalization = false
+
+	// start the node
+	log.Info("Starting the caff node")
+	builder2, cleanupCaffNode, err := createCaffNode(ctx, t, builder, false)
+	Require(t, err)
+	builderCaffNode := builder2.L2
+	defer cleanupCaffNode()
+
+	// Transfer via the delayed inbox
+	delayedTx3 := l2Info.PrepareTx("Owner", newAccount, 3e7, transferAmount, nil)
+	tx3 := builder.L1.SendWaitTestTransactions(t, []*types.Transaction{
+		WrapL2ForDelayed(t, delayedTx3, builder.L1Info, "Faucet", 100000),
+	})
+	// Wait for the tx to appear on the caff node
+	err = waitForWith(ctx, 240*time.Second, 10*time.Second, func() bool {
+		balance := builderCaffNode.GetBalance(t, addr)
+		log.Info("waiting for balance", "account", newAccount, "addr", addr, "balance", balance)
+		if balance.Cmp(transferAmount) >= 0 {
+			log.Info("Balance has entered account", "balance", balance, "account", newAccount)
+		}
+		return balance.Cmp(transferAmount) >= 0
+	})
+	Require(t, err)
+
+	finalizedHeader, err := builder.L1.Client.HeaderByNumber(ctx, big.NewInt(rpc.FinalizedBlockNumber.Int64()))
+	if tx3[0].BlockNumber.Int64() <= finalizedHeader.Number.Int64() {
+		t.Fatal("Tx finalized before appearing in the caff node")
+	}
+	Require(t, err)
+}
+
+// RequireErr:
+// This serves to assert that we should be expecting some error during the test, and if there is not an error, fail the test.
+func RequireErr(t *testing.T, err error, expectedError error) {
+	t.Helper()
+	if err == nil {
+		log.Error("expected an error to occurr", "expected error", expectedError)
+		t.Fatal(err, expectedError)
+	}
+}
+
+// ExpectErr:
+// This serves to assert that we should be expecting a specific error during the test, and if the error does not match, fail the test.
+func ExpectErr(t *testing.T, err error, expectedError error) {
+	t.Helper()
+	if !errors.Is(err, expectedError) {
+		t.Fatal(err, expectedError)
+	}
+}
+
+// This tests that the caff node config validates that known versions of arb sequencers are not enabled if the caff node is.
+func TestEspressoCaffNodeConfig(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	builder := createCaffNodeConfig(ctx, t)
+	err := builder.nodeConfig.Validate()
+	Require(t, err)
+
+	expectedErr := errors.New("cannot start a Caff node with any sequencer enabled")
+	// Test if this node is attempting to be a sequencer
+	builder.nodeConfig.Sequencer = true
+	err = builder.nodeConfig.Validate()
+	RequireErr(t, err, expectedErr)
+	// Test the delayed sequencer
+	builder.nodeConfig.Sequencer = false
+	builder.nodeConfig.DelayedSequencer.Enable = true
+
+	err = builder.nodeConfig.Validate()
+	RequireErr(t, err, expectedErr)
+
+	builder.nodeConfig.DelayedSequencer.Enable = false
+	builder.nodeConfig.SeqCoordinator.Enable = true
+
+	err = builder.nodeConfig.Validate()
+	RequireErr(t, err, expectedErr)
+
+}
+
+func TestEspressoCaffNodeDangerousConfig(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	builder, cleanup := createL1AndL2Node(ctx, t, true)
+	defer cleanup()
+
+	// start the node
+	_, cleanupCaffNode, err := createCaffNode(ctx, t, builder, true)
+	if cleanupCaffNode != nil {
+		defer cleanupCaffNode()
+	}
+
+	// The actual error is wrapped in an array, so we need to check for that
+	expectedErrMsg := "No next hotshot block found in database or dangerous.ignore-database-hotshot-block is set to true, please set config.CaffNodeConfig.NextHotshotBlock"
+
+	if err == nil {
+		t.Fatal("Expected an error but got nil")
+	}
+
+	// Check if the error contains the expected message (since it might be wrapped)
+	if !strings.Contains(err.Error(), expectedErrMsg) {
+		t.Errorf("Expected error to contain %q, got %q", expectedErrMsg, err.Error())
+	}
 }

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -16,11 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-<<<<<<< HEAD
 func createCaffNode(ctx context.Context, t *testing.T, existing *NodeBuilder, dangerous bool) (*NodeBuilder, func(), error) {
-=======
-func createCaffNode(ctx context.Context, t *testing.T, existing *NodeBuilder) (*NodeBuilder, func()) {
->>>>>>> e865504649aaaf308b28360d3d6ec73c9855d35e
 	builder := NewNodeBuilder(ctx).DefaultConfig(t, false)
 	nodeConfig := builder.nodeConfig
 	execConfig := builder.execConfig
@@ -50,10 +46,14 @@ func createCaffNode(ctx context.Context, t *testing.T, existing *NodeBuilder) (*
 	nodeConfig.EspressoCaffNode.HotshotPollingInterval = time.Millisecond * 100
 	nodeConfig.ParentChainReader.Enable = true
 
-	cleanup := builder.BuildEspressoCaffNode(t, existing)
-	return builder, cleanup
-}
+	if dangerous {
+		nodeConfig.EspressoCaffNode.Dangerous.IgnoreDatabaseHotshotBlock = true
+		nodeConfig.EspressoCaffNode.NextHotshotBlock = 0
+	}
 
+	cleanup, err := builder.BuildEspressoCaffNode(t, existing)
+	return builder, cleanup, err
+}
 
 func createCaffNodeConfig(ctx context.Context, t *testing.T) *NodeBuilder {
 	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
@@ -245,7 +245,7 @@ func Setup(t *testing.T) (context.Context, common.Address, info, string, context
 
 	valNodeCleanup := createValidationNode(ctx, t, true)
 
-	builder, cleanup := createL1AndL2Node(ctx, t, true)
+	builder, cleanup := createL1AndL2Node(ctx, t, true, false)
 
 	err := waitForL1Node(ctx)
 	Require(t, err)
@@ -460,7 +460,7 @@ func TestEspressoCaffNodeDangerousConfig(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	builder, cleanup := createL1AndL2Node(ctx, t, true)
+	builder, cleanup := createL1AndL2Node(ctx, t, true, false)
 	defer cleanup()
 
 	// start the node

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -663,7 +663,7 @@ func (b *NodeBuilder) BuildL2(t *testing.T) func() {
 	return func() { b.L2.cleanup() }
 }
 
-func (b *NodeBuilder) BuildEspressoCaffNode(t *testing.T, existing *NodeBuilder) func() {
+func (b *NodeBuilder) BuildEspressoCaffNode(t *testing.T, existing *NodeBuilder) (func(), error) {
 	b.L2 = NewTestClient(b.ctx)
 	AddValNodeIfNeeded(t, b.ctx, b.nodeConfig, true, "", b.valnodeConfig.Wasm.RootPath)
 
@@ -680,16 +680,22 @@ func (b *NodeBuilder) BuildEspressoCaffNode(t *testing.T, existing *NodeBuilder)
 	execConfig := b.execConfig
 	execConfigFetcher := func() *gethexec.Config { return execConfig }
 	execNode, err := gethexec.CreateExecutionNode(b.ctx, b.L2.Stack, chainDb, blockchain, nil, execConfigFetcher)
-	Require(t, err)
+	if err != nil {
+		return nil, err
+	}
 
 	fatalErrChan := make(chan error, 10)
 	b.L2.ConsensusNode, err = arbnode.CreateNode(
 		b.ctx, b.L2.Stack, execNode, arbDb, NewFetcherFromConfig(b.nodeConfig), blockchain.Config(),
 		l1Client, deployInfo, nil, nil, nil, fatalErrChan, big.NewInt(1337), nil)
-	Require(t, err)
+	if err != nil {
+		return nil, err
+	}
 
 	err = b.L2.ConsensusNode.Start(b.ctx)
-	Require(t, err)
+	if err != nil {
+		return nil, err
+	}
 
 	b.L2.Client = ClientForStack(t, b.L2.Stack)
 
@@ -697,7 +703,7 @@ func (b *NodeBuilder) BuildEspressoCaffNode(t *testing.T, existing *NodeBuilder)
 
 	b.L2.ExecNode = getExecNode(t, b.L2.ConsensusNode)
 	b.L2.cleanup = func() { b.L2.ConsensusNode.StopAndWait() }
-	return func() { b.L2.cleanup() }
+	return func() { b.L2.cleanup() }, nil
 }
 
 // L2 -Only. RestartL2Node shutdowns the existing l2 node and start it again using the same data dir.


### PR DESCRIPTION

### This PR:
Adds a dangrous config to Caff node which allows you to bypass the hotshot block number stored in the database. 
This is useful in the case where database has an outdated value



### Key places to review:
- espresso_caff_node.go

 ### How to test this PR:  
Run the `TestCaffNodeDangerousConfig` test




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210197320051326