### PR TITLE
Fix last potential message can be nil

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -1599,6 +1599,10 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 		// for a time.
 		// So when error occurs, we break the loop and continue the rest of the function to see
 		// if we can make a new batch.
+		lastPotentialMsg = &arbostypes.MessageWithMetadata{
+			// Only initializing `DelayedMessagesRead` is fine because this is the only field needed in `estimateGas`.
+			DelayedMessagesRead: batchPosition.DelayedMessageCount,
+		}
 		bufferCount := b.espressoStreamer.GetMessageCount()
 		i := uint64(0)
 		addMessageLoop = func() bool {


### PR DESCRIPTION
### This PR:
- Fix a critical bug where the batch poster panics when the batcher attempts to forcibly post a batch but there are no available messages in the Espresso streamer
- `lastPotentialMessage` is used to estimate gas and we can get a valid value from the batch position.

### This PR does not:
- Add a test for it. Will add a unit test later and also a test script for this in the `nitro-testnode` repo.