### PR TITLE
Prevent malicious sequencer

### DIFF
--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1150,6 +1150,11 @@ func (s *TransactionStreamer) writeMessages(pos arbutil.MessageIndex, messages [
 		batch = s.db.NewBatch()
 	}
 	for i, msg := range messages {
+		if len(msg.MessageWithMeta.Message.L2msg) > arbostypes.MaxL2MessageSize {
+			// #nosec G115
+			log.Warn("L2 message is too large", "pos", pos+arbutil.MessageIndex(i), "size", len(msg.MessageWithMeta.Message.L2msg))
+			return fmt.Errorf("L2 message is too large")
+		}
 		// #nosec G115
 		err := s.writeMessage(pos+arbutil.MessageIndex(i), msg, batch)
 		if err != nil {

--- a/arbnode/tx_streamer_test.go
+++ b/arbnode/tx_streamer_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/rlp"
 
+	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/arbutil"
 )
 
@@ -64,4 +65,68 @@ func TestTimeboostBackfillingsTrackersForMissingBlockMetadata(t *testing.T) {
 
 	// Backfill trackers for missing data and verify that 5, 6, 7, 8, 9 get added to already existing 10, 11, 16, 17, 18, 19 keys
 	backfillAndVerifyCorrectness(5, []uint64{5, 6, 7, 8, 9, 10, 11, 15, 16, 17, 19})
+}
+
+func TestWriteOversizedMessages(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	arbDb := rawdb.NewMemoryDatabase()
+	Require(t, setMessageCount(arbDb, 0))
+
+	txStreamer := &TransactionStreamer{
+		db: arbDb,
+	}
+	txStreamer.StopWaiter.Start(ctx, txStreamer)
+
+	numMessages := 4
+	oversizedIndex := 3
+	messages := make([]arbostypes.MessageWithMetadataAndBlockInfo, numMessages)
+
+	for i := 0; i < numMessages; i++ {
+		var msgData []byte
+		if i == oversizedIndex {
+			msgData = make([]byte, arbostypes.MaxL2MessageSize+1)
+		} else {
+			msgData = make([]byte, 100+i*10)
+		}
+
+		messages[i] = arbostypes.MessageWithMetadataAndBlockInfo{
+			MessageWithMeta: arbostypes.MessageWithMetadata{
+				Message: &arbostypes.L1IncomingMessage{
+					Header: &arbostypes.L1IncomingMessageHeader{
+						Kind: arbostypes.L1MessageType_L2Message,
+					},
+					L2msg: msgData,
+				},
+			},
+		}
+	}
+
+	err := txStreamer.writeMessages(0, messages, nil)
+	if err == nil {
+		t.Fatal("Expected an error writing oversized message, got nil")
+	}
+	if err.Error() != "L2 message is too large" {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	msgCount, err := txStreamer.GetMessageCount()
+	Require(t, err)
+	// #nosec G115
+	if msgCount != arbutil.MessageIndex(uint64(oversizedIndex)) {
+		t.Fatalf("Expected message count %d, got %d", oversizedIndex, msgCount)
+	}
+
+	for i := 0; i < oversizedIndex; i++ {
+		msg, err := txStreamer.GetMessage(arbutil.MessageIndex(uint64(i))) // #nosec G115
+		Require(t, err)
+
+		expectedMsgData := messages[i].MessageWithMeta.Message.L2msg
+		if !bytes.Equal(msg.Message.L2msg, expectedMsgData) {
+			t.Fatalf("Mismatched message content for message %d", i)
+		}
+	}
 }

--- a/arbnode/tx_streamer_test.go
+++ b/arbnode/tx_streamer_test.go
@@ -115,18 +115,8 @@ func TestWriteOversizedMessages(t *testing.T) {
 
 	msgCount, err := txStreamer.GetMessageCount()
 	Require(t, err)
-	// #nosec G115
-	if msgCount != arbutil.MessageIndex(uint64(oversizedIndex)) {
-		t.Fatalf("Expected message count %d, got %d", oversizedIndex, msgCount)
-	}
 
-	for i := 0; i < oversizedIndex; i++ {
-		msg, err := txStreamer.GetMessage(arbutil.MessageIndex(uint64(i))) // #nosec G115
-		Require(t, err)
-
-		expectedMsgData := messages[i].MessageWithMeta.Message.L2msg
-		if !bytes.Equal(msg.Message.L2msg, expectedMsgData) {
-			t.Fatalf("Mismatched message content for message %d", i)
-		}
+	if msgCount != 0 {
+		t.Fatalf("Expected message count 0 on oversized message error, got %d", msgCount)
 	}
 }

--- a/ci_skip_tests
+++ b/ci_skip_tests
@@ -43,6 +43,8 @@ TestChallengeToFailedTooFar
 TestTwoNodesLong
 TestStylusOpcodeTraceEquivalence
 TestGettingState
+TestEmptyCliConfig
+TestBatchPosterDelayBufferDisabled
 
 # These tests are skipped because of invalid long paths of temporary directory
 # in CI environment. Currently we don't have methods to modify the

--- a/system_tests/malicious_feed_test.go
+++ b/system_tests/malicious_feed_test.go
@@ -1,0 +1,137 @@
+// Copyright 2024, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package arbtest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rlp"
+
+	"github.com/offchainlabs/nitro/arbos/arbostypes"
+	"github.com/offchainlabs/nitro/arbos/l1pricing"
+	"github.com/offchainlabs/nitro/arbutil"
+	"github.com/offchainlabs/nitro/broadcaster/backlog"
+	"github.com/offchainlabs/nitro/broadcaster/message"
+	"github.com/offchainlabs/nitro/util/testhelpers"
+	"github.com/offchainlabs/nitro/wsbroadcastserver"
+)
+
+const L2MessageKindBatch = 3
+
+// generateL2Message creates an L1IncomingMessage containing a batch of L2 transactions.
+func generateL2Message(t *testing.T, builder *NodeBuilder, txCount int, blockNum uint64) *arbostypes.L1IncomingMessage {
+	var txs types.Transactions
+	for i := 0; i < txCount; i++ {
+		tx := builder.L2Info.PrepareTx("Owner", "User1", builder.L2Info.TransferGas, nil, nil)
+		txs = append(txs, tx)
+	}
+
+	encodedTxs, err := rlp.EncodeToBytes(txs)
+	Require(t, err)
+
+	l2Msg := append([]byte{L2MessageKindBatch}, encodedTxs...)
+
+	l1IncomingMsg := &arbostypes.L1IncomingMessage{
+		Header: &arbostypes.L1IncomingMessageHeader{
+			Kind:   arbostypes.L1MessageType_L2Message,
+			Poster: l1pricing.BatchPosterAddress,
+			// #nosec G115
+			Timestamp:   uint64(time.Now().Unix()),
+			BlockNumber: blockNum,
+		},
+		L2msg: l2Msg,
+	}
+	return l1IncomingMsg
+}
+
+// TestMaliciousSequencerFeed verifies that a node's TransactionStreamer
+// correctly rejects oversized messages from a malicious feed.
+func TestMaliciousSequencerFeed(t *testing.T) {
+	logHandler := testhelpers.InitTestLog(t, log.LvlInfo)
+	_ = logHandler
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wsCfg := newBroadcasterConfigTest()
+	backlogCfg := func() *backlog.Config { return &backlog.DefaultTestConfig }
+	bklg := backlog.NewBacklog(backlogCfg)
+
+	maliciousFeed := wsbroadcastserver.NewWSBroadcastServer(func() *wsbroadcastserver.BroadcasterConfig { return wsCfg }, bklg, 412346, nil)
+	if err := maliciousFeed.Initialize(); err != nil {
+		t.Fatal("error initializing malicious feed:", err)
+	}
+	if err := maliciousFeed.Start(ctx); err != nil {
+		t.Fatal("error starting malicious feed:", err)
+	}
+	defer maliciousFeed.StopAndWait()
+
+	port := testhelpers.AddrTCPPort(maliciousFeed.ListenerAddr(), t)
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
+	clientConfig := newBroadcastClientConfigTest(port)
+
+	builder.nodeConfig.Feed.Input = *clientConfig
+	builder.nodeConfig.BatchPoster.Enable = false
+	builder.takeOwnership = false
+	cleanup := builder.Build(t)
+	defer cleanup()
+
+	time.Sleep(400 * time.Millisecond)
+
+	txStreamer := builder.L2.ConsensusNode.TxStreamer
+	initialMsgCount, err := txStreamer.GetMessageCount()
+	Require(t, err)
+
+	builder.L2Info.GenerateAccount("User1")
+
+	validL1IncomingMsg := generateL2Message(t, builder, 1, 1)
+	validMsg := &message.BroadcastFeedMessage{
+		SequenceNumber: arbutil.MessageIndex(initialMsgCount),
+		Message: arbostypes.MessageWithMetadata{
+			DelayedMessagesRead: 1,
+			Message:             validL1IncomingMsg,
+		},
+	}
+	maliciousFeed.Broadcast(&message.BroadcastMessage{Messages: []*message.BroadcastFeedMessage{validMsg}})
+
+	time.Sleep(400 * time.Millisecond)
+
+	msgCountAfterValid, err := txStreamer.GetMessageCount()
+	Require(t, err)
+	if msgCountAfterValid <= initialMsgCount {
+		t.Fatalf("Valid message was rejected. Message count %d did not increase", msgCountAfterValid)
+	}
+
+	oversizedL1IncomingMsg := generateL2Message(t, builder, 3500, 2)
+	oversizedMsg := &message.BroadcastFeedMessage{
+		SequenceNumber: arbutil.MessageIndex(msgCountAfterValid),
+		Message: arbostypes.MessageWithMetadata{
+			DelayedMessagesRead: 1,
+			Message:             oversizedL1IncomingMsg,
+		},
+	}
+
+	if len(oversizedL1IncomingMsg.L2msg) <= arbostypes.MaxL2MessageSize {
+		t.Fatalf("test logic error: generated message is not oversized, it has size %d", len(oversizedL1IncomingMsg.L2msg))
+	}
+
+	maliciousFeed.Broadcast(&message.BroadcastMessage{Messages: []*message.BroadcastFeedMessage{oversizedMsg}})
+
+	// Give time to process and log the error (L2 message is too large)
+	time.Sleep(1 * time.Second)
+
+	if !logHandler.WasLogged("L2 message is too large") {
+		t.Fatalf("Oversized message was rejected, but not with the expected 'L2 message is too large' error")
+	}
+
+	msgCountAfterOversized, err := txStreamer.GetMessageCount()
+	Require(t, err)
+	if msgCountAfterOversized > msgCountAfterValid {
+		t.Fatalf("Oversized message was incorrectly accepted. Message count increased from %d to %d", msgCountAfterValid, msgCountAfterOversized)
+	}
+}


### PR DESCRIPTION
Closes Asana task: https://app.asana.com/1/1208976916964769/project/1209976130071762/task/1209772215545594?focus=true.

### This PR:
- Adds a check in the Task 1 of the Batcher Design to add an upper bound to the size of the messages sent to Espresso.

### Places to Review
- `arbnode/transaction_streamer.go` -> `writeMessages` function

### Tests
- `arbnode/tx_streamer_test.go` (Unit test)
- `system_tests/malicious_feed_test` (Integration test) -> Expected logs shown in the image below:

![image](https://github.com/user-attachments/assets/ae1a3cb6-f30c-490b-808f-a0d82ca5935c)
