### PR TITLE
Update bold submodule to v3.5.6 commit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -39,5 +39,5 @@
 [submodule "bold"]
 	path = bold
 	url = https://github.com/EspressoSystems/bold.git
-	branch = 55c6b6d7daacb856dd877c1ce7c870d7d7b831cf
+	branch = release-v3.5.6-55c6b6d7
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -39,5 +39,5 @@
 [submodule "bold"]
 	path = bold
 	url = https://github.com/EspressoSystems/bold.git
-	branch = sync-v3.5.6
+	branch = 55c6b6d7daacb856dd877c1ce7c870d7d7b831cf
 


### PR DESCRIPTION
Instead of pointing to the PR branch in the `.gitmodules` file, point the bold repository to the v3.5.6 release.