### PR TITLE
Adding some fixes for the caff node

### DIFF
--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -63,7 +63,7 @@ var DefaultEspressoCaffNodeConfig = EspressoCaffNodeConfig{
 	WaitForFinalization:     true,
 	WaitForConfirmations:    false,
 	RequiredBlockDepth:      6,
-	BlocksToRead:            100,
+	BlocksToRead:            10000,
 	Dangerous:               DefaultDangerousCaffNodeConfig,
 	FromBlock:               1,
 }

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -27,6 +27,7 @@ type EspressoCaffNodeConfig struct {
 	Enable                  bool                    `koanf:"enable"`
 	HotShotUrls             []string                `koanf:"hotshot-urls"`
 	NextHotshotBlock        uint64                  `koanf:"next-hotshot-block"`
+	FromBlock               uint64                  `koanf:"from-block"`
 	Namespace               uint64                  `koanf:"namespace"`
 	RetryTime               time.Duration           `koanf:"retry-time"`
 	HotshotPollingInterval  time.Duration           `koanf:"hotshot-polling-interval"`
@@ -42,6 +43,7 @@ type EspressoCaffNodeConfig struct {
 
 type DangerousCaffNodeConfig struct {
 	IgnoreDatabaseHotshotBlock bool `koanf:"ignore-database-hotshot-block"`
+	IgnoreDatabaseFromBlock    bool `koanf:"ignore-database-from-block"`
 }
 
 var DefaultDangerousCaffNodeConfig = DangerousCaffNodeConfig{
@@ -63,6 +65,7 @@ var DefaultEspressoCaffNodeConfig = EspressoCaffNodeConfig{
 	RequiredBlockDepth:      6,
 	BlocksToRead:            100,
 	Dangerous:               DefaultDangerousCaffNodeConfig,
+	FromBlock:               0,
 }
 
 func EspressoCaffNodeConfigAddOptions(prefix string, f *flag.FlagSet) {
@@ -79,11 +82,13 @@ func EspressoCaffNodeConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".wait-for-confirmations", DefaultEspressoCaffNodeConfig.WaitForConfirmations, "Configures the Caff node to only produce blocks from delayed messages if they have atleast requiredBlockDepth confirmations on the parent chain")
 	f.Uint64(prefix+".required-block-depth", DefaultEspressoCaffNodeConfig.RequiredBlockDepth, "Configures the required block depth/number of confirmations on the parent chain that a delayed message is required to have before this Caff node will add it to it's state")
 	f.Uint64(prefix+".blocks-to-read", DefaultEspressoCaffNodeConfig.BlocksToRead, "Configures the number of blocks to read from the parent chain for delayed messages")
+	f.Uint64(prefix+".from-block", DefaultEspressoCaffNodeConfig.FromBlock, "Configures the block number to start reading delayed messages from")
 	DangerousCaffNodeConfigAddOptions(prefix+".dangerous", f)
 }
 
 func DangerousCaffNodeConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".ignore-database-hotshot-block", DefaultDangerousCaffNodeConfig.IgnoreDatabaseHotshotBlock, "Ignores the database hotshot block and starts from the next block specified in the config by the user")
+	f.Bool(prefix+".ignore-database-from-block", DefaultDangerousCaffNodeConfig.IgnoreDatabaseFromBlock, "Ignores the database from block and starts from the next block specified in the config by the user")
 }
 
 type EspressoCaffNodeConfigFetcher func() *EspressoCaffNodeConfig
@@ -142,8 +147,20 @@ func NewEspressoCaffNode(
 		common.HexToAddress(configFetcher().BatchPosterAddr),
 	)
 
+	fromBlock := configFetcher().FromBlock
+	if !configFetcher().Dangerous.IgnoreDatabaseFromBlock {
+		fromBlock, err = readCurrentL1BlockFromDb(db)
+		if err != nil {
+			log.Crit("failed to read l1 block from db", "err", err)
+			return nil
+		}
+	}
+	if fromBlock == 0 {
+		log.Crit("fromBlock is 0, please provide a valid block number")
+	}
+
 	delayedMessageFetcher := NewDelayedMessageFetcher(delayedBridge, l1Reader, db, blocksToRead,
-		configFetcher().WaitForFinalization, configFetcher().WaitForConfirmations, configFetcher().RequiredBlockDepth)
+		configFetcher().WaitForFinalization, configFetcher().WaitForConfirmations, configFetcher().RequiredBlockDepth, fromBlock)
 
 	return &EspressoCaffNode{
 		configFetcher:         configFetcher,

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -167,10 +167,12 @@ func NewEspressoCaffNode(
 func (n *EspressoCaffNode) nextMessage() (*espressostreamer.MessageWithMetadataAndPos, error) {
 	messageWithMetadataAndPos, err := n.espressoStreamer.Next()
 	if err != nil {
+		log.Error("unable to get the next message", "err", err)
 		return nil, err
 	}
 
 	if messageWithMetadataAndPos == nil {
+		log.Error("No message found, waiting for the next message")
 		return nil, nil
 	}
 
@@ -195,7 +197,7 @@ func (n *EspressoCaffNode) reset(messageWithMetadataAndPos *espressostreamer.Mes
 Creates a block from the next message in the queue.
 */
 func (n *EspressoCaffNode) createBlock() (returnValue bool) {
-
+	log.Debug("Starting new block creation")
 	lastBlockHeader := n.executionEngine.Bc().CurrentBlock()
 
 	messageWithMetadataAndPos, err := n.nextMessage()
@@ -206,8 +208,11 @@ func (n *EspressoCaffNode) createBlock() (returnValue bool) {
 
 	if messageWithMetadataAndPos == nil {
 		// No message found, so we need to wait for the next message
+		log.Warn("No message found, waiting for the next message")
 		return false
 	}
+
+	log.Debug("Got the next message", "messageWithMetadataAndPos", messageWithMetadataAndPos)
 
 	messageWithMetadata := messageWithMetadataAndPos.MessageWithMeta
 
@@ -305,7 +310,7 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 	// The reason we do the reset here is because database is only initialized after Caff node is initialized
 	// so if we want to read the current position from the database, we need to reset the streamer
 	// during the start of the espresso streamer and caff node
-	log.Debug("Starting streamer at", "nextHotshotBlock", nextHotshotBlock, "currentMessagePos", currentMessagePos)
+	log.Info("Starting streamer at", "nextHotshotBlock", nextHotshotBlock, "currentMessagePos", currentMessagePos)
 	n.espressoStreamer.Reset(uint64(currentMessagePos), nextHotshotBlock)
 
 	// Deserialize the current block from the database to get the parent chain block number

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -215,7 +215,6 @@ func (n *EspressoCaffNode) reset(messageWithMetadataAndPos *espressostreamer.Mes
 Creates a block from the next message in the queue.
 */
 func (n *EspressoCaffNode) createBlock() (returnValue bool) {
-	log.Debug("Starting new block creation")
 	lastBlockHeader := n.executionEngine.Bc().CurrentBlock()
 
 	messageWithMetadataAndPos, err := n.nextMessage()
@@ -229,8 +228,6 @@ func (n *EspressoCaffNode) createBlock() (returnValue bool) {
 		log.Warn("No message found, waiting for the next message")
 		return false
 	}
-
-	log.Debug("Got the next message", "messageWithMetadataAndPos", messageWithMetadataAndPos)
 
 	messageWithMetadata := messageWithMetadataAndPos.MessageWithMeta
 

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -65,7 +65,7 @@ var DefaultEspressoCaffNodeConfig = EspressoCaffNodeConfig{
 	RequiredBlockDepth:      6,
 	BlocksToRead:            100,
 	Dangerous:               DefaultDangerousCaffNodeConfig,
-	FromBlock:               0,
+	FromBlock:               1,
 }
 
 func EspressoCaffNodeConfigAddOptions(prefix string, f *flag.FlagSet) {
@@ -152,11 +152,14 @@ func NewEspressoCaffNode(
 		fromBlock, err = readCurrentL1BlockFromDb(db)
 		if err != nil {
 			log.Crit("failed to read l1 block from db", "err", err)
-			return nil
 		}
 	}
+
 	if fromBlock == 0 {
-		log.Crit("fromBlock is 0, please provide a valid block number")
+		fromBlock = configFetcher().FromBlock
+		if fromBlock == 0 {
+			log.Crit("fromBlock is 0, please provide a valid block number")
+		}
 	}
 
 	delayedMessageFetcher := NewDelayedMessageFetcher(delayedBridge, l1Reader, db, blocksToRead,
@@ -189,7 +192,6 @@ func (n *EspressoCaffNode) nextMessage() (*espressostreamer.MessageWithMetadataA
 	}
 
 	if messageWithMetadataAndPos == nil {
-		log.Error("No message found, waiting for the next message")
 		return nil, nil
 	}
 

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 
@@ -332,14 +331,10 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 	log.Info("Starting streamer at", "nextHotshotBlock", nextHotshotBlock, "currentMessagePos", currentMessagePos)
 	n.espressoStreamer.Reset(uint64(currentMessagePos), nextHotshotBlock)
 
-	// Deserialize the current block from the database to get the parent chain block number
-	// and the delayed messages read. Note: the nonce in the header of the block contains the delayed messages read
-	header := types.DeserializeHeaderExtraInformation(n.executionEngine.Bc().CurrentHeader())
-	parentChainBlockNumber := header.L1BlockNumber
 	// Nonce of the previous block is the number of delayed messages read
 	// Check `NextDelayedMessageNumber` in execution node to confirm this
 	delayedMessagesRead := n.executionEngine.Bc().CurrentBlock().Nonce.Uint64()
-	n.delayedMessageFetcher.reset(parentChainBlockNumber, delayedMessagesRead)
+	n.delayedMessageFetcher.reset(delayedMessagesRead)
 
 	err = n.CallIterativelySafe(func(ctx context.Context) time.Duration {
 		madeBlock := n.createBlock()

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -225,7 +225,6 @@ func (n *EspressoCaffNode) createBlock() (returnValue bool) {
 
 	if messageWithMetadataAndPos == nil {
 		// No message found, so we need to wait for the next message
-		log.Warn("No message found, waiting for the next message")
 		return false
 	}
 

--- a/arbnode/espresso_caff_node_test.go
+++ b/arbnode/espresso_caff_node_test.go
@@ -66,7 +66,7 @@ func (m *MockDelayedMessageFetcher) processDelayedMessage(messageWithMetadataAnd
 	return messageWithMetadataAndPos, nil
 }
 
-func (m *MockDelayedMessageFetcher) reset(parentChainBlockNum uint64, seqNum uint64) {}
+func (m *MockDelayedMessageFetcher) reset(seqNum uint64) {}
 
 func TestEspressoCaffNodeShouldReadDelayedMessageFromL1(t *testing.T) {
 

--- a/arbnode/espresso_delayed_message_fetcher.go
+++ b/arbnode/espresso_delayed_message_fetcher.go
@@ -51,17 +51,9 @@ func NewDelayedMessageFetcher(
 	waitForFinalization bool,
 	waitForConfirmations bool,
 	requiredBlockDepth uint64,
+	fromBlock uint64,
 ) *DelayedMessageFetcher {
-	var fromBlock uint64
-	fromBlock, err := readCurrentL1BlockFromDb(db)
-	if err != nil {
-		log.Crit("failed to read l1 block from db", "err", err)
-		return nil
-	}
 
-	if fromBlock == 0 {
-		fromBlock = delayedBridge.fromBlock
-	}
 	delayedCount, err := readDelayedMessageCount(db)
 	if err != nil && !dbutil.IsErrNotFound(err) {
 		log.Crit("failed to read delayed message count from db", "err", err)

--- a/arbnode/espresso_delayed_message_fetcher.go
+++ b/arbnode/espresso_delayed_message_fetcher.go
@@ -26,7 +26,7 @@ var (
 )
 
 type DelayedMessageFetcherInterface interface {
-	reset(parentChainBlockNumber uint64, seqNum uint64)
+	reset(seqNum uint64)
 	getDelayedMessageCountAtBlock(blockNumber uint64) (uint64, error)
 	processDelayedMessage(messageWithMetadataAndPos *espressostreamer.MessageWithMetadataAndPos) (*espressostreamer.MessageWithMetadataAndPos, error)
 }
@@ -77,8 +77,7 @@ func NewDelayedMessageFetcher(
 	}
 }
 
-func (f *DelayedMessageFetcher) reset(parentChainBlockNumber uint64, seqNum uint64) {
-	f.fromBlock = parentChainBlockNumber
+func (f *DelayedMessageFetcher) reset(seqNum uint64) {
 	f.delayedCount = seqNum
 }
 

--- a/arbnode/espresso_delayed_message_fetcher.go
+++ b/arbnode/espresso_delayed_message_fetcher.go
@@ -128,6 +128,7 @@ func (f *DelayedMessageFetcher) getDelayedMessage(index uint64) (*arbostypes.L1I
 	for startBlock <= endBlock && !hasFound {
 		from := big.NewInt(0).SetUint64(startBlock)
 		to := big.NewInt(0).SetUint64(startBlock + f.blocksToRead)
+
 		log.Debug("Looking for delayed messages from range", "from", from, "to", to)
 		msgs, err := f.delayedBridge.LookupMessagesInRange(context.Background(), from, to, nil)
 		if err != nil {
@@ -137,24 +138,18 @@ func (f *DelayedMessageFetcher) getDelayedMessage(index uint64) (*arbostypes.L1I
 		for _, msg := range msgs {
 			seqNum, err := msg.Message.Header.SeqNum()
 			if err != nil {
-				log.Error("Failed to get seq num from message", "err", err)
 				return nil, err
 			}
-			log.Debug("Checking if delayed message matches", "seqNum", seqNum, "index", index)
 			if seqNum == index {
-				log.Debug("Found delayed message", "seqNum", seqNum, "index", index)
 				hasFound = true
 			}
 			err = f.storeDelayedMessage(batch, seqNum, *msg)
 			if err != nil {
-				log.Error("Failed to store delayed message", "err", err)
 				return nil, err
 			}
-			log.Debug("Stored delayed message", "seqNum", seqNum, "index", index)
 		}
 		// Read the next `blocksToRead` blocks
 		startBlock = startBlock + f.blocksToRead + 1
-		log.Debug("Reading next block", "startBlock", startBlock)
 	}
 
 	// if startBlock is less than the endBlock this means
@@ -197,7 +192,6 @@ func (f *DelayedMessageFetcher) getDelayedMessage(index uint64) (*arbostypes.L1I
 func (f *DelayedMessageFetcher) processDelayedMessage(messageWithMetadataAndPos *espressostreamer.MessageWithMetadataAndPos) (*espressostreamer.MessageWithMetadataAndPos, error) {
 	delayedMessagesRead := messageWithMetadataAndPos.MessageWithMeta.DelayedMessagesRead
 	if delayedMessagesRead > f.delayedCount+1 || delayedMessagesRead < f.delayedCount {
-		log.Error("messages are not processed in order", "delayedMessagesRead", delayedMessagesRead, "delayedCount", f.delayedCount)
 		return nil, fmt.Errorf("delayed message count is greater than the delayed count")
 	}
 	if delayedMessagesRead == f.delayedCount+1 {
@@ -258,7 +252,6 @@ func (f *DelayedMessageFetcher) isDelayedMessageWithinSafetyTolerance(message *e
 			log.Warn("Error getting finalized block header to check safety tolerance of delayed message", "err", err)
 			return false, err
 		}
-		log.Debug("Safe block number", "safeBlockNumber", safeBlockNumber, "message", message)
 	} else if f.waitForConfirmations {
 		// if we are waiting for block confirmations, get the latest header and subtract the required block depth.
 		latestHeader, err := f.l1Reader.Client().HeaderByNumber(context.Background(), nil)
@@ -267,7 +260,6 @@ func (f *DelayedMessageFetcher) isDelayedMessageWithinSafetyTolerance(message *e
 			return false, err
 		}
 		safeBlockNumber = latestHeader.Number.Sub(latestHeader.Number, new(big.Int).SetUint64(f.requiredBlockDepth)).Uint64()
-		log.Debug("Safe block number", "safeBlockNumber", safeBlockNumber, "message", message)
 	} else {
 		// If we haven't configured a safety strategy, every delayed message is valid to include in the nodes state.
 		log.Debug("No safety strategy configured, every delayed message is valid")
@@ -281,10 +273,8 @@ func (f *DelayedMessageFetcher) isDelayedMessageWithinSafetyTolerance(message *e
 		return false, err
 	}
 	if (message.MessageWithMeta.Message.Header.BlockNumber <= safeBlockNumber) && (message.MessageWithMeta.DelayedMessagesRead <= delayCount) {
-		log.Debug("Delayed message is safe", "message", message)
 		return true, nil
 	}
-	log.Debug("Delayed message is not safe", "message", message)
 	return false, nil
 }
 

--- a/arbnode/espresso_delayed_message_fetcher.go
+++ b/arbnode/espresso_delayed_message_fetcher.go
@@ -161,14 +161,11 @@ func (f *DelayedMessageFetcher) getDelayedMessage(index uint64) (*arbostypes.L1I
 		f.fromBlock = endBlock + 1
 	}
 
-	log.Debug("Updating from block", "fromBlock", f.fromBlock)
-
 	err = storeCurrentL1Block(batch, f.fromBlock)
 	if err != nil {
 		log.Error("Failed to store current L1 block", "err", err)
 		return nil, err
 	}
-	log.Debug("Stored current L1 block", "fromBlock", f.fromBlock)
 
 	err = batch.Write()
 	if err != nil {
@@ -176,7 +173,6 @@ func (f *DelayedMessageFetcher) getDelayedMessage(index uint64) (*arbostypes.L1I
 	}
 
 	if !hasFound {
-		log.Error("No delayed message found", "index", index)
 		return nil, fmt.Errorf("no message found for pos %d", index)
 	}
 
@@ -185,13 +181,14 @@ func (f *DelayedMessageFetcher) getDelayedMessage(index uint64) (*arbostypes.L1I
 		log.Error("Failed to read delayed message", "err", err)
 		return nil, err
 	}
-	log.Debug("Read delayed message", "index", index, "result", result)
+
 	return result.Message, nil
 }
 
 func (f *DelayedMessageFetcher) processDelayedMessage(messageWithMetadataAndPos *espressostreamer.MessageWithMetadataAndPos) (*espressostreamer.MessageWithMetadataAndPos, error) {
 	delayedMessagesRead := messageWithMetadataAndPos.MessageWithMeta.DelayedMessagesRead
 	if delayedMessagesRead > f.delayedCount+1 || delayedMessagesRead < f.delayedCount {
+		log.Error("messages are not processed in order", "delayedMessagesRead", delayedMessagesRead, "delayedCount", f.delayedCount)
 		return nil, fmt.Errorf("delayed message count is greater than the delayed count")
 	}
 	if delayedMessagesRead == f.delayedCount+1 {
@@ -208,10 +205,9 @@ func (f *DelayedMessageFetcher) processDelayedMessage(messageWithMetadataAndPos 
 		messageWithMetadataAndPos.MessageWithMeta.Message = message
 		isDelayedMessageWithinSafetyTolerance, err := f.isDelayedMessageWithinSafetyTolerance(messageWithMetadataAndPos)
 		if err != nil {
-			log.Error("Failed to check if delayed message is within safety tolerance", "err", err)
 			return messageWithMetadataAndPos, err
 		}
-		log.Debug("Checked if delayed message is within safety tolerance", "isDelayedMessageWithinSafetyTolerance", isDelayedMessageWithinSafetyTolerance)
+
 		if !isDelayedMessageWithinSafetyTolerance {
 			return messageWithMetadataAndPos, fmt.Errorf("delayed message was not within safety tolerance parameters, the node needs to wait until it is")
 		}
@@ -221,7 +217,6 @@ func (f *DelayedMessageFetcher) processDelayedMessage(messageWithMetadataAndPos 
 			log.Error("Failed to store delayed message count", "err", err)
 			return messageWithMetadataAndPos, err
 		}
-		log.Debug("Stored delayed message count", "delayedCount", f.delayedCount)
 	}
 
 	return messageWithMetadataAndPos, nil
@@ -252,6 +247,7 @@ func (f *DelayedMessageFetcher) isDelayedMessageWithinSafetyTolerance(message *e
 			log.Warn("Error getting finalized block header to check safety tolerance of delayed message", "err", err)
 			return false, err
 		}
+
 	} else if f.waitForConfirmations {
 		// if we are waiting for block confirmations, get the latest header and subtract the required block depth.
 		latestHeader, err := f.l1Reader.Client().HeaderByNumber(context.Background(), nil)
@@ -260,6 +256,7 @@ func (f *DelayedMessageFetcher) isDelayedMessageWithinSafetyTolerance(message *e
 			return false, err
 		}
 		safeBlockNumber = latestHeader.Number.Sub(latestHeader.Number, new(big.Int).SetUint64(f.requiredBlockDepth)).Uint64()
+
 	} else {
 		// If we haven't configured a safety strategy, every delayed message is valid to include in the nodes state.
 		log.Debug("No safety strategy configured, every delayed message is valid")
@@ -276,6 +273,7 @@ func (f *DelayedMessageFetcher) isDelayedMessageWithinSafetyTolerance(message *e
 		return true, nil
 	}
 	return false, nil
+
 }
 
 /*

--- a/arbnode/espresso_delayed_message_fetcher.go
+++ b/arbnode/espresso_delayed_message_fetcher.go
@@ -96,11 +96,13 @@ func (f *DelayedMessageFetcher) getDelayedMessage(index uint64) (*arbostypes.L1I
 	// Check if the delayed message at index exists in the database
 	msg, err := f.readDelayedMessage(index)
 	if err != nil && !dbutil.IsErrNotFound(err) {
+		log.Error("Failed to read delayed message", "err", err, "msg", msg)
 		return nil, err
 	}
 	// If the delayed message already exists in the database and we have already processed it
 	// the parent block number then we can just return the message
 	if msg != nil && f.fromBlock >= msg.ParentChainBlockNumber {
+		log.Debug("Delayed message already exists in the database and we have already processed it", "msg", msg.ParentChainBlockNumber, "fromBlock", f.fromBlock)
 		return msg.Message, nil
 	}
 
@@ -115,6 +117,8 @@ func (f *DelayedMessageFetcher) getDelayedMessage(index uint64) (*arbostypes.L1I
 		return nil, fmt.Errorf("l1 block number %d is less than from block %d", currL1, f.fromBlock)
 	}
 
+	log.Debug("Current L1 block and from block", "currL1", currL1, "fromBlock", f.fromBlock)
+
 	startBlock := f.fromBlock
 	endBlock := currL1
 	hasFound := false
@@ -125,26 +129,33 @@ func (f *DelayedMessageFetcher) getDelayedMessage(index uint64) (*arbostypes.L1I
 	for startBlock <= endBlock && !hasFound {
 		from := big.NewInt(0).SetUint64(startBlock)
 		to := big.NewInt(0).SetUint64(startBlock + f.blocksToRead)
+		log.Debug("Looking for delayed messages from range", "from", from, "to", to)
 		msgs, err := f.delayedBridge.LookupMessagesInRange(context.Background(), from, to, nil)
 		if err != nil {
+			log.Error("Failed to lookup delayed messages", "err", err)
 			return nil, err
 		}
 		for _, msg := range msgs {
 			seqNum, err := msg.Message.Header.SeqNum()
-
 			if err != nil {
+				log.Error("Failed to get seq num from message", "err", err)
 				return nil, err
 			}
+			log.Debug("Checking if delayed message matches", "seqNum", seqNum, "index", index)
 			if seqNum == index {
+				log.Debug("Found delayed message", "seqNum", seqNum, "index", index)
 				hasFound = true
 			}
 			err = f.storeDelayedMessage(batch, seqNum, *msg)
 			if err != nil {
+				log.Error("Failed to store delayed message", "err", err)
 				return nil, err
 			}
+			log.Debug("Stored delayed message", "seqNum", seqNum, "index", index)
 		}
 		// Read the next `blocksToRead` blocks
 		startBlock = startBlock + f.blocksToRead + 1
+		log.Debug("Reading next block", "startBlock", startBlock)
 	}
 
 	// if startBlock is less than the endBlock this means
@@ -156,10 +167,14 @@ func (f *DelayedMessageFetcher) getDelayedMessage(index uint64) (*arbostypes.L1I
 		f.fromBlock = endBlock + 1
 	}
 
+	log.Debug("Updating from block", "fromBlock", f.fromBlock)
+
 	err = storeCurrentL1Block(batch, f.fromBlock)
 	if err != nil {
+		log.Error("Failed to store current L1 block", "err", err)
 		return nil, err
 	}
+	log.Debug("Stored current L1 block", "fromBlock", f.fromBlock)
 
 	err = batch.Write()
 	if err != nil {
@@ -167,13 +182,16 @@ func (f *DelayedMessageFetcher) getDelayedMessage(index uint64) (*arbostypes.L1I
 	}
 
 	if !hasFound {
+		log.Error("No delayed message found", "index", index)
 		return nil, fmt.Errorf("no message found for pos %d", index)
 	}
 
 	result, err := f.readDelayedMessage(index)
 	if err != nil {
+		log.Error("Failed to read delayed message", "err", err)
 		return nil, err
 	}
+	log.Debug("Read delayed message", "index", index, "result", result)
 	return result.Message, nil
 }
 
@@ -197,16 +215,20 @@ func (f *DelayedMessageFetcher) processDelayedMessage(messageWithMetadataAndPos 
 		messageWithMetadataAndPos.MessageWithMeta.Message = message
 		isDelayedMessageWithinSafetyTolerance, err := f.isDelayedMessageWithinSafetyTolerance(messageWithMetadataAndPos)
 		if err != nil {
+			log.Error("Failed to check if delayed message is within safety tolerance", "err", err)
 			return messageWithMetadataAndPos, err
 		}
+		log.Debug("Checked if delayed message is within safety tolerance", "isDelayedMessageWithinSafetyTolerance", isDelayedMessageWithinSafetyTolerance)
 		if !isDelayedMessageWithinSafetyTolerance {
 			return messageWithMetadataAndPos, fmt.Errorf("delayed message was not within safety tolerance parameters, the node needs to wait until it is")
 		}
 		f.delayedCount++
 		err = storeDelayedMessageCount(f.db, f.delayedCount)
 		if err != nil {
+			log.Error("Failed to store delayed message count", "err", err)
 			return messageWithMetadataAndPos, err
 		}
+		log.Debug("Stored delayed message count", "delayedCount", f.delayedCount)
 	}
 
 	return messageWithMetadataAndPos, nil
@@ -237,7 +259,7 @@ func (f *DelayedMessageFetcher) isDelayedMessageWithinSafetyTolerance(message *e
 			log.Warn("Error getting finalized block header to check safety tolerance of delayed message", "err", err)
 			return false, err
 		}
-
+		log.Debug("Safe block number", "safeBlockNumber", safeBlockNumber, "message", message)
 	} else if f.waitForConfirmations {
 		// if we are waiting for block confirmations, get the latest header and subtract the required block depth.
 		latestHeader, err := f.l1Reader.Client().HeaderByNumber(context.Background(), nil)
@@ -246,9 +268,10 @@ func (f *DelayedMessageFetcher) isDelayedMessageWithinSafetyTolerance(message *e
 			return false, err
 		}
 		safeBlockNumber = latestHeader.Number.Sub(latestHeader.Number, new(big.Int).SetUint64(f.requiredBlockDepth)).Uint64()
-
+		log.Debug("Safe block number", "safeBlockNumber", safeBlockNumber, "message", message)
 	} else {
 		// If we haven't configured a safety strategy, every delayed message is valid to include in the nodes state.
+		log.Debug("No safety strategy configured, every delayed message is valid")
 		return true, nil
 	}
 
@@ -259,10 +282,11 @@ func (f *DelayedMessageFetcher) isDelayedMessageWithinSafetyTolerance(message *e
 		return false, err
 	}
 	if (message.MessageWithMeta.Message.Header.BlockNumber <= safeBlockNumber) && (message.MessageWithMeta.DelayedMessagesRead <= delayCount) {
+		log.Debug("Delayed message is safe", "message", message)
 		return true, nil
 	}
+	log.Debug("Delayed message is not safe", "message", message)
 	return false, nil
-
 }
 
 /*

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -513,7 +513,8 @@ func mainImpl() int {
 		return 1
 	}
 
-	if l2BlockChain.Config().ArbitrumChainParams.DataAvailabilityCommittee != nodeConfig.Node.DataAvailability.Enable {
+	// Data availability committee can be enabled only if the node is not an espresso caff node
+	if l2BlockChain.Config().ArbitrumChainParams.DataAvailabilityCommittee != nodeConfig.Node.DataAvailability.Enable && !nodeConfig.Node.EspressoCaffNode.Enable {
 		flag.Usage()
 		log.Error(fmt.Sprintf("data availability service usage for this chain is set to %v but --node.data-availability.enable is set to %v", l2BlockChain.Config().ArbitrumChainParams.DataAvailabilityCommittee, nodeConfig.Node.DataAvailability.Enable))
 		return 1

--- a/espressostreamer/espresso_streamer.go
+++ b/espressostreamer/espresso_streamer.go
@@ -121,6 +121,7 @@ func (s *EspressoStreamer) Next() (*MessageWithMetadataAndPos, error) {
 		return 1
 	})
 	if !found {
+		log.Debug("Not found the current message pos", "currentMessagePos", s.currentMessagePos)
 		return nil, nil
 	}
 	if message == nil {
@@ -288,6 +289,7 @@ func (s *EspressoStreamer) Start(ctxIn context.Context) error {
 	s.StopWaiter.Start(ctxIn, s)
 
 	ephemeralErrorHandler := util.NewEphemeralErrorHandler(3*time.Minute, FailedToFetchTransactionsErr.Error(), 1*time.Minute)
+	processedHotshotBlocks := 0
 	err := s.CallIterativelySafe(func(ctx context.Context) time.Duration {
 		err := s.QueueMessagesFromHotshot(ctx, s.parseEspressoTransaction)
 		if err != nil {
@@ -298,7 +300,13 @@ func (s *EspressoStreamer) Start(ctxIn context.Context) error {
 		} else {
 			ephemeralErrorHandler.Reset()
 		}
-		log.Debug("Now processing hotshot block", "block number", s.nextHotshotBlockNum)
+		processedHotshotBlocks += 1
+		if processedHotshotBlocks == 100 {
+			log.Info("Now processing hotshot block", "block number", s.nextHotshotBlockNum)
+			processedHotshotBlocks = 0
+		} else {
+			log.Debug("Now processing hotshot block", "block number", s.nextHotshotBlockNum)
+		}
 		return s.pollingHotshotPollingInterval
 	})
 	return err

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ replace github.com/offchainlabs/bold => ./bold
 require (
 	cloud.google.com/go/storage v1.43.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
-	github.com/EspressoSystems/espresso-network/sdks/go v0.2.1
+	github.com/EspressoSystems/espresso-network/sdks/go v0.1.3
 	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible
 	github.com/Shopify/toxiproxy v2.1.4+incompatible
 	github.com/alicebob/miniredis/v2 v2.32.1

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7Oputl
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
+github.com/EspressoSystems/espresso-network/sdks/go v0.1.3 h1:/A/rHBKqHzTU84to3nqcBEiwCbHvSziT7T7mNQPMiGU=
+github.com/EspressoSystems/espresso-network/sdks/go v0.1.3/go.mod h1:aJX3rhV7d3QQ3dvmEFIKDfQvSFP9aUnFNENGpXPwELM=
 github.com/EspressoSystems/espresso-network/sdks/go v0.2.1 h1:lE+2kUIQhKAw78jlTz5L92gYywRD5uydWskwlLn3YwA=
 github.com/EspressoSystems/espresso-network/sdks/go v0.2.1/go.mod h1:aJX3rhV7d3QQ3dvmEFIKDfQvSFP9aUnFNENGpXPwELM=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible h1:1G1pk05UrOh0NlF1oeaaix1x8XzrfjIDK47TY0Zehcw=

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -39,6 +39,7 @@ func createCaffNode(ctx context.Context, t *testing.T, existing *NodeBuilder, da
 	nodeConfig.EspressoCaffNode.WaitForFinalization = existing.nodeConfig.EspressoCaffNode.WaitForFinalization
 	nodeConfig.EspressoCaffNode.WaitForConfirmations = existing.nodeConfig.EspressoCaffNode.WaitForConfirmations
 	nodeConfig.EspressoCaffNode.RequiredBlockDepth = existing.nodeConfig.EspressoCaffNode.RequiredBlockDepth
+	nodeConfig.EspressoCaffNode.FromBlock = 1
 
 	// for testing, we can use the same hotshot url for both
 	nodeConfig.EspressoCaffNode.HotShotUrls = []string{hotShotUrl, hotShotUrl, hotShotUrl, hotShotUrl}

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -77,7 +77,7 @@ func createCaffNodeConfig(ctx context.Context, t *testing.T) *NodeBuilder {
 	nodeConfig.EspressoCaffNode.HotShotUrls = []string{hotShotUrl, hotShotUrl, hotShotUrl, hotShotUrl}
 	nodeConfig.EspressoCaffNode.RetryTime = time.Second * 1
 	nodeConfig.EspressoCaffNode.HotshotPollingInterval = time.Millisecond * 100
-
+	nodeConfig.EspressoCaffNode.FromBlock = 1
 	nodeConfig.ParentChainReader.Enable = true
 
 	return builder


### PR DESCRIPTION
Adding some fixes to caff node:

1. Updated it to use the new go sdk version that removes slog
2. Logging processed hotshot blocks after every 100 blocks
3. Added the ability for the user to supply the from block