### PR TITLE
Caff node force inclusion checker

### DIFF
--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -261,7 +261,10 @@ func (n *EspressoCaffNode) createBlock(ctx context.Context) (returnValue bool) {
 func (n *EspressoCaffNode) Start(ctx context.Context) error {
 	n.StopWaiter.Start(ctx, n)
 	n.espressoStreamer.Start(ctx)
-	n.forceInclusionChecker.Start(ctx)
+	err := n.forceInclusionChecker.Start(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to start force inclusion checker: %w", err)
+	}
 
 	// This is +1 because the current block is the block after the last processed block
 	currentBlockNum := n.executionEngine.Bc().CurrentBlock().Number.Uint64() + 1

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -18,6 +18,7 @@ import (
 	"github.com/offchainlabs/nitro/espressostreamer"
 	"github.com/offchainlabs/nitro/espressotee"
 	"github.com/offchainlabs/nitro/execution/gethexec"
+	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
 	"github.com/offchainlabs/nitro/util/headerreader"
 	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
@@ -37,6 +38,9 @@ type EspressoCaffNodeConfig struct {
 	WaitForConfirmations    bool          `koanf:"wait-for-confirmations"`
 	RequiredBlockDepth      uint64        `koanf:"required-block-depth"`
 	BlocksToRead            uint64        `koanf:"blocks-to-read"`
+
+	// Force Inclusion Checker
+	ForceInclusionCheckerConfig ForceInclusionCheckerConfig `koanf:"force-inclusion-checker"`
 }
 
 var DefaultEspressoCaffNodeConfig = EspressoCaffNodeConfig{
@@ -71,6 +75,8 @@ func EspressoCaffNodeConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".wait-for-confirmations", DefaultEspressoCaffNodeConfig.WaitForConfirmations, "Configures the Caff node to only produce blocks from delayed messages if they have atleast requiredBlockDepth confirmations on the parent chain")
 	f.Uint64(prefix+".required-block-depth", DefaultEspressoCaffNodeConfig.RequiredBlockDepth, "Configures the required block depth/number of confirmations on the parent chain that a delayed message is required to have before this Caff node will add it to it's state")
 	f.Uint64(prefix+".blocks-to-read", DefaultEspressoCaffNodeConfig.BlocksToRead, "Configures the number of blocks to read from the parent chain for delayed messages")
+
+	EspressoForceInclusionConfigAddOptions(prefix+".force-inclusion-checker", f)
 }
 
 type EspressoCaffNodeConfigFetcher func() *EspressoCaffNodeConfig
@@ -87,6 +93,9 @@ type EspressoCaffNode struct {
 	delayedMessageFetcher DelayedMessageFetcherInterface
 
 	l1Reader *headerreader.HeaderReader
+
+	forceInclusionChecker *ForceInclusionChecker
+	fatalErrChan          chan error
 }
 
 func NewEspressoCaffNode(
@@ -97,6 +106,8 @@ func NewEspressoCaffNode(
 	db ethdb.Database,
 	recordPerformance bool,
 	blocksToRead uint64,
+	seqInboxAddr common.Address,
+	fatalErrChan chan error,
 ) *EspressoCaffNode {
 	if !configFetcher().Enable {
 		return nil
@@ -130,6 +141,20 @@ func NewEspressoCaffNode(
 	delayedMessageFetcher := NewDelayedMessageFetcher(delayedBridge, l1Reader, db, blocksToRead,
 		configFetcher().WaitForFinalization, configFetcher().WaitForConfirmations, configFetcher().RequiredBlockDepth)
 
+	seqInbox, err := bridgegen.NewSequencerInbox(seqInboxAddr, l1Reader.Client())
+	if err != nil {
+		log.Crit("failed to create sequencer inbox", "err", err)
+		return nil
+	}
+
+	forceInclusionChecker := NewForceInclusionChecker(
+		&SeqInbox{seqInbox: seqInbox},
+		configFetcher().ForceInclusionCheckerConfig,
+		l1Reader,
+		delayedMessageFetcher,
+		fatalErrChan,
+	)
+
 	return &EspressoCaffNode{
 		configFetcher:         configFetcher,
 		executionEngine:       execEngine,
@@ -137,6 +162,7 @@ func NewEspressoCaffNode(
 		espressoStreamer:      espressoStreamer,
 		db:                    db,
 		l1Reader:              l1Reader,
+		forceInclusionChecker: forceInclusionChecker,
 	}
 }
 
@@ -235,6 +261,7 @@ func (n *EspressoCaffNode) createBlock(ctx context.Context) (returnValue bool) {
 func (n *EspressoCaffNode) Start(ctx context.Context) error {
 	n.StopWaiter.Start(ctx, n)
 	n.espressoStreamer.Start(ctx)
+	n.forceInclusionChecker.Start(ctx)
 
 	// This is +1 because the current block is the block after the last processed block
 	currentBlockNum := n.executionEngine.Bc().CurrentBlock().Number.Uint64() + 1

--- a/arbnode/espresso_force_inclusion_checker.go
+++ b/arbnode/espresso_force_inclusion_checker.go
@@ -1,0 +1,155 @@
+package arbnode
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
+	"github.com/offchainlabs/nitro/util/arbmath"
+	"github.com/offchainlabs/nitro/util/headerreader"
+	"github.com/offchainlabs/nitro/util/stopwaiter"
+	flag "github.com/spf13/pflag"
+)
+
+type ForceInclusionCheckerConfig struct {
+	RetryTime                time.Duration `koanf:"retry-time"`
+	PollingInterval          time.Duration `koanf:"polling-interval"`
+	BlockThresholdTolerance  uint64        `koanf:"block-threshold-tolerance"`
+	SecondThresholdTolerance uint64        `koanf:"second-threshold-tolerance"`
+}
+
+var DefaultEspressoForceInclusionCheckerConfig = ForceInclusionCheckerConfig{
+	RetryTime:                time.Second * 2,
+	PollingInterval:          time.Second * 100,
+	BlockThresholdTolerance:  20,
+	SecondThresholdTolerance: 200,
+}
+
+func EspressoForceInclusionConfigAddOptions(prefix string, f *flag.FlagSet) {
+	f.Duration(prefix+".retry-time", DefaultEspressoForceInclusionCheckerConfig.RetryTime, "retry time after a failure")
+	f.Duration(prefix+".polling-interval", DefaultEspressoForceInclusionCheckerConfig.PollingInterval, "time after a success")
+	f.Uint64(prefix+".block-threshold-tolerance", DefaultEspressoForceInclusionCheckerConfig.BlockThresholdTolerance, "block threshold tolerance")
+	f.Uint64(prefix+".second-threshold-tolerance", DefaultEspressoForceInclusionCheckerConfig.SecondThresholdTolerance, "second threshold tolerance")
+}
+
+// SeqInboxInterface defines an interface for interacting with the sequencer inbox contract.
+// Note: When `deployBold` is disabled, the [MaxTimeVariation](cci:1://file:///Users/jeremyhe/work/nitro-espresso-integration/arbnode/espresso_force_inclusion_checker.go:14:1-14:78) values are hardcoded,
+// which makes this interface difficult to mock in tests.
+type SeqInboxInterface interface {
+	MaxTimeVariation(context.Context) (*big.Int, *big.Int, *big.Int, *big.Int, error)
+	TotalDelayedMessagesRead(context.Context) (*big.Int, error)
+}
+
+type SeqInbox struct {
+	seqInbox *bridgegen.SequencerInbox
+}
+
+func (s *SeqInbox) MaxTimeVariation(ctx context.Context) (*big.Int, *big.Int, *big.Int, *big.Int, error) {
+	return s.seqInbox.MaxTimeVariation(&bind.CallOpts{Context: ctx})
+}
+
+func (s *SeqInbox) TotalDelayedMessagesRead(ctx context.Context) (*big.Int, error) {
+	return s.seqInbox.TotalDelayedMessagesRead(&bind.CallOpts{Context: ctx})
+}
+
+type ForceInclusionChecker struct {
+	stopwaiter.StopWaiter
+
+	seqInbox              SeqInboxInterface
+	config                ForceInclusionCheckerConfig
+	l1Reader              *headerreader.HeaderReader
+	delayedMessageFetcher *DelayedMessageFetcher
+	fatalErrChan          chan error
+}
+
+func NewForceInclusionChecker(
+	seqInbox SeqInboxInterface,
+	config ForceInclusionCheckerConfig,
+	l1Reader *headerreader.HeaderReader,
+	delayedMessageFetcher *DelayedMessageFetcher,
+	fatalErrChan chan error,
+) *ForceInclusionChecker {
+	return &ForceInclusionChecker{
+		seqInbox:              seqInbox,
+		config:                config,
+		l1Reader:              l1Reader,
+		delayedMessageFetcher: delayedMessageFetcher,
+		fatalErrChan:          fatalErrChan,
+	}
+}
+
+func (f *ForceInclusionChecker) checkIfMessageCanBeForceIncluded(ctx context.Context) error {
+	// Get the total number of delayed messages read in the sequencer inbox
+	totalDelayedMessagesRead, err := f.seqInbox.TotalDelayedMessagesRead(ctx)
+	if err != nil {
+		return fmt.Errorf("error getting total delayed messages read: %w", err)
+	}
+
+	// Get the earliest block number that is without the force inclusion tolerance
+	badBlockNumber := f.getForceInclusionToleranceBlockNumber(ctx)
+	// Check the delayed message count at this block number
+	count, err := f.delayedMessageFetcher.getDelayedMessageCountAtBlock(badBlockNumber)
+	if err != nil {
+		return fmt.Errorf("error getting delayed message count at block %d: %w", badBlockNumber, err)
+	}
+	// If the message count in delay inbox is less than or equal to the total delayed messages read
+	// then no force inclusion is going to happen.
+	if count <= arbmath.BigToUintSaturating(totalDelayedMessagesRead) {
+		return nil
+	}
+	// Force inclusion is going to happen, panic the node.
+	err = fmt.Errorf("force inclusion is going to happen")
+	f.fatalErrChan <- err
+	return err
+}
+
+func (f *ForceInclusionChecker) Start(ctx context.Context) error {
+	f.StopWaiter.Start(ctx, f)
+
+	return f.CallIterativelySafe(func(ctx context.Context) time.Duration {
+		err := f.checkIfMessageCanBeForceIncluded(ctx)
+		if err != nil {
+			log.Error("error checking force inclusion", "err", err)
+			return f.config.RetryTime
+		}
+		return f.config.PollingInterval
+	})
+}
+
+func (f *ForceInclusionChecker) getForceInclusionToleranceBlockNumber(ctx context.Context) uint64 {
+	maxTimeVariationDelayBlocks, _, maxTimeVariationDelaySeconds, _, err := f.seqInbox.MaxTimeVariation(ctx)
+	if err != nil {
+		return 0
+	}
+	currentParentChainBlock, err := f.l1Reader.Client().BlockByNumber(ctx, nil)
+	if err != nil {
+		return 0
+	}
+
+	lastBadBlockNumber := arbmath.SaturatingUSub(f.config.BlockThresholdTolerance+currentParentChainBlock.NumberU64(), arbmath.BigToUintSaturating(maxTimeVariationDelayBlocks))
+	lastBadBlockTime := arbmath.SaturatingUSub(f.config.SecondThresholdTolerance+currentParentChainBlock.Time(), arbmath.BigToUintSaturating(maxTimeVariationDelaySeconds))
+
+	lastBadBlock := f.findFirstParentChainBlockBelow(ctx, lastBadBlockNumber, lastBadBlockTime)
+	return lastBadBlock
+}
+
+func (f *ForceInclusionChecker) findFirstParentChainBlockBelow(ctx context.Context, lastBadBlockNumber uint64, lastBadBlockTime uint64) uint64 {
+	client := f.l1Reader.Client()
+	blockNumber := lastBadBlockNumber
+
+	for blockNumber > 0 {
+		block, err := client.BlockByNumber(ctx, arbmath.UintToBig(blockNumber))
+		if err != nil {
+			return 0
+		}
+		if block.NumberU64() <= lastBadBlockNumber || block.Time() <= lastBadBlockTime {
+			return block.NumberU64()
+		}
+		blockNumber--
+	}
+	return 0
+}

--- a/arbnode/espresso_force_inclusion_checker.go
+++ b/arbnode/espresso_force_inclusion_checker.go
@@ -37,7 +37,7 @@ func EspressoForceInclusionConfigAddOptions(prefix string, f *flag.FlagSet) {
 }
 
 // SeqInboxInterface defines an interface for interacting with the sequencer inbox contract.
-// Note: When `deployBold` is disabled, the [MaxTimeVariation](cci:1://file:///Users/jeremyhe/work/nitro-espresso-integration/arbnode/espresso_force_inclusion_checker.go:14:1-14:78) values are hardcoded,
+// Note: When `deployBold` is disabled, the [MaxTimeVariation](arbnode/espresso_force_inclusion_checker.go:14:1-14:78) values are hardcoded,
 // which makes this interface difficult to mock in tests.
 type SeqInboxInterface interface {
 	MaxTimeVariation(context.Context) (*big.Int, *big.Int, *big.Int, *big.Int, error)

--- a/arbnode/espresso_force_inclusion_checker.go
+++ b/arbnode/espresso_force_inclusion_checker.go
@@ -22,6 +22,8 @@ type ForceInclusionCheckerConfig struct {
 	PollingInterval          time.Duration `koanf:"polling-interval"`
 	BlockThresholdTolerance  uint64        `koanf:"block-threshold-tolerance"`
 	SecondThresholdTolerance uint64        `koanf:"second-threshold-tolerance"`
+
+	ErrorToleranceDuration time.Duration `koanf:"error-tolerance-duration"`
 }
 
 var DefaultEspressoForceInclusionCheckerConfig = ForceInclusionCheckerConfig{
@@ -29,6 +31,7 @@ var DefaultEspressoForceInclusionCheckerConfig = ForceInclusionCheckerConfig{
 	PollingInterval:          time.Second * 100,
 	BlockThresholdTolerance:  20,
 	SecondThresholdTolerance: 200,
+	ErrorToleranceDuration:   time.Hour * 1,
 }
 
 func EspressoForceInclusionConfigAddOptions(prefix string, f *flag.FlagSet) {
@@ -36,6 +39,7 @@ func EspressoForceInclusionConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Duration(prefix+".polling-interval", DefaultEspressoForceInclusionCheckerConfig.PollingInterval, "time after a success")
 	f.Uint64(prefix+".block-threshold-tolerance", DefaultEspressoForceInclusionCheckerConfig.BlockThresholdTolerance, "block threshold tolerance")
 	f.Uint64(prefix+".second-threshold-tolerance", DefaultEspressoForceInclusionCheckerConfig.SecondThresholdTolerance, "second threshold tolerance")
+	f.Duration(prefix+".error-tolerance-duration", DefaultEspressoForceInclusionCheckerConfig.ErrorToleranceDuration, "error tolerance duration")
 }
 
 // SeqInboxInterface defines an interface for interacting with the sequencer inbox contract.
@@ -114,13 +118,20 @@ func (f *ForceInclusionChecker) checkIfMessageCanBeForceIncluded(ctx context.Con
 
 func (f *ForceInclusionChecker) Start(ctx context.Context) error {
 	f.StopWaiter.Start(ctx, f)
+	var firstErrFound time.Time
 
 	return f.CallIterativelySafe(func(ctx context.Context) time.Duration {
 		err := f.checkIfMessageCanBeForceIncluded(ctx)
 		if err != nil {
+			if firstErrFound.IsZero() {
+				firstErrFound = time.Now()
+			} else if time.Since(firstErrFound) > f.config.ErrorToleranceDuration {
+				f.fatalErrChan <- err
+			}
 			log.Error("error checking force inclusion", "err", err)
 			return f.config.RetryTime
 		}
+		firstErrFound = time.Time{}
 		return f.config.PollingInterval
 	})
 }
@@ -153,10 +164,34 @@ func (f *ForceInclusionChecker) getForceInclusionToleranceBlockNumber(ctx contex
 			return 0, err
 		}
 		rng, err := n.L2BlockRangeForL1(&bind.CallOpts{Context: ctx}, lastBadBlockNumber)
-		if err != nil {
-			return 0, err
+		if err == nil {
+			lastBadBlockNumber = rng.LastBlock
+		} else {
+			genesis, err := n.NitroGenesisBlock(&bind.CallOpts{Context: ctx})
+			if err != nil {
+				return 0, err
+			}
+			target := lastBadBlockNumber
+			start := genesis.Uint64()
+			end := parentLatestHeader.Number.Uint64()
+			lastBadBlockNumber, err = binarySearchForBlockNumber(ctx, start, end, func(ctx context.Context, blockNumber uint64) (int, error) {
+				block, err := f.l1Reader.Client().BlockByNumber(ctx, arbmath.UintToBig(blockNumber))
+				if err != nil {
+					return 0, err
+				}
+				l1Block := types.DeserializeHeaderExtraInformation(block.Header()).L1BlockNumber
+				if l1Block < target {
+					return binarySearch_LessThanTarget, nil
+				} else if l1Block > target {
+					return binarySearch_GreaterThanTarget, nil
+				} else {
+					return binarySearch_EqualToTarget, nil
+				}
+			})
+			if err != nil {
+				return 0, err
+			}
 		}
-		lastBadBlockNumber = rng.LastBlock
 	}
 
 	lastBadBlock := f.findFirstParentChainBlockBelow(ctx, lastBadBlockNumber, lastBadBlockTime)

--- a/arbnode/espresso_force_inclusion_checker.go
+++ b/arbnode/espresso_force_inclusion_checker.go
@@ -7,8 +7,10 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
+	"github.com/offchainlabs/nitro/solgen/go/node_interfacegen"
 	"github.com/offchainlabs/nitro/util/arbmath"
 	"github.com/offchainlabs/nitro/util/headerreader"
 	"github.com/offchainlabs/nitro/util/stopwaiter"
@@ -90,7 +92,10 @@ func (f *ForceInclusionChecker) checkIfMessageCanBeForceIncluded(ctx context.Con
 	}
 
 	// Get the earliest block number that is without the force inclusion tolerance
-	badBlockNumber := f.getForceInclusionToleranceBlockNumber(ctx)
+	badBlockNumber, err := f.getForceInclusionToleranceBlockNumber(ctx)
+	if err != nil {
+		return fmt.Errorf("error getting force inclusion tolerance block number: %w", err)
+	}
 	// Check the delayed message count at this block number
 	count, err := f.delayedMessageFetcher.getDelayedMessageCountAtBlock(badBlockNumber)
 	if err != nil {
@@ -120,21 +125,42 @@ func (f *ForceInclusionChecker) Start(ctx context.Context) error {
 	})
 }
 
-func (f *ForceInclusionChecker) getForceInclusionToleranceBlockNumber(ctx context.Context) uint64 {
+func (f *ForceInclusionChecker) getForceInclusionToleranceBlockNumber(ctx context.Context) (uint64, error) {
 	maxTimeVariationDelayBlocks, _, maxTimeVariationDelaySeconds, _, err := f.seqInbox.MaxTimeVariation(ctx)
 	if err != nil {
-		return 0
-	}
-	currentParentChainBlock, err := f.l1Reader.Client().BlockByNumber(ctx, nil)
-	if err != nil {
-		return 0
+		return 0, err
 	}
 
-	lastBadBlockNumber := arbmath.SaturatingUSub(f.config.BlockThresholdTolerance+currentParentChainBlock.NumberU64(), arbmath.BigToUintSaturating(maxTimeVariationDelayBlocks))
-	lastBadBlockTime := arbmath.SaturatingUSub(f.config.SecondThresholdTolerance+currentParentChainBlock.Time(), arbmath.BigToUintSaturating(maxTimeVariationDelaySeconds))
+	parentLatestHeader, err := f.l1Reader.LastHeader(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	l1BlockNumber := parentLatestHeader.Number.Uint64()
+	l1TimeStamp := parentLatestHeader.Time
+
+	if f.l1Reader.IsParentChainArbitrum() {
+		headerInfo := types.DeserializeHeaderExtraInformation(parentLatestHeader)
+		l1BlockNumber = headerInfo.L1BlockNumber
+	}
+
+	lastBadBlockNumber := arbmath.SaturatingUSub(f.config.BlockThresholdTolerance+l1BlockNumber, arbmath.BigToUintSaturating(maxTimeVariationDelayBlocks))
+	lastBadBlockTime := arbmath.SaturatingUSub(f.config.SecondThresholdTolerance+l1TimeStamp, arbmath.BigToUintSaturating(maxTimeVariationDelaySeconds))
+
+	if f.l1Reader.IsParentChainArbitrum() {
+		n, err := node_interfacegen.NewNodeInterface(types.NodeInterfaceAddress, f.l1Reader.Client())
+		if err != nil {
+			return 0, err
+		}
+		rng, err := n.L2BlockRangeForL1(&bind.CallOpts{Context: ctx}, lastBadBlockNumber)
+		if err != nil {
+			return 0, err
+		}
+		lastBadBlockNumber = rng.LastBlock
+	}
 
 	lastBadBlock := f.findFirstParentChainBlockBelow(ctx, lastBadBlockNumber, lastBadBlockTime)
-	return lastBadBlock
+	return lastBadBlock, nil
 }
 
 func (f *ForceInclusionChecker) findFirstParentChainBlockBelow(ctx context.Context, lastBadBlockNumber uint64, lastBadBlockTime uint64) uint64 {

--- a/arbnode/espresso_force_inclusion_checker.go
+++ b/arbnode/espresso_force_inclusion_checker.go
@@ -2,6 +2,7 @@ package arbnode
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -15,6 +16,10 @@ import (
 	"github.com/offchainlabs/nitro/util/headerreader"
 	"github.com/offchainlabs/nitro/util/stopwaiter"
 	flag "github.com/spf13/pflag"
+)
+
+const (
+	ForceInclusionErr = errors.New("force inclusion is going to happen")
 )
 
 type ForceInclusionCheckerConfig struct {
@@ -111,28 +116,36 @@ func (f *ForceInclusionChecker) checkIfMessageCanBeForceIncluded(ctx context.Con
 		return nil
 	}
 	// Force inclusion is going to happen, panic the node.
-	err = fmt.Errorf("force inclusion is going to happen")
-	f.fatalErrChan <- err
-	return err
+	return ForceInclusionErr
 }
 
 func (f *ForceInclusionChecker) Start(ctx context.Context) error {
 	f.StopWaiter.Start(ctx, f)
 	var firstErrFound time.Time
 
+	// Do the check first before caff node starts
+	err := f.checkIfMessageCanBeForceIncluded(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to check force inclusion: %w", err)
+	}
+
 	return f.CallIterativelySafe(func(ctx context.Context) time.Duration {
 		err := f.checkIfMessageCanBeForceIncluded(ctx)
-		if err != nil {
-			if firstErrFound.IsZero() {
-				firstErrFound = time.Now()
-			} else if time.Since(firstErrFound) > f.config.ErrorToleranceDuration {
-				f.fatalErrChan <- err
-			}
-			log.Error("error checking force inclusion", "err", err)
-			return f.config.RetryTime
+		if err == nil {
+			firstErrFound = time.Time{}
+			return f.config.PollingInterval
 		}
-		firstErrFound = time.Time{}
-		return f.config.PollingInterval
+		if errors.Is(err, ForceInclusionErr) {
+			f.fatalErrChan <- err
+			return 0
+		}
+		if firstErrFound.IsZero() {
+			firstErrFound = time.Now()
+		} else if time.Since(firstErrFound) > f.config.ErrorToleranceDuration {
+			f.fatalErrChan <- err
+		}
+		log.Error("error checking force inclusion", "err", err)
+		return f.config.RetryTime
 	})
 }
 

--- a/arbnode/espresso_force_inclusion_checker.go
+++ b/arbnode/espresso_force_inclusion_checker.go
@@ -18,7 +18,7 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
-const (
+var (
 	ForceInclusionErr = errors.New("force inclusion is going to happen")
 )
 
@@ -180,6 +180,9 @@ func (f *ForceInclusionChecker) getForceInclusionToleranceBlockNumber(ctx contex
 		if err == nil {
 			lastBadBlockNumber = rng.LastBlock
 		} else {
+			// If the L2 block range for L1 call fails, we will use binary search
+			// The start block number should be the genesis block
+			// Reference: https://github.com/OffchainLabs/arbitrum-sdk/blob/792a7ee3ccf09842653bc49b771671706894cbb4/src/lib/inbox/inbox.ts#L104-L113
 			genesis, err := n.NitroGenesisBlock(&bind.CallOpts{Context: ctx})
 			if err != nil {
 				return 0, err

--- a/arbnode/espresso_force_inclusion_checker.go
+++ b/arbnode/espresso_force_inclusion_checker.go
@@ -33,10 +33,10 @@ type ForceInclusionCheckerConfig struct {
 
 var DefaultEspressoForceInclusionCheckerConfig = ForceInclusionCheckerConfig{
 	RetryTime:                time.Second * 2,
-	PollingInterval:          time.Second * 100,
+	PollingInterval:          time.Minute * 8,
 	BlockThresholdTolerance:  20,
 	SecondThresholdTolerance: 200,
-	ErrorToleranceDuration:   time.Hour * 1,
+	ErrorToleranceDuration:   time.Minute * 8,
 }
 
 func EspressoForceInclusionConfigAddOptions(prefix string, f *flag.FlagSet) {

--- a/arbnode/espresso_utils.go
+++ b/arbnode/espresso_utils.go
@@ -30,7 +30,6 @@ func binarySearchForBlockNumber(
 ) (uint64, error) {
 	for start < end {
 		mid := (start + end) / 2
-		fmt.Println("mid", mid)
 		result, err := f(ctx, mid)
 		if err != nil {
 			return 0, err

--- a/arbnode/espresso_utils.go
+++ b/arbnode/espresso_utils.go
@@ -1,6 +1,7 @@
 package arbnode
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -14,6 +15,38 @@ import (
 	"github.com/offchainlabs/nitro/solgen/go/espressogen"
 	"github.com/offchainlabs/nitro/util/signature"
 )
+
+var (
+	binarySearch_LessThanTarget    = -1
+	binarySearch_GreaterThanTarget = 1
+	binarySearch_EqualToTarget     = 0
+)
+
+// Looks for the first block number that is equal to or greater than the target
+func binarySearchForBlockNumber(
+	ctx context.Context,
+	start, end uint64,
+	f func(context.Context, uint64) (int, error),
+) (uint64, error) {
+	for start < end {
+		mid := (start + end) / 2
+		fmt.Println("mid", mid)
+		result, err := f(ctx, mid)
+		if err != nil {
+			return 0, err
+		}
+		if result == binarySearch_GreaterThanTarget {
+			end = mid
+		} else if result == binarySearch_LessThanTarget {
+			start = mid + 1
+		} else {
+			// We are looking for the first block number.
+			// So the loop should continue until start == end
+			end = mid
+		}
+	}
+	return start, nil
+}
 
 // We should be able to get the address as soon as we have the signer.
 // We don't want to change a lot of code to make this work since we are working on a forked repo.

--- a/arbnode/espresso_utils_test.go
+++ b/arbnode/espresso_utils_test.go
@@ -2,6 +2,7 @@ package arbnode
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -86,5 +87,55 @@ func TestGetMessageForSubmittingToEspresso(t *testing.T) {
 	}
 	if !bytes.Equal(msg.Message.L2msg, []byte{4}) {
 		t.Fatalf("expected message with L2msg [4], got %v", msg.Message.L2msg)
+	}
+}
+
+func TestBinarySearchForBlockNumber(t *testing.T) {
+	target := uint64(64)
+	count := 0
+	ctx := context.Background()
+	start := uint64(0)
+	end := uint64(100)
+	f := func(ctx context.Context, blockNumber uint64) (int, error) {
+		count++
+		if blockNumber < target {
+			return -1, nil
+		} else if blockNumber > target {
+			return 1, nil
+		}
+		return 0, nil
+	}
+	result, err := binarySearchForBlockNumber(ctx, start, end, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != target {
+		t.Fatalf("expected result %d, got %d", target, result)
+	}
+	if count > 7 {
+		t.Fatalf("expected count less than %d, got %d", 7, count)
+	}
+
+	targetRangeStart := uint64(60)
+	targetRangeEnd := uint64(70)
+	count = 0
+	f = func(ctx context.Context, blockNumber uint64) (int, error) {
+		count++
+		if blockNumber < targetRangeStart {
+			return -1, nil
+		} else if blockNumber > targetRangeEnd {
+			return 1, nil
+		}
+		return 0, nil
+	}
+	result, err = binarySearchForBlockNumber(ctx, start, end, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != targetRangeStart {
+		t.Fatalf("expected result %d, got %d", targetRangeStart, result)
+	}
+	if count > 7 {
+		t.Fatalf("expected count less than %d, got %d", 7, count)
 	}
 }

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -568,6 +568,8 @@ func createNodeImpl(
 				arbDb,
 				config.EspressoCaffNode.RecordPerformance,
 				config.EspressoCaffNode.BlocksToRead,
+				deployInfo.SequencerInbox,
+				fatalErrChan,
 			)
 
 			return &Node{

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -2,12 +2,16 @@ package arbtest
 
 import (
 	"context"
+	"math/big"
 	"strconv"
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/offchainlabs/nitro/arbnode"
+	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
 )
 
 func createCaffNode(ctx context.Context, t *testing.T, existing *NodeBuilder) (*TestClient, func()) {
@@ -139,4 +143,84 @@ func TestEspressoCaffNode(t *testing.T) {
 	// Send transaction to CaffNode and it should works later
 	err = checkTransferTxOnL2(t, ctx, builderCaffNode, "User17", builder.L2Info)
 	Require(t, err)
+}
+
+func TestEspressoForceInclusionChecker(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
+	cleanup := builder.Build(t)
+	defer cleanup()
+
+	addr := builder.addresses.SequencerInbox
+	seqInbox, err := bridgegen.NewSequencerInbox(addr, builder.L1.Client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockSeqInbox := &MockSeqInbox{
+		MaxDelayBlocks:  big.NewInt(20),
+		MaxDelaySeconds: big.NewInt(200),
+		seqInbox:        seqInbox,
+	}
+
+	config := arbnode.ForceInclusionCheckerConfig{
+		RetryTime:                time.Second * 2,
+		PollingInterval:          time.Second * 1,
+		BlockThresholdTolerance:  20,
+		SecondThresholdTolerance: 200,
+	}
+
+	delayedBridge, err := arbnode.NewDelayedBridge(builder.L1.Client, builder.addresses.Bridge, builder.addresses.DeployedAt)
+
+	reader := builder.L2.ConsensusNode.L1Reader
+
+	delayedMessageFetcher := arbnode.NewDelayedMessageFetcher(
+		delayedBridge,
+		reader,
+		builder.L2.ConsensusNode.ArbDB,
+		100,
+		false,
+		false,
+		10,
+	)
+
+	fatalErrChan := make(chan error)
+
+	forceInclusionChecker := arbnode.NewForceInclusionChecker(mockSeqInbox, config, reader, delayedMessageFetcher, fatalErrChan)
+	forceInclusionChecker.Start(ctx)
+
+	delayedTx := builder.L2Info.PrepareTx("Faucet", "Owner", 3e7, transferAmount, nil)
+	builder.L1.SendWaitTestTransactions(t, []*types.Transaction{
+		WrapL2ForDelayed(t, delayedTx, builder.L1Info, "Faucet", 100000),
+	})
+
+	select {
+	case err := <-fatalErrChan:
+		if err == nil {
+			t.Fatal("expected an error from fatalErrChan, got nil")
+		} else {
+			t.Logf("received error as expected: %v", err)
+		}
+	case <-time.After(100 * time.Second):
+		t.Fatal("did not receive error from fatalErrChan within timeout")
+	}
+}
+
+// MockSeqInbox is a mock implementation of the sequencer inbox interface,
+// allowing customizable time variation values for testing purposes.
+// This is useful because the real contract hardcodes MaxTimeVariation when deployBold is disabled.
+type MockSeqInbox struct {
+	MaxDelayBlocks  *big.Int
+	MaxDelaySeconds *big.Int
+	seqInbox        *bridgegen.SequencerInbox
+}
+
+func (m *MockSeqInbox) MaxTimeVariation(ctx context.Context) (*big.Int, *big.Int, *big.Int, *big.Int, error) {
+	return m.MaxDelayBlocks, nil, m.MaxDelaySeconds, nil, nil
+}
+
+func (m *MockSeqInbox) TotalDelayedMessagesRead(ctx context.Context) (*big.Int, error) {
+	return m.seqInbox.TotalDelayedMessagesRead(&bind.CallOpts{Context: ctx})
 }

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -170,6 +170,7 @@ func TestEspressoForceInclusionChecker(t *testing.T) {
 		PollingInterval:          time.Second * 1,
 		BlockThresholdTolerance:  20,
 		SecondThresholdTolerance: 200,
+		ErrorToleranceDuration:   time.Minute * 10,
 	}
 
 	delayedBridge, err := arbnode.NewDelayedBridge(builder.L1.Client, builder.addresses.Bridge, builder.addresses.DeployedAt)


### PR DESCRIPTION
### This PR:
- Adds a force inclusion checker in caff node following [this design doc](https://github.com/EspressoSystems/book/pull/52). The only change is getting the delayed count using the existing function.
- Adds a test

### Key places to review:
- caff_node_test.go


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209845224208640
  - https://app.asana.com/0/0/1209837645605781