### PR TITLE
Fix that last potential message can be nil when building a batch

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -1619,7 +1619,7 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 	for addMessageLoop() {
 		msg, err := getNextMessage()
 		if err != nil {
-			if breakLoopWhenErrorOccurs {
+			if breakLoopWhenErrorOccurs && lastPotentialMsg != nil {
 				log.Error("Error getting next message", "err", err, "pos", b.building.msgCount)
 				break
 			}


### PR DESCRIPTION
### This PR:
fixes a bug when the last message is nil
