### PR TITLE
Fix backport

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -19,7 +19,6 @@ jobs:
         uses: korthout/backport-action@v3
 
       - name: create issue if backport failed
-        if: failure()
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
### This PR:
The backport action will never fail even it doesn't manage to create a backport PR. Therefore, remove the `failure` condition.