### PR TITLE
Cherry Pick Backports - (#639) Add from block + (#638) Forbid registering signers above gas limit

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -1656,10 +1656,7 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 		return false, fmt.Errorf("batch was reverted, not posting any more batches")
 	}
 	if b.streamer.EspressoKeyManager != nil {
-		registered, err := b.streamer.EspressoKeyManager.HasRegistered()
-		if err != nil {
-			return false, err
-		}
+		registered := b.streamer.EspressoKeyManager.HasRegistered()
 		if !registered {
 			return false, fmt.Errorf("ephemeral keys are not yet registed in Espresso TEE Contract")
 		}

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -327,6 +327,14 @@ func (p *DataPoster) Sender() common.Address {
 	return p.auth.From
 }
 
+func (p *DataPoster) BaseFee() (*big.Int, error) {
+	header, err := p.headerReader.LastHeader(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return header.BaseFee, nil
+}
+
 func (p *DataPoster) MaxMempoolTransactions() uint64 {
 	if p.usingNoOpStorage {
 		return 1

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 
@@ -27,6 +26,7 @@ type EspressoCaffNodeConfig struct {
 	Enable                  bool                    `koanf:"enable"`
 	HotShotUrls             []string                `koanf:"hotshot-urls"`
 	NextHotshotBlock        uint64                  `koanf:"next-hotshot-block"`
+	FromBlock               uint64                  `koanf:"from-block"`
 	Namespace               uint64                  `koanf:"namespace"`
 	RetryTime               time.Duration           `koanf:"retry-time"`
 	HotshotPollingInterval  time.Duration           `koanf:"hotshot-polling-interval"`
@@ -43,6 +43,7 @@ type EspressoCaffNodeConfig struct {
 
 type DangerousCaffNodeConfig struct {
 	IgnoreDatabaseHotshotBlock bool `koanf:"ignore-database-hotshot-block"`
+	IgnoreDatabaseFromBlock    bool `koanf:"ignore-database-from-block"`
 }
 
 var DefaultDangerousCaffNodeConfig = DangerousCaffNodeConfig{
@@ -63,8 +64,9 @@ var DefaultEspressoCaffNodeConfig = EspressoCaffNodeConfig{
 	WaitForFinalization:     true,
 	WaitForConfirmations:    false,
 	RequiredBlockDepth:      6,
-	BlocksToRead:            100,
+	BlocksToRead:            10000,
 	Dangerous:               DefaultDangerousCaffNodeConfig,
+	FromBlock:               1,
 }
 
 func EspressoCaffNodeConfigAddOptions(prefix string, f *flag.FlagSet) {
@@ -82,11 +84,13 @@ func EspressoCaffNodeConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".wait-for-confirmations", DefaultEspressoCaffNodeConfig.WaitForConfirmations, "Configures the Caff node to only produce blocks from delayed messages if they have atleast requiredBlockDepth confirmations on the parent chain")
 	f.Uint64(prefix+".required-block-depth", DefaultEspressoCaffNodeConfig.RequiredBlockDepth, "Configures the required block depth/number of confirmations on the parent chain that a delayed message is required to have before this Caff node will add it to it's state")
 	f.Uint64(prefix+".blocks-to-read", DefaultEspressoCaffNodeConfig.BlocksToRead, "Configures the number of blocks to read from the parent chain for delayed messages")
+	f.Uint64(prefix+".from-block", DefaultEspressoCaffNodeConfig.FromBlock, "Configures the block number to start reading delayed messages from")
 	DangerousCaffNodeConfigAddOptions(prefix+".dangerous", f)
 }
 
 func DangerousCaffNodeConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".ignore-database-hotshot-block", DefaultDangerousCaffNodeConfig.IgnoreDatabaseHotshotBlock, "Ignores the database hotshot block and starts from the next block specified in the config by the user")
+	f.Bool(prefix+".ignore-database-from-block", DefaultDangerousCaffNodeConfig.IgnoreDatabaseFromBlock, "Ignores the database from block and starts from the next block specified in the config by the user")
 }
 
 type EspressoCaffNodeConfigFetcher func() *EspressoCaffNodeConfig
@@ -146,8 +150,23 @@ func NewEspressoCaffNode(
 		configFetcher().RetryTime,
 	)
 
+	fromBlock := configFetcher().FromBlock
+	if !configFetcher().Dangerous.IgnoreDatabaseFromBlock {
+		fromBlock, err = readCurrentL1BlockFromDb(db)
+		if err != nil {
+			log.Crit("failed to read l1 block from db", "err", err)
+		}
+	}
+
+	if fromBlock == 0 {
+		fromBlock = configFetcher().FromBlock
+		if fromBlock == 0 {
+			log.Crit("fromBlock is 0, please provide a valid block number")
+		}
+	}
+
 	delayedMessageFetcher := NewDelayedMessageFetcher(delayedBridge, l1Reader, db, blocksToRead,
-		configFetcher().WaitForFinalization, configFetcher().WaitForConfirmations, configFetcher().RequiredBlockDepth)
+		configFetcher().WaitForFinalization, configFetcher().WaitForConfirmations, configFetcher().RequiredBlockDepth, fromBlock)
 
 	return &EspressoCaffNode{
 		configFetcher:         configFetcher,
@@ -280,17 +299,13 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 	// The reason we do the reset here is because database is only initialized after Caff node is initialized
 	// so if we want to read the current position from the database, we need to reset the streamer
 	// during the start of the espresso streamer and caff node
-	log.Debug("Starting streamer at", "nextHotshotBlock", nextHotshotBlock, "currentMessagePos", currentMessagePos)
+	log.Info("Starting streamer at", "nextHotshotBlock", nextHotshotBlock, "currentMessagePos", currentMessagePos)
 	n.espressoStreamer.Reset(uint64(currentMessagePos), nextHotshotBlock)
 
-	// Deserialize the current block from the database to get the parent chain block number
-	// and the delayed messages read. Note: the nonce in the header of the block contains the delayed messages read
-	header := types.DeserializeHeaderExtraInformation(n.executionEngine.Bc().CurrentHeader())
-	parentChainBlockNumber := header.L1BlockNumber
 	// Nonce of the previous block is the number of delayed messages read
 	// Check `NextDelayedMessageNumber` in execution node to confirm this
 	delayedMessagesRead := n.executionEngine.Bc().CurrentBlock().Nonce.Uint64()
-	n.delayedMessageFetcher.reset(parentChainBlockNumber, delayedMessagesRead)
+	n.delayedMessageFetcher.reset(delayedMessagesRead)
 
 	err = n.CallIterativelySafe(func(ctx context.Context) time.Duration {
 		madeBlock := n.createBlock(ctx)

--- a/arbnode/espresso_caff_node_test.go
+++ b/arbnode/espresso_caff_node_test.go
@@ -93,7 +93,7 @@ func (m *MockDelayedMessageFetcher) processDelayedMessage(messageWithMetadataAnd
 	return messageWithMetadataAndPos, nil
 }
 
-func (m *MockDelayedMessageFetcher) reset(parentChainBlockNum uint64, seqNum uint64) {}
+func (m *MockDelayedMessageFetcher) reset(seqNum uint64) {}
 
 func TestEspressoCaffNodeShouldReadDelayedMessageFromL1(t *testing.T) {
 

--- a/arbutil/espresso_utils.go
+++ b/arbutil/espresso_utils.go
@@ -21,7 +21,7 @@ type SubmittedEspressoTx struct {
 	Hash        string
 	Pos         []MessageIndex
 	Payload     []byte
-	SubmittedAt time.Time
+	SubmittedAt time.Time `rlp:"optional"`
 }
 
 func BuildRawHotShotPayload(

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -513,7 +513,8 @@ func mainImpl() int {
 		return 1
 	}
 
-	if l2BlockChain.Config().ArbitrumChainParams.DataAvailabilityCommittee != nodeConfig.Node.DataAvailability.Enable {
+	// Data availability committee can be enabled only if the node is not an espresso caff node
+	if l2BlockChain.Config().ArbitrumChainParams.DataAvailabilityCommittee != nodeConfig.Node.DataAvailability.Enable && !nodeConfig.Node.EspressoCaffNode.Enable {
 		flag.Usage()
 		log.Error(fmt.Sprintf("data availability service usage for this chain is set to %v but --node.data-availability.enable is set to %v", l2BlockChain.Config().ArbitrumChainParams.DataAvailabilityCommittee, nodeConfig.Node.DataAvailability.Enable))
 		return 1

--- a/espressostreamer/espresso_streamer.go
+++ b/espressostreamer/espresso_streamer.go
@@ -350,6 +350,7 @@ func (s *EspressoStreamer) Start(ctxIn context.Context) error {
 	s.StopWaiter.Start(ctxIn, s)
 
 	ephemeralErrorHandler := util.NewEphemeralErrorHandler(3*time.Minute, FailedToFetchTransactionsErr.Error(), 1*time.Minute)
+	processedHotshotBlocks := 0
 	err := s.CallIterativelySafe(func(ctx context.Context) time.Duration {
 		err := s.QueueMessagesFromHotshot(ctx, s.parseEspressoTransaction)
 		if err != nil {
@@ -360,7 +361,13 @@ func (s *EspressoStreamer) Start(ctxIn context.Context) error {
 		} else {
 			ephemeralErrorHandler.Reset()
 		}
-		log.Debug("Now processing hotshot block", "block number", s.nextHotshotBlockNum)
+		processedHotshotBlocks += 1
+		if processedHotshotBlocks == 100 {
+			log.Info("Now processing hotshot block", "block number", s.nextHotshotBlockNum)
+			processedHotshotBlocks = 0
+		} else {
+			log.Debug("Now processing hotshot block", "block number", s.nextHotshotBlockNum)
+		}
 		return 0
 	})
 	return err

--- a/espressotee/espresso_tee_helpers.go
+++ b/espressotee/espresso_tee_helpers.go
@@ -2,10 +2,13 @@ package espressotee
 
 import (
 	"fmt"
+	"math/big"
 	"strings"
 	"time"
 
 	"github.com/spf13/pflag"
+
+	"github.com/ethereum/go-ethereum/log"
 )
 
 type TEE uint8
@@ -26,30 +29,108 @@ func (t TEE) FromString(s string) (TEE, error) {
 	}
 }
 
+type ContractVerificationFunc func() (bool, error)
+
+func ContractVerification(
+	maxRetries int,
+	retryDelay time.Duration,
+	fn ContractVerificationFunc,
+	msg string,
+) (bool, error) {
+	var err error
+	success := false
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		success, err = fn()
+		if err != nil {
+			log.Error(msg, "err", err)
+		}
+		if success {
+			return true, nil
+		}
+
+		if attempt < maxRetries-1 {
+			log.Error(msg, "attempt", attempt, "retry delay", retryDelay)
+			time.Sleep(retryDelay)
+		}
+	}
+	return false, nil
+}
+
+type BaseFeeCheckFunc func() (*big.Int, error)
+
+func BaseFeeCheck(
+	maxBaseFee uint64,
+	maxRetries int,
+	retryDelay time.Duration,
+	fn BaseFeeCheckFunc,
+	msg string,
+) error {
+	lowBaseFee := false
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		latestBaseFee, err := fn()
+		if err != nil && attempt < maxRetries-1 {
+			log.Error(msg, "err", err, "delay", retryDelay, "attempt", attempt+1)
+			if attempt < maxRetries-1 {
+				time.Sleep(retryDelay)
+			}
+			continue
+		}
+
+		if latestBaseFee.Uint64() > maxBaseFee {
+			log.Error(
+				msg,
+				"base fee", latestBaseFee.Uint64(),
+				"max base fee", maxBaseFee,
+				"delay", retryDelay,
+				"attempt", attempt+1,
+			)
+			if attempt < maxRetries-1 {
+				time.Sleep(retryDelay)
+			}
+			continue
+		}
+
+		lowBaseFee = true
+		break
+	}
+	if !lowBaseFee {
+		return fmt.Errorf("base fee is not low enough to attempt to register signer")
+	}
+	return nil
+}
+
 type EspressoRegisterSignerConfig struct {
 	MaxTxnWaitTime                time.Duration `koanf:"max-txn-wait-time"`
-	RetryDelay                    time.Duration `koanf:"retry-delay"`
+	RetryBaseFeeDelay             time.Duration `koanf:"retry-base-fee-delay"`
+	RetryReadContractDelay        time.Duration `koanf:"retry-read-contract-delay"`
 	MaxRetries                    uint8         `koanf:"max-retries"`
 	GasLimitBufferIncreasePercent uint64        `koanf:"gas-limit-buffer-increase-percent"`
+	MaxBaseFee                    uint64        `koanf:"max-base-fee"`
 }
 
 var DefaultEspressoRegisterSignerConfig = EspressoRegisterSignerConfig{
 	MaxTxnWaitTime:                3 * time.Minute,
-	RetryDelay:                    5 * time.Second,
+	RetryBaseFeeDelay:             1 * time.Minute,
+	RetryReadContractDelay:        5 * time.Second,
 	MaxRetries:                    5,
 	GasLimitBufferIncreasePercent: 20,
+	MaxBaseFee:                    70000000,
 }
 
 type EspressoRegisterSignerOpts struct {
 	MaxTxnWaitTime                time.Duration
-	RetryDelay                    time.Duration
+	RetryBaseFeeDelay             time.Duration
+	RetryReadContractDelay        time.Duration
 	MaxRetries                    int
 	GasLimitBufferIncreasePercent uint64
+	MaxBaseFee                    uint64
 }
 
 func AddEspressoRegisterSignerConfigOptions(prefix string, f *pflag.FlagSet) {
 	f.Duration(prefix+".max-txn-wait-time", DefaultEspressoRegisterSignerConfig.MaxTxnWaitTime, "max transaction wait time when calling espresso tee verifier contracts")
-	f.Duration(prefix+".retry-delay", DefaultEspressoRegisterSignerConfig.RetryDelay, "delay in between verification calls to espresso tee contracts")
+	f.Duration(prefix+".retry-base-fee-delay", DefaultEspressoRegisterSignerConfig.RetryBaseFeeDelay, "delay in calls to check the base fee")
+	f.Duration(prefix+".retry-read-contract-delay", DefaultEspressoRegisterSignerConfig.RetryReadContractDelay, "delay in calls to read from contract for verification")
 	f.Int(prefix+".max-retries", int(DefaultEspressoRegisterSignerConfig.MaxRetries), "how many times to check if we have data in our espresso tee contracts")
 	f.Uint64(prefix+".gas-limit-buffer-increase-percent", DefaultEspressoRegisterSignerConfig.GasLimitBufferIncreasePercent, "buffer increase to gas limit in espresso tee contracts")
+	f.Uint64(prefix+".max-base-fee", DefaultEspressoRegisterSignerConfig.MaxBaseFee, "max base fee to use when calling espresso tee contracts")
 }

--- a/espressotee/espresso_verifier.go
+++ b/espressotee/espresso_verifier.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -16,8 +17,18 @@ import (
 )
 
 type EspressoTEEVerifierInterface interface {
-	RegisterSigner(dataPoster *dataposter.DataPoster, attestation []byte, data []byte, teeType uint8, registerSignerOpts EspressoRegisterSignerOpts) error
-	RegisteredSigners(signer common.Address, teeType uint8) (bool, error)
+	RegisterSigner(
+		dataPoster *dataposter.DataPoster,
+		attestation []byte,
+		data []byte,
+		teeType uint8,
+		registerSignerOpts EspressoRegisterSignerOpts,
+	) error
+	RegisteredSigners(
+		signer common.Address,
+		teeType uint8,
+		registerSignerOpts EspressoRegisterSignerOpts,
+	) (bool, error)
 }
 
 type EspressoTEEVerifier struct {
@@ -30,7 +41,27 @@ func NewEspressoTEEVerifier(contract *espressogen.IEspressoTEEVerifier, l1Client
 	return &EspressoTEEVerifier{contract: contract, l1Client: l1Client, address: address}
 }
 
-func (e *EspressoTEEVerifier) RegisterSigner(dataPoster *dataposter.DataPoster, attestation []byte, data []byte, teeType uint8, registerSignerOpts EspressoRegisterSignerOpts) error {
+func (e *EspressoTEEVerifier) RegisterSigner(
+	dataPoster *dataposter.DataPoster,
+	attestation []byte,
+	data []byte,
+	teeType uint8,
+	registerSignerOpts EspressoRegisterSignerOpts,
+) error {
+	// First check base fee is low enough
+	err := BaseFeeCheck(
+		registerSignerOpts.MaxBaseFee,
+		registerSignerOpts.MaxRetries,
+		registerSignerOpts.RetryBaseFeeDelay,
+		func() (*big.Int, error) {
+			return dataPoster.BaseFee()
+		},
+		"register signer: latest base fee is greater than max base fee",
+	)
+	if err != nil {
+		return err
+	}
+
 	contractABI, err := espressogen.IEspressoTEEVerifierMetaData.GetAbi()
 	if err != nil {
 		return err
@@ -63,10 +94,12 @@ func (e *EspressoTEEVerifier) RegisterSigner(dataPoster *dataposter.DataPoster, 
 	// Add a buffer to the estimate for the gas limit
 	gasLimit := estimate * (100 + registerSignerOpts.GasLimitBufferIncreasePercent) / 100
 	log.Info("register signer gas limit", "gas limit", gasLimit)
+
 	// Since we use batch poster private key to register signer, we need to use dataposter to post transaction
 	// So the dataposter can track the proper nonce once we start posting batches
 	tx, err := dataPoster.PostSimpleTransaction(context.Background(), e.address, calldata, gasLimit, dataPoster.Auth().Value)
 	if err != nil {
+		log.Info("failed to post register signer transaction", "err", err)
 		return err
 	}
 
@@ -77,7 +110,11 @@ func (e *EspressoTEEVerifier) RegisterSigner(dataPoster *dataposter.DataPoster, 
 	receipt, err := bind.WaitMined(ctx, e.l1Client, tx)
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
-			return fmt.Errorf("register signer timed out after %v minutes waiting for tx %s to be mined", registerSignerOpts.MaxTxnWaitTime, tx.Hash().Hex())
+			return fmt.Errorf(
+				"register signer timed out after %v minutes waiting for tx %s to be mined",
+				registerSignerOpts.MaxTxnWaitTime,
+				tx.Hash().Hex(),
+			)
 		}
 		return err
 	}
@@ -91,6 +128,17 @@ func (e *EspressoTEEVerifier) RegisterSigner(dataPoster *dataposter.DataPoster, 
 	return nil
 }
 
-func (e *EspressoTEEVerifier) RegisteredSigners(address common.Address, teeType uint8) (bool, error) {
-	return e.contract.RegisteredSigners(&bind.CallOpts{}, address, teeType)
+func (e *EspressoTEEVerifier) RegisteredSigners(address common.Address, teeType uint8, registerSignerOpts EspressoRegisterSignerOpts) (bool, error) {
+	ok, err := ContractVerification(
+		registerSignerOpts.MaxRetries,
+		registerSignerOpts.RetryReadContractDelay,
+		func() (bool, error) {
+			return e.contract.RegisteredSigners(&bind.CallOpts{}, address, teeType)
+		},
+		"address not yet registered in contract",
+	)
+	if err != nil {
+		return false, err
+	}
+	return ok, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ replace github.com/offchainlabs/bold => ./bold
 require (
 	cloud.google.com/go/storage v1.43.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
-	github.com/EspressoSystems/espresso-network/sdks/go v0.2.1
+	github.com/EspressoSystems/espresso-network/sdks/go v0.2.2
 	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible
 	github.com/Shopify/toxiproxy v2.1.4+incompatible
 	github.com/alicebob/miniredis/v2 v2.32.1
@@ -93,8 +93,10 @@ require (
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sigurn/crc8 v0.0.0-20220107193325-2243fe600f9f // indirect
+	github.com/spf13/cobra v1.5.0 // indirect
 	github.com/status-im/keycard-go v0.2.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
-github.com/EspressoSystems/espresso-network/sdks/go v0.2.1 h1:lE+2kUIQhKAw78jlTz5L92gYywRD5uydWskwlLn3YwA=
-github.com/EspressoSystems/espresso-network/sdks/go v0.2.1/go.mod h1:aJX3rhV7d3QQ3dvmEFIKDfQvSFP9aUnFNENGpXPwELM=
+github.com/EspressoSystems/espresso-network/sdks/go v0.2.2 h1:a8QtZ9C0CgYfk+FEOQf4aSBNfP2keLLOcE9c7mSz1fY=
+github.com/EspressoSystems/espresso-network/sdks/go v0.2.2/go.mod h1:aJX3rhV7d3QQ3dvmEFIKDfQvSFP9aUnFNENGpXPwELM=
 github.com/GaijinEntertainment/go-exhaustruct/v2 v2.2.0/go.mod h1:n/vLeA7V+QY84iYAGwMkkUUp9ooeuftMEvaDrSVch+Q=
 github.com/HdrHistogram/hdrhistogram-go v1.1.0/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
@@ -785,6 +785,7 @@ github.com/imdario/mergo v0.3.4/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
@@ -1224,6 +1225,7 @@ github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v1.3.0/go.mod h1:BrRVncBjOJa/eUcVVm9CE+oC6as8k+VYr4NY7WCi9V4=
 github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
+github.com/spf13/cobra v1.5.0 h1:X+jTBEBqF0bHN+9cSMgmfuvv2VHJ9ezmFNf9Y/XstYU=
 github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJoUM=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -40,6 +40,7 @@ func createCaffNode(ctx context.Context, t *testing.T, existing *NodeBuilder, da
 	nodeConfig.EspressoCaffNode.WaitForConfirmations = existing.nodeConfig.EspressoCaffNode.WaitForConfirmations
 	nodeConfig.EspressoCaffNode.RequiredBlockDepth = existing.nodeConfig.EspressoCaffNode.RequiredBlockDepth
 	nodeConfig.EspressoCaffNode.BatchPosterAddr = "0xb386a74Dcab67b66F8AC07B4f08365d37495Dd23"
+	nodeConfig.EspressoCaffNode.FromBlock = 1
 
 	// for testing, we can use the same hotshot url for both
 	nodeConfig.EspressoCaffNode.HotShotUrls = []string{hotShotUrl, hotShotUrl, hotShotUrl, hotShotUrl}
@@ -79,7 +80,7 @@ func createCaffNodeConfig(ctx context.Context, t *testing.T) *NodeBuilder {
 	nodeConfig.EspressoCaffNode.HotShotUrls = []string{hotShotUrl, hotShotUrl, hotShotUrl, hotShotUrl}
 	nodeConfig.EspressoCaffNode.RetryTime = time.Second * 1
 	nodeConfig.EspressoCaffNode.HotshotPollingInterval = time.Millisecond * 100
-
+	nodeConfig.EspressoCaffNode.FromBlock = 1
 	nodeConfig.ParentChainReader.Enable = true
 
 	return builder

--- a/system_tests/espresso_sovereign_sequencer_test.go
+++ b/system_tests/espresso_sovereign_sequencer_test.go
@@ -42,6 +42,7 @@ func createL1AndL2Node(
 	builder.nodeConfig.BatchPoster.HotShotUrls = []string{hotShotUrl, hotShotUrl}
 	builder.nodeConfig.BatchPoster.UseEscapeHatch = false
 	builder.nodeConfig.BatchPoster.EspressoTeeVerifierAddress = "0xA46C59ce2FCaF445F96f66F0411e06A94D34BF45"
+	builder.nodeConfig.BatchPoster.EspressoRegisterSignerConfig.MaxBaseFee = 10000000000 // 100 GWEI for tests
 
 	// validator config
 	builder.nodeConfig.BlockValidator.Enable = true


### PR DESCRIPTION
Back porting two PRs from Integration branch:

- #638
- #639

Also add the RLP `optional` tag to the new parameter `SubmittedAt` in the `SubmittedEspressoTx` struct.