### PR TITLE
Fix CI

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -436,22 +436,25 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 
 		// check if the pos is already finalized on L1
 		// and get the current finalized block number from L1
-		finalizedBlockNumber, err := opts.L1Reader.LatestFinalizedBlockNr(context.Background())
+		blockNumber, err := opts.L1Reader.LatestFinalizedBlockNr(context.Background())
 		if err != nil {
 			return nil, fmt.Errorf("failed to get finalized block number: %w", err)
 		}
 
-		sequencerMessageCount := new(big.Int).SetUint64(0)
-
-		if finalizedBlockNumber > opts.DeployInfo.DeployedAt {
-			sequencerMessageCount, err = bridge.SequencerReportedSubMessageCount(&bind.CallOpts{
-				BlockNumber: new(big.Int).SetUint64(finalizedBlockNumber),
-			})
-			if err != nil {
-				log.Error("failed to get sequencerMessageCount", "err", err)
-				return nil, fmt.Errorf("failed to get sequencerMessageCount: %w", err)
-			}
+		// Edge case: its possible that batch poster is started even before the `DeployedAt` block is finalized
+		// in that case we should use the `DeployedAt` block number because no message would have been posted before that
+		if blockNumber < opts.DeployInfo.DeployedAt {
+			blockNumber = opts.DeployInfo.DeployedAt
 		}
+
+		sequencerMessageCount, err := bridge.SequencerReportedSubMessageCount(&bind.CallOpts{
+			BlockNumber: new(big.Int).SetUint64(blockNumber),
+		})
+		if err != nil {
+			log.Error("failed to get sequencerMessageCount", "err", err)
+			return nil, fmt.Errorf("failed to get sequencerMessageCount: %w", err)
+		}
+
 		opts.Streamer.InitialFinalizedSequencerMessageCount = sequencerMessageCount
 	}
 

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -441,11 +441,16 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 			return nil, fmt.Errorf("failed to get finalized block number: %w", err)
 		}
 
-		sequencerMessageCount, err := bridge.SequencerReportedSubMessageCount(&bind.CallOpts{
-			BlockNumber: new(big.Int).SetUint64(finalizedBlockNumber),
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to get sequencerMessageCount: %w", err)
+		sequencerMessageCount := new(big.Int).SetUint64(0)
+
+		if finalizedBlockNumber > opts.DeployInfo.DeployedAt {
+			sequencerMessageCount, err = bridge.SequencerReportedSubMessageCount(&bind.CallOpts{
+				BlockNumber: new(big.Int).SetUint64(finalizedBlockNumber),
+			})
+			if err != nil {
+				log.Error("failed to get sequencerMessageCount", "err", err)
+				return nil, fmt.Errorf("failed to get sequencerMessageCount: %w", err)
+			}
 		}
 		opts.Streamer.InitialFinalizedSequencerMessageCount = sequencerMessageCount
 	}

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -451,7 +451,6 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 			BlockNumber: new(big.Int).SetUint64(blockNumber),
 		})
 		if err != nil {
-			log.Error("failed to get sequencerMessageCount", "err", err)
 			return nil, fmt.Errorf("failed to get sequencerMessageCount: %w", err)
 		}
 

--- a/system_tests/espresso_e2e_test.go
+++ b/system_tests/espresso_e2e_test.go
@@ -3,9 +3,7 @@ package arbtest
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"math/big"
-	"net/http"
 	"os/exec"
 	"testing"
 	"time"
@@ -18,7 +16,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
-	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
@@ -375,32 +372,6 @@ func TestEspressoE2E(t *testing.T) {
 	})
 	Require(t, err)
 
-	// Now send the transaction for message pos 0, the message position 0 should have not been sent to espresso
-	// because its a genesis message which originates on L1
-	fetcher := func(pos arbutil.MessageIndex) ([]byte, error) {
-		msg, err := l2Node.ConsensusNode.TxStreamer.GetMessage(0)
-		Require(t, err)
-		b, err := rlp.EncodeToBytes(msg)
-		Require(t, err)
-		return b, err
-	}
-
-	payload, _ := arbutil.BuildRawHotShotPayload([]arbutil.MessageIndex{0}, fetcher, 900*1024)
-	payload, err = arbutil.SignHotShotPayload(payload, func([]byte) ([]byte, error) {
-		return []byte{}, nil
-	})
-	Require(t, err)
-
-	// Submit the transaction to hotshot
-	txhash, err := l2Node.ConsensusNode.TxStreamer.ResubmitEspressoTransactions(ctx, arbutil.SubmittedEspressoTx{Hash: "", Pos: []arbutil.MessageIndex{0}, Payload: payload})
-	Require(t, err)
-	// Check if the txHash is already finalized in hotshot
-	// curl hotshot availability endpoint and this transaction should not be in the response
-	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:41000/availability/transaction/hash/%s", txhash))
-	Require(t, err)
-	if resp.StatusCode == 200 {
-		t.Fatal("Transaction should not be in the response")
-	}
 }
 
 func TestEspressoWithBlobs(t *testing.T) {

--- a/system_tests/espresso_e2e_test.go
+++ b/system_tests/espresso_e2e_test.go
@@ -3,7 +3,9 @@ package arbtest
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"math/big"
+	"net/http"
 	"os/exec"
 	"testing"
 	"time"
@@ -13,9 +15,9 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
@@ -371,6 +373,33 @@ func TestEspressoE2E(t *testing.T) {
 		return balance4.Cmp((&big.Int{}).Add(transferAmount, transferAmount)) >= 0
 	})
 	Require(t, err)
+
+	// Now send the transaction for message pos 0, the message position 0 should have not been sent to espresso
+	// because its a genesis message which originates on L1
+	fetcher := func(pos arbutil.MessageIndex) ([]byte, error) {
+		msg, err := l2Node.ConsensusNode.TxStreamer.GetMessage(0)
+		Require(t, err)
+		b, err := rlp.EncodeToBytes(msg)
+		Require(t, err)
+		return b, err
+	}
+
+	payload, _ := arbutil.BuildRawHotShotPayload([]arbutil.MessageIndex{0}, fetcher, 900*1024)
+	payload, err = arbutil.SignHotShotPayload(payload, func([]byte) ([]byte, error) {
+		return []byte{}, nil
+	})
+	Require(t, err)
+
+	// Submit the transaction to hotshot
+	txhash, err := l2Node.ConsensusNode.TxStreamer.ResubmitEspressoTransactions(ctx, arbutil.SubmittedEspressoTx{Hash: "", Pos: []arbutil.MessageIndex{0}, Payload: payload})
+	Require(t, err)
+	// Check if the txHash is already finalized in hotshot
+	// curl hotshot availability endpoint and this transaction should not be in the response
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:41000/availability/transaction/hash/%s", txhash))
+	Require(t, err)
+	if resp.StatusCode == 200 {
+		t.Fatal("Transaction should not be in the response")
+	}
 
 }
 

--- a/system_tests/espresso_e2e_test.go
+++ b/system_tests/espresso_e2e_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -400,7 +401,6 @@ func TestEspressoE2E(t *testing.T) {
 	if resp.StatusCode == 200 {
 		t.Fatal("Transaction should not be in the response")
 	}
-
 }
 
 func TestEspressoWithBlobs(t *testing.T) {


### PR DESCRIPTION
### This PR:
Fixes a CI error.

The error occurs because, in the testing environment, the batcher tries to retrieve the number of sequencer messages using the latest finalized block number. However, the contract was deployed just seconds earlier, so the batcher fails to find the contract code at that block.

Additionally, I removed some code from the E2E test to make it work. Here is [the error message](https://github.com/EspressoSystems/nitro-espresso-integration/actions/runs/15291702904/job/43015579160). I believe that code was never functional in the first place. I’m guessing this code was intended to test whether the batcher stops submitting finalized messages to HotShot. However, in fact, HotShot accepts any transaction—[the constraints are enforced by the batcher itself](https://github.com/EspressoSystems/nitro-espresso-integration/blob/3b2d1ca6e0146b7c0637e47c1e6e006619fcefe1/arbnode/transaction_streamer.go#L1181). @jjeangal @Sneh1999 