### PR TITLE
Zs/mutex fixes

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -94,7 +94,6 @@ const (
 	sequencerBatchPostWithBlobsDelayProofMethodName = "addSequencerL2BatchFromBlobsDelayProof"
 	oldSequencerBatchPostWithBlobsMethodName        = "addSequencerL2BatchFromBlobs"
 	newSequencerBatchPostWithBlobsMethodName        = "addSequencerL2BatchFromBlobs0"
-	espressoTransactionSizeLimit                    = 900 * 1024
 )
 
 type batchPosterPosition struct {
@@ -210,6 +209,7 @@ type BatchPosterConfig struct {
 	EspressoTxnsSendingInterval      time.Duration                            `koanf:"espresso-txns-sending-interval"`
 	EspressoTxnsResubmissionInterval time.Duration                            `koanf:"espresso-txns-resubmission-interval"`
 	ResubmitEspressoTxDeadline       time.Duration                            `koanf:"resubmit-espresso-tx-deadline"`
+	EspressoTxSizeLimit              int64                                    `koanf:"espresso-tx-size-limit"`
 	// MaxBlockLagBeforeEscapeHatch specifies the maximum number of L1 blocks that HotShot
 	// state updates can lag behind before triggering the escape hatch. If the difference
 	// between the current L1 block number and the latest state update's block number
@@ -287,6 +287,7 @@ func BatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Duration(prefix+".espresso-txns-resubmission-interval", DefaultBatchPosterConfig.EspressoTxnsResubmissionInterval, "interval between checking if the node should resubmitting transactions to Espresso Network")
 	f.Duration(prefix+".resubmit-espresso-tx-deadline", DefaultBatchPosterConfig.ResubmitEspressoTxDeadline, "time threshold after which a transaction will be automatically resubmitted if no response is received")
 	f.Uint64(prefix+".max-block-lag-before-escape-hatch", DefaultBatchPosterConfig.MaxBlockLagBeforeEscapeHatch, "specifies the switch delay threshold used to determine hotshot liveness")
+	f.Int64(prefix+".espresso-tx-size-limit", DefaultBatchPosterConfig.EspressoTxSizeLimit, "specifies the maximum size of a transaction to be sent to the Espresso Network")
 	espressotee.AddEspressoRegisterSignerConfigOptions(prefix+".espresso-register-signer-config", f)
 	redislock.AddConfigOptions(prefix+".redis-lock", f)
 	dataposter.DataPosterConfigAddOptions(prefix+".data-poster", f, dataposter.DefaultDataPosterConfig)
@@ -333,6 +334,7 @@ var DefaultBatchPosterConfig = BatchPosterConfig{
 	HotShotUrls:                      []string{""},
 	EspressoTeeType:                  "SGX",
 	EspressoRegisterSignerConfig:     espressotee.DefaultEspressoRegisterSignerConfig,
+	EspressoTxSizeLimit:              200 * 1024,
 }
 
 var DefaultBatchPosterL1WalletConfig = genericconf.WalletConfig{
@@ -376,6 +378,7 @@ var TestBatchPosterConfig = BatchPosterConfig{
 	HotShotUrls:                      []string{},
 	EspressoTeeType:                  "SGX",
 	EspressoRegisterSignerConfig:     espressotee.DefaultEspressoRegisterSignerConfig,
+	EspressoTxSizeLimit:              200 * 1024,
 }
 
 type BatchPosterOpts struct {
@@ -498,7 +501,7 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 		opts.Streamer.espressoTxnsSendingInterval = opts.Config().EspressoTxnsSendingInterval
 		opts.Streamer.espressoTxnsResubmissionInterval = opts.Config().EspressoTxnsResubmissionInterval
 		opts.Streamer.maxBlockLagBeforeEscapeHatch = opts.Config().MaxBlockLagBeforeEscapeHatch
-		opts.Streamer.espressoMaxTransactionSize = espressoTransactionSizeLimit
+		opts.Streamer.espressoMaxTransactionSize = opts.Config().EspressoTxSizeLimit
 		opts.Streamer.resubmitEspressoTxDeadline = opts.Config().ResubmitEspressoTxDeadline
 	}
 

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -207,6 +207,7 @@ type BatchPosterConfig struct {
 	HotShotUrls                  []string                                 `koanf:"hotshot-urls"`
 	UseEscapeHatch               bool                                     `koanf:"use-escape-hatch"`
 	EspressoTxnsPollingInterval  time.Duration                            `koanf:"espresso-txns-polling-interval"`
+	EspressoTxnsSendingInterval  time.Duration                            `koanf:"espresso-txns-sending-interval"`
 	ResubmitEspressoTxDeadline   time.Duration                            `koanf:"resubmit-espresso-tx-deadline"`
 	// MaxBlockLagBeforeEscapeHatch specifies the maximum number of L1 blocks that HotShot
 	// state updates can lag behind before triggering the escape hatch. If the difference
@@ -281,6 +282,7 @@ func BatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Uint64(prefix+".delay-buffer-threshold-margin", DefaultBatchPosterConfig.DelayBufferThresholdMargin, "the number of blocks to post the batch before reaching the delay buffer threshold")
 	f.Bool(prefix+".use-escape-hatch", DefaultBatchPosterConfig.UseEscapeHatch, "if true, Escape Hatch functionality will be used")
 	f.Duration(prefix+".espresso-txns-polling-interval", DefaultBatchPosterConfig.EspressoTxnsPollingInterval, "interval between polling for transactions to be included in the block")
+	f.Duration(prefix+".espresso-txns-sending-interval", DefaultBatchPosterConfig.EspressoTxnsSendingInterval, "interval between sending transactions to Espresso Network")
 	f.Duration(prefix+".resubmit-espresso-tx-deadline", DefaultBatchPosterConfig.ResubmitEspressoTxDeadline, "time threshold after which a transaction will be automatically resubmitted if no response is received")
 	f.Uint64(prefix+".max-block-lag-before-escape-hatch", DefaultBatchPosterConfig.MaxBlockLagBeforeEscapeHatch, "specifies the switch delay threshold used to determine hotshot liveness")
 	espressotee.AddEspressoRegisterSignerConfigOptions(prefix+".espresso-register-signer-config", f)
@@ -321,6 +323,7 @@ var DefaultBatchPosterConfig = BatchPosterConfig{
 	DelayBufferThresholdMargin:     25, // 5 minutes considering 12-second blocks
 	UseEscapeHatch:                 false,
 	EspressoTxnsPollingInterval:    time.Second,
+	EspressoTxnsSendingInterval:    time.Second,
 	ResubmitEspressoTxDeadline:     10 * time.Minute,
 	MaxBlockLagBeforeEscapeHatch:   350,
 	LightClientAddress:             "",
@@ -362,6 +365,7 @@ var TestBatchPosterConfig = BatchPosterConfig{
 	DelayBufferThresholdMargin:     0,
 	UseEscapeHatch:                 false,
 	EspressoTxnsPollingInterval:    time.Second,
+	EspressoTxnsSendingInterval:    time.Second,
 	MaxBlockLagBeforeEscapeHatch:   10,
 	LightClientAddress:             "",
 	ResubmitEspressoTxDeadline:     10 * time.Second,
@@ -487,6 +491,7 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 		opts.Streamer.lightClientReader = lightClientReader
 		opts.Streamer.UseEscapeHatch = opts.Config().UseEscapeHatch
 		opts.Streamer.espressoTxnsPollingInterval = opts.Config().EspressoTxnsPollingInterval
+		opts.Streamer.espressoTxnsSendingInterval = opts.Config().EspressoTxnsSendingInterval
 		opts.Streamer.maxBlockLagBeforeEscapeHatch = opts.Config().MaxBlockLagBeforeEscapeHatch
 		opts.Streamer.espressoMaxTransactionSize = espressoTransactionSizeLimit
 		opts.Streamer.resubmitEspressoTxDeadline = opts.Config().ResubmitEspressoTxDeadline

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -200,15 +200,16 @@ type BatchPosterConfig struct {
 	gasRefunder  common.Address
 	l1BlockBound l1BlockBound
 	// Espresso specific flags
-	EspressoTeeVerifierAddress   string                                   `koanf:"espresso-tee-verifier-address"`
-	EspressoTeeType              string                                   `koanf:"espresso-tee-type"`
-	EspressoRegisterSignerConfig espressotee.EspressoRegisterSignerConfig `koanf:"espresso-register-signer-config"`
-	LightClientAddress           string                                   `koanf:"light-client-address"`
-	HotShotUrls                  []string                                 `koanf:"hotshot-urls"`
-	UseEscapeHatch               bool                                     `koanf:"use-escape-hatch"`
-	EspressoTxnsPollingInterval  time.Duration                            `koanf:"espresso-txns-polling-interval"`
-	EspressoTxnsSendingInterval  time.Duration                            `koanf:"espresso-txns-sending-interval"`
-	ResubmitEspressoTxDeadline   time.Duration                            `koanf:"resubmit-espresso-tx-deadline"`
+	EspressoTeeVerifierAddress       string                                   `koanf:"espresso-tee-verifier-address"`
+	EspressoTeeType                  string                                   `koanf:"espresso-tee-type"`
+	EspressoRegisterSignerConfig     espressotee.EspressoRegisterSignerConfig `koanf:"espresso-register-signer-config"`
+	LightClientAddress               string                                   `koanf:"light-client-address"`
+	HotShotUrls                      []string                                 `koanf:"hotshot-urls"`
+	UseEscapeHatch                   bool                                     `koanf:"use-escape-hatch"`
+	EspressoTxnsPollingInterval      time.Duration                            `koanf:"espresso-txns-polling-interval"`
+	EspressoTxnsSendingInterval      time.Duration                            `koanf:"espresso-txns-sending-interval"`
+	EspressoTxnsResubmissionInterval time.Duration                            `koanf:"espresso-txns-resubmission-interval"`
+	ResubmitEspressoTxDeadline       time.Duration                            `koanf:"resubmit-espresso-tx-deadline"`
 	// MaxBlockLagBeforeEscapeHatch specifies the maximum number of L1 blocks that HotShot
 	// state updates can lag behind before triggering the escape hatch. If the difference
 	// between the current L1 block number and the latest state update's block number
@@ -283,6 +284,7 @@ func BatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Bool(prefix+".use-escape-hatch", DefaultBatchPosterConfig.UseEscapeHatch, "if true, Escape Hatch functionality will be used")
 	f.Duration(prefix+".espresso-txns-polling-interval", DefaultBatchPosterConfig.EspressoTxnsPollingInterval, "interval between polling for transactions to be included in the block")
 	f.Duration(prefix+".espresso-txns-sending-interval", DefaultBatchPosterConfig.EspressoTxnsSendingInterval, "interval between sending transactions to Espresso Network")
+	f.Duration(prefix+".espresso-txns-resubmission-interval", DefaultBatchPosterConfig.EspressoTxnsResubmissionInterval, "interval between checking if the node should resubmitting transactions to Espresso Network")
 	f.Duration(prefix+".resubmit-espresso-tx-deadline", DefaultBatchPosterConfig.ResubmitEspressoTxDeadline, "time threshold after which a transaction will be automatically resubmitted if no response is received")
 	f.Uint64(prefix+".max-block-lag-before-escape-hatch", DefaultBatchPosterConfig.MaxBlockLagBeforeEscapeHatch, "specifies the switch delay threshold used to determine hotshot liveness")
 	espressotee.AddEspressoRegisterSignerConfigOptions(prefix+".espresso-register-signer-config", f)
@@ -298,38 +300,39 @@ var DefaultBatchPosterConfig = BatchPosterConfig{
 	// This default is overridden for L3 chains in applyChainParameters in cmd/nitro/nitro.go
 	MaxSize: 100000,
 	// Try to fill 3 blobs per batch
-	Max4844BatchSize:               blobs.BlobEncodableData*(params.MaxBlobGasPerBlock/params.BlobTxBlobGasPerBlob)/2 - 2000,
-	PollInterval:                   time.Second * 10,
-	PollIntervalAfterBatchPost:     time.Second * 10,
-	ErrorDelay:                     time.Second * 10,
-	MaxDelay:                       time.Hour,
-	WaitForMaxDelay:                false,
-	CompressionLevel:               brotli.BestCompression,
-	DASRetentionPeriod:             daprovider.DefaultDASRetentionPeriod,
-	GasRefunderAddress:             "",
-	ExtraBatchGas:                  50_000,
-	Post4844Blobs:                  false,
-	IgnoreBlobPrice:                false,
-	DataPoster:                     dataposter.DefaultDataPosterConfig,
-	ParentChainWallet:              DefaultBatchPosterL1WalletConfig,
-	L1BlockBound:                   "",
-	L1BlockBoundBypass:             time.Hour,
-	UseAccessLists:                 true,
-	RedisLock:                      redislock.DefaultCfg,
-	GasEstimateBaseFeeMultipleBips: arbmath.OneInUBips * 3 / 2,
-	ReorgResistanceMargin:          10 * time.Minute,
-	CheckBatchCorrectness:          true,
-	MaxEmptyBatchDelay:             3 * 24 * time.Hour,
-	DelayBufferThresholdMargin:     25, // 5 minutes considering 12-second blocks
-	UseEscapeHatch:                 false,
-	EspressoTxnsPollingInterval:    time.Second,
-	EspressoTxnsSendingInterval:    time.Second,
-	ResubmitEspressoTxDeadline:     10 * time.Minute,
-	MaxBlockLagBeforeEscapeHatch:   350,
-	LightClientAddress:             "",
-	HotShotUrls:                    []string{""},
-	EspressoTeeType:                "SGX",
-	EspressoRegisterSignerConfig:   espressotee.DefaultEspressoRegisterSignerConfig,
+	Max4844BatchSize:                 blobs.BlobEncodableData*(params.MaxBlobGasPerBlock/params.BlobTxBlobGasPerBlob)/2 - 2000,
+	PollInterval:                     time.Second * 10,
+	PollIntervalAfterBatchPost:       time.Second * 10,
+	ErrorDelay:                       time.Second * 10,
+	MaxDelay:                         time.Hour,
+	WaitForMaxDelay:                  false,
+	CompressionLevel:                 brotli.BestCompression,
+	DASRetentionPeriod:               daprovider.DefaultDASRetentionPeriod,
+	GasRefunderAddress:               "",
+	ExtraBatchGas:                    50_000,
+	Post4844Blobs:                    false,
+	IgnoreBlobPrice:                  false,
+	DataPoster:                       dataposter.DefaultDataPosterConfig,
+	ParentChainWallet:                DefaultBatchPosterL1WalletConfig,
+	L1BlockBound:                     "",
+	L1BlockBoundBypass:               time.Hour,
+	UseAccessLists:                   true,
+	RedisLock:                        redislock.DefaultCfg,
+	GasEstimateBaseFeeMultipleBips:   arbmath.OneInUBips * 3 / 2,
+	ReorgResistanceMargin:            10 * time.Minute,
+	CheckBatchCorrectness:            true,
+	MaxEmptyBatchDelay:               3 * 24 * time.Hour,
+	DelayBufferThresholdMargin:       25, // 5 minutes considering 12-second blocks
+	UseEscapeHatch:                   false,
+	EspressoTxnsPollingInterval:      time.Second,
+	EspressoTxnsSendingInterval:      time.Second,
+	EspressoTxnsResubmissionInterval: 2 * time.Second,
+	ResubmitEspressoTxDeadline:       10 * time.Minute,
+	MaxBlockLagBeforeEscapeHatch:     350,
+	LightClientAddress:               "",
+	HotShotUrls:                      []string{""},
+	EspressoTeeType:                  "SGX",
+	EspressoRegisterSignerConfig:     espressotee.DefaultEspressoRegisterSignerConfig,
 }
 
 var DefaultBatchPosterL1WalletConfig = genericconf.WalletConfig{
@@ -341,37 +344,38 @@ var DefaultBatchPosterL1WalletConfig = genericconf.WalletConfig{
 }
 
 var TestBatchPosterConfig = BatchPosterConfig{
-	Enable:                         true,
-	MaxSize:                        100000,
-	Max4844BatchSize:               DefaultBatchPosterConfig.Max4844BatchSize,
-	PollInterval:                   time.Millisecond * 10,
-	PollIntervalAfterBatchPost:     time.Millisecond * 10,
-	ErrorDelay:                     time.Millisecond * 10,
-	MaxDelay:                       0,
-	WaitForMaxDelay:                false,
-	CompressionLevel:               2,
-	DASRetentionPeriod:             daprovider.DefaultDASRetentionPeriod,
-	GasRefunderAddress:             "",
-	ExtraBatchGas:                  10_000,
-	Post4844Blobs:                  false,
-	IgnoreBlobPrice:                false,
-	DataPoster:                     dataposter.TestDataPosterConfig,
-	ParentChainWallet:              DefaultBatchPosterL1WalletConfig,
-	L1BlockBound:                   "",
-	L1BlockBoundBypass:             time.Hour,
-	UseAccessLists:                 true,
-	GasEstimateBaseFeeMultipleBips: arbmath.OneInUBips * 3 / 2,
-	CheckBatchCorrectness:          true,
-	DelayBufferThresholdMargin:     0,
-	UseEscapeHatch:                 false,
-	EspressoTxnsPollingInterval:    time.Second,
-	EspressoTxnsSendingInterval:    time.Second,
-	MaxBlockLagBeforeEscapeHatch:   10,
-	LightClientAddress:             "",
-	ResubmitEspressoTxDeadline:     10 * time.Second,
-	HotShotUrls:                    []string{},
-	EspressoTeeType:                "SGX",
-	EspressoRegisterSignerConfig:   espressotee.DefaultEspressoRegisterSignerConfig,
+	Enable:                           true,
+	MaxSize:                          100000,
+	Max4844BatchSize:                 DefaultBatchPosterConfig.Max4844BatchSize,
+	PollInterval:                     time.Millisecond * 10,
+	PollIntervalAfterBatchPost:       time.Millisecond * 10,
+	ErrorDelay:                       time.Millisecond * 10,
+	MaxDelay:                         0,
+	WaitForMaxDelay:                  false,
+	CompressionLevel:                 2,
+	DASRetentionPeriod:               daprovider.DefaultDASRetentionPeriod,
+	GasRefunderAddress:               "",
+	ExtraBatchGas:                    10_000,
+	Post4844Blobs:                    false,
+	IgnoreBlobPrice:                  false,
+	DataPoster:                       dataposter.TestDataPosterConfig,
+	ParentChainWallet:                DefaultBatchPosterL1WalletConfig,
+	L1BlockBound:                     "",
+	L1BlockBoundBypass:               time.Hour,
+	UseAccessLists:                   true,
+	GasEstimateBaseFeeMultipleBips:   arbmath.OneInUBips * 3 / 2,
+	CheckBatchCorrectness:            true,
+	DelayBufferThresholdMargin:       0,
+	UseEscapeHatch:                   false,
+	EspressoTxnsPollingInterval:      time.Second,
+	EspressoTxnsSendingInterval:      time.Second,
+	EspressoTxnsResubmissionInterval: 2 * time.Second,
+	MaxBlockLagBeforeEscapeHatch:     10,
+	LightClientAddress:               "",
+	ResubmitEspressoTxDeadline:       10 * time.Second,
+	HotShotUrls:                      []string{},
+	EspressoTeeType:                  "SGX",
+	EspressoRegisterSignerConfig:     espressotee.DefaultEspressoRegisterSignerConfig,
 }
 
 type BatchPosterOpts struct {
@@ -492,6 +496,7 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 		opts.Streamer.UseEscapeHatch = opts.Config().UseEscapeHatch
 		opts.Streamer.espressoTxnsPollingInterval = opts.Config().EspressoTxnsPollingInterval
 		opts.Streamer.espressoTxnsSendingInterval = opts.Config().EspressoTxnsSendingInterval
+		opts.Streamer.espressoTxnsResubmissionInterval = opts.Config().EspressoTxnsResubmissionInterval
 		opts.Streamer.maxBlockLagBeforeEscapeHatch = opts.Config().MaxBlockLagBeforeEscapeHatch
 		opts.Streamer.espressoMaxTransactionSize = espressoTransactionSizeLimit
 		opts.Streamer.resubmitEspressoTxDeadline = opts.Config().ResubmitEspressoTxDeadline

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1941,8 +1941,6 @@ func (s *TransactionStreamer) submitTransactionsToEspresso(ctx context.Context, 
 }
 
 func (s *TransactionStreamer) pollToResubmitEspressoTransactions(ctx context.Context, ignored struct{}) time.Duration {
-	s.espressoSubmittedTxnsMutex.Lock()
-	defer s.espressoSubmittedTxnsMutex.Unlock()
 	retryRate := s.espressoTxnsSendingInterval * 2
 	submittedTxns, err := s.getEspressoSubmittedTxns()
 	if err != nil {

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1503,7 +1503,7 @@ func (s *TransactionStreamer) checkSubmittedTransactionForFinality(ctx context.C
 	if lastConfirmedPosInDb, _ := s.getLastConfirmedPos(); lastConfirmedPosInDb != nil {
 		lastConfirmedPos = *lastConfirmedPosInDb
 	}
-	dataArray := []espressoTypes.TransactionQueryData{}
+	blockHeights := []uint64{}
 	posArray := []int{}
 	for i, submittedTx := range submittedTxns {
 		hash := submittedTx.Hash
@@ -1512,7 +1512,7 @@ func (s *TransactionStreamer) checkSubmittedTransactionForFinality(ctx context.C
 			return fmt.Errorf("invalid hotshot tx hash, failed to parse hash %s: %w", hash, err)
 		}
 
-		data, err := s.checkEspressoQueryNodesForTransaction(ctx, submittedTxHash)
+		blockHeight, err := s.checkEspressoQueryNodesForTransaction(ctx, submittedTxHash)
 		if err != nil {
 			resubmittedTxn, err := s.resubmitTransactionIfPastDelay(ctx, submittedTx)
 			if err != nil {
@@ -1526,15 +1526,14 @@ func (s *TransactionStreamer) checkSubmittedTransactionForFinality(ctx context.C
 			log.Info("encountered an error trying to check espresso for a submitted txn", "err", err)
 			continue
 		}
-		log.Info("transaction checked", "hash", hash, "data", data)
+		log.Info("transaction checked", "hash", hash, "data", blockHeight)
 
-		dataArray = append(dataArray, data)
+		blockHeights = append(blockHeights, blockHeight)
 		posArray = append(posArray, i)
 	}
 
-	for i, data := range dataArray {
+	for i, height := range blockHeights {
 		submittedTx := submittedTxns[posArray[i]]
-		height := data.BlockHeight
 
 		resp, err := s.espressoClient.FetchTransactionsInBlock(ctx, height, s.chainConfig.ChainID.Uint64())
 		if err != nil {
@@ -1593,13 +1592,13 @@ func (s *TransactionStreamer) checkSubmittedTransactionForFinality(ctx context.C
 	return nil
 }
 
-func (s *TransactionStreamer) checkEspressoQueryNodesForTransaction(ctx context.Context, hash *tagged_base64.TaggedBase64) (espressoTypes.TransactionQueryData, error) {
-	tx, err := s.espressoClient.FetchTransactionByHash(ctx, hash)
+func (s *TransactionStreamer) checkEspressoQueryNodesForTransaction(ctx context.Context, hash *tagged_base64.TaggedBase64) (uint64, error) {
+	payload, err := s.espressoClient.FetchExplorerTransactionByHash(ctx, hash)
 	if err != nil {
-		return espressoTypes.TransactionQueryData{}, fmt.Errorf("failed to fetch transaction from espresso: %w", err)
+		return 0, fmt.Errorf("failed to fetch transaction from espresso: %w", err)
 	}
 
-	return tx, nil
+	return payload.TransactionsDetails.ExplorerDetails.BlockHeight, nil
 }
 
 func (s *TransactionStreamer) resubmitTransaction(ctx context.Context, submittedTx arbutil.SubmittedEspressoTx) (*arbutil.SubmittedEspressoTx, error) {
@@ -2007,7 +2006,7 @@ func (s *TransactionStreamer) shouldResubmitEspressoTransactions(ctx context.Con
 		return false
 	}
 
-	_, err = s.espressoClient.FetchTransactionByHash(ctx, submittedTxHash)
+	_, err = s.espressoClient.FetchExplorerTransactionByHash(ctx, submittedTxHash)
 	if err == nil {
 		// if we are able to fetch the transaction, we dont need to resubmit
 		return false

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1503,7 +1503,6 @@ func (s *TransactionStreamer) checkSubmittedTransactionForFinality(ctx context.C
 	if lastConfirmedPosInDb, _ := s.getLastConfirmedPos(); lastConfirmedPosInDb != nil {
 		lastConfirmedPos = *lastConfirmedPosInDb
 	}
-	hasInterrupted := false
 	dataArray := []espressoTypes.TransactionQueryData{}
 	posArray := []int{}
 	for i, submittedTx := range submittedTxns {
@@ -1524,16 +1523,13 @@ func (s *TransactionStreamer) checkSubmittedTransactionForFinality(ctx context.C
 			} else {
 				newSubmittedTxns = append(newSubmittedTxns, submittedTx)
 			}
-			log.Info("encountered an error trying to check espresso for a submitted txn", "err")
-			hasInterrupted = true
+			log.Info("encountered an error trying to check espresso for a submitted txn", "err", err)
+			continue
 		}
 		log.Info("transaction checked", "hash", hash, "data", data)
 
-		if !hasInterrupted {
-			// This is essentially the same as checking that data is nil.
-			dataArray = append(dataArray, data)
-			posArray = append(posArray, i)
-		}
+		dataArray = append(dataArray, data)
+		posArray = append(posArray, i)
 	}
 
 	for i, data := range dataArray {

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -65,9 +65,10 @@ type TransactionStreamer struct {
 	config         TransactionStreamerConfigFetcher
 	snapSyncConfig *SnapSyncConfig
 
-	insertionMutex                  sync.Mutex // cannot be acquired while reorgMutex is held
-	reorgMutex                      sync.RWMutex
-	espressoTxnsStateInsertionMutex sync.Mutex
+	insertionMutex             sync.Mutex // cannot be acquired while reorgMutex is held
+	reorgMutex                 sync.RWMutex
+	espressoPendingTxnPosMutex sync.Mutex
+	espressoSubmittedTxnsMutex sync.Mutex
 
 	newMessageNotifier     chan struct{}
 	newSovereignTxNotifier chan struct{}
@@ -1485,8 +1486,8 @@ func (s *TransactionStreamer) backfillTrackersForMissingBlockMetadata(ctx contex
 // Check if the latest submitted transaction has been finalized on L1 and verify it.
 // Return a bool indicating whether a new transaction can be submitted to HotShot
 func (s *TransactionStreamer) checkSubmittedTransactionForFinality(ctx context.Context) error {
-	s.espressoTxnsStateInsertionMutex.Lock()
-	defer s.espressoTxnsStateInsertionMutex.Unlock()
+	s.espressoSubmittedTxnsMutex.Lock()
+	defer s.espressoSubmittedTxnsMutex.Unlock()
 
 	submittedTxns, err := s.getEspressoSubmittedTxns()
 	if err != nil {
@@ -1714,8 +1715,8 @@ func (s *TransactionStreamer) setEspressoPendingTxnsPos(batch ethdb.KeyValueWrit
 
 // Append a position to the pending queue. Please ensure this position is valid beforehand.
 func (s *TransactionStreamer) SubmitEspressoTransactionPos(pos []arbutil.MessageIndex) error {
-	s.espressoTxnsStateInsertionMutex.Lock()
-	defer s.espressoTxnsStateInsertionMutex.Unlock()
+	s.espressoPendingTxnPosMutex.Lock()
+	defer s.espressoPendingTxnPosMutex.Unlock()
 
 	batch := s.db.NewBatch()
 	pendingTxnsPos, err := s.getEspressoPendingTxnsPos()
@@ -1756,23 +1757,23 @@ func (s *TransactionStreamer) ResubmitEspressoTransactions(ctx context.Context, 
 }
 
 func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) error {
-	s.espressoTxnsStateInsertionMutex.Lock()
+	s.espressoPendingTxnPosMutex.Lock()
 	pendingTxnsPos, err := s.getEspressoPendingTxnsPos()
 	if err != nil {
-		s.espressoTxnsStateInsertionMutex.Unlock()
+		s.espressoPendingTxnPosMutex.Unlock()
 		return err
 	}
 	if len(pendingTxnsPos) > 0 {
 		fetcher := func(pos arbutil.MessageIndex) ([]byte, error) {
 			msg, err := s.GetMessage(pos)
 			if err != nil {
-				s.espressoTxnsStateInsertionMutex.Unlock()
+				s.espressoPendingTxnPosMutex.Unlock()
 				return nil, err
 			}
 			if pos > 1 {
 				prevMsg, err := s.GetMessage(pos - 1)
 				if err != nil {
-					s.espressoTxnsStateInsertionMutex.Unlock()
+					s.espressoPendingTxnPosMutex.Unlock()
 					return nil, err
 				}
 				if prevMsg.DelayedMessagesRead+1 == msg.DelayedMessagesRead {
@@ -1786,7 +1787,7 @@ func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) er
 			}
 			b, err := rlp.EncodeToBytes(msg)
 			if err != nil {
-				s.espressoTxnsStateInsertionMutex.Unlock()
+				s.espressoPendingTxnPosMutex.Unlock()
 				return nil, err
 			}
 			return b, nil
@@ -1797,18 +1798,18 @@ func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) er
 		err = s.setEspressoPendingTxnsPos(batch, pendingTxnsPos)
 
 		if err != nil {
-			s.espressoTxnsStateInsertionMutex.Unlock()
+			s.espressoPendingTxnPosMutex.Unlock()
 			return fmt.Errorf("failed to set the pending txn list in the db batch: %w", err)
 		}
 
 		err = batch.Write()
 
 		if err != nil {
-			s.espressoTxnsStateInsertionMutex.Unlock()
+			s.espressoPendingTxnPosMutex.Unlock()
 			return fmt.Errorf("failed to write pending txn list batch to db: %w", err)
 		}
 
-		s.espressoTxnsStateInsertionMutex.Unlock()
+		s.espressoPendingTxnPosMutex.Unlock()
 
 		if msgCnt == 0 {
 			return fmt.Errorf("failed to build the hotshot transaction: a large message has exceeded the size limit or failed to get a message from storage")
@@ -1835,8 +1836,8 @@ func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) er
 		batch = s.db.NewBatch()
 		submittedPos := pendingTxnsPos[:msgCnt]
 
-		s.espressoTxnsStateInsertionMutex.Lock()
-		defer s.espressoTxnsStateInsertionMutex.Unlock()
+		s.espressoSubmittedTxnsMutex.Lock()
+		defer s.espressoSubmittedTxnsMutex.Unlock()
 
 		submittedTxns, err := s.getEspressoSubmittedTxns()
 		if err != nil {
@@ -1954,6 +1955,8 @@ func (s *TransactionStreamer) submitTransactionsToEspresso(ctx context.Context, 
 }
 
 func (s *TransactionStreamer) pollToResubmitEspressoTransactions(ctx context.Context, ignored struct{}) time.Duration {
+	s.espressoSubmittedTxnsMutex.Lock()
+	defer s.espressoSubmittedTxnsMutex.Unlock()
 	retryRate := s.espressoTxnsPollingInterval * 2
 	submittedTxns, err := s.getEspressoSubmittedTxns()
 	if err != nil {

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1529,6 +1529,8 @@ func (s *TransactionStreamer) checkSubmittedTransactionForFinality(ctx context.C
 
 		validated := arbutil.ValidateIfPayloadIsInBlock(submittedTx.Payload, resp.Transactions)
 		if !validated {
+			// This may seem redundant as we have a resubmission loop, but hitting this code path means that we were able to find the submitted tx hash across a quorom of
+			// the query nodes, and got a result for what block it should be in. However, we were unable to validate that the payload was in the block.
 			log.Warn("Transaction payload not found in block, attempt to resubmit", "height", height, "tx", submittedTx.Hash)
 			resubmittedTxn, err := s.resubmitTransaction(ctx, submittedTx)
 			if err != nil {
@@ -1753,7 +1755,6 @@ func (s *TransactionStreamer) ResubmitEspressoTransactions(ctx context.Context, 
 
 func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) error {
 	s.espressoTxnsStateInsertionMutex.Lock()
-	defer s.espressoTxnsStateInsertionMutex.Unlock()
 	pendingTxnsPos, err := s.getEspressoPendingTxnsPos()
 	if err != nil {
 		return err
@@ -1785,6 +1786,22 @@ func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) er
 			return b, nil
 		}
 		payload, msgCnt := arbutil.BuildRawHotShotPayload(pendingTxnsPos, fetcher, s.espressoMaxTransactionSize)
+		batch := s.db.NewBatch()
+		pendingTxnsPos = pendingTxnsPos[msgCnt:]
+		err = s.setEspressoPendingTxnsPos(batch, pendingTxnsPos)
+
+		if err != nil {
+			return fmt.Errorf("failed to set the pending txn list in the db batch: %w", err)
+		}
+
+		err = batch.Write()
+
+		if err != nil {
+			return fmt.Errorf("failed to write pending txn list batch to db: %w", err)
+		}
+
+		s.espressoTxnsStateInsertionMutex.Unlock()
+
 		if msgCnt == 0 {
 			return fmt.Errorf("failed to build the hotshot transaction: a large message has exceeded the size limit or failed to get a message from storage")
 		}
@@ -1807,8 +1824,11 @@ func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) er
 			return fmt.Errorf("failed to submit transaction to espresso: %w", err)
 		}
 
-		batch := s.db.NewBatch()
+		batch = s.db.NewBatch()
 		submittedPos := pendingTxnsPos[:msgCnt]
+
+		s.espressoTxnsStateInsertionMutex.Lock()
+		defer s.espressoTxnsStateInsertionMutex.Unlock()
 
 		submittedTxns, err := s.getEspressoSubmittedTxns()
 		if err != nil {
@@ -1828,12 +1848,6 @@ func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) er
 
 		if err = s.setEspressoSubmittedTxns(batch, submittedTxns); err != nil {
 			return fmt.Errorf("failed to set espresso submitted txns: %w", err)
-		}
-
-		pendingTxnsPos = pendingTxnsPos[msgCnt:]
-		err = s.setEspressoPendingTxnsPos(batch, pendingTxnsPos)
-		if err != nil {
-			return fmt.Errorf("failed to set the pending txn: %w", err)
 		}
 
 		err = batch.Write()
@@ -1932,9 +1946,6 @@ func (s *TransactionStreamer) submitTransactionsToEspresso(ctx context.Context, 
 }
 
 func (s *TransactionStreamer) pollToResubmitEspressoTransactions(ctx context.Context, ignored struct{}) time.Duration {
-	s.espressoTxnsStateInsertionMutex.Lock()
-	defer s.espressoTxnsStateInsertionMutex.Unlock()
-
 	retryRate := s.espressoTxnsPollingInterval * 2
 	submittedTxns, err := s.getEspressoSubmittedTxns()
 	if err != nil {

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1190,21 +1190,23 @@ func (s *TransactionStreamer) writeMessages(pos arbutil.MessageIndex, messages [
 				return err
 			}
 			if s.shouldSubmitEspressoTransaction(&indexToSubmitUint64) {
-				log.Info("Enqueuing pending transaction to Espresso", "pos", indexToSubmit)
+				log.Info("adding transaction to list of pending tx's to submit to Espresso", "pos", indexToSubmit)
 				messagesToEnqueue = append(messagesToEnqueue, indexToSubmit)
 				if err != nil {
 					log.Error("Failed to enqueue pending transaction to Espresso", "pos", pos+arbutil.MessageIndex(idx), "err", err)
 					return err
 				}
-				log.Info("Enqueued pending transaction to Espresso was successful", "pos", pos+arbutil.MessageIndex(idx))
 			}
-
 		}
+
 		err = s.enqueuePendingTransaction(messagesToEnqueue)
 		if err != nil {
 			log.Error("unable to enqueue a transaction to the pending list to be submitted to espresso.", "err", err, "messages", messagesToEnqueue)
 			return err
 		}
+		startIdx := messagesToEnqueue[0]
+		endIdx := messagesToEnqueue[len(messagesToEnqueue)-1]
+		log.Info("Successfully enqueued range of transactions from startIdx to endIdx", "startIdx", startIdx, "endIdx", endIdx)
 	}
 
 	err = batch.Write()
@@ -1757,17 +1759,20 @@ func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) er
 	s.espressoTxnsStateInsertionMutex.Lock()
 	pendingTxnsPos, err := s.getEspressoPendingTxnsPos()
 	if err != nil {
+		s.espressoTxnsStateInsertionMutex.Unlock()
 		return err
 	}
 	if len(pendingTxnsPos) > 0 {
 		fetcher := func(pos arbutil.MessageIndex) ([]byte, error) {
 			msg, err := s.GetMessage(pos)
 			if err != nil {
+				s.espressoTxnsStateInsertionMutex.Unlock()
 				return nil, err
 			}
 			if pos > 1 {
 				prevMsg, err := s.GetMessage(pos - 1)
 				if err != nil {
+					s.espressoTxnsStateInsertionMutex.Unlock()
 					return nil, err
 				}
 				if prevMsg.DelayedMessagesRead+1 == msg.DelayedMessagesRead {
@@ -1781,6 +1786,7 @@ func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) er
 			}
 			b, err := rlp.EncodeToBytes(msg)
 			if err != nil {
+				s.espressoTxnsStateInsertionMutex.Unlock()
 				return nil, err
 			}
 			return b, nil
@@ -1791,12 +1797,14 @@ func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) er
 		err = s.setEspressoPendingTxnsPos(batch, pendingTxnsPos)
 
 		if err != nil {
+			s.espressoTxnsStateInsertionMutex.Unlock()
 			return fmt.Errorf("failed to set the pending txn list in the db batch: %w", err)
 		}
 
 		err = batch.Write()
 
 		if err != nil {
+			s.espressoTxnsStateInsertionMutex.Unlock()
 			return fmt.Errorf("failed to write pending txn list batch to db: %w", err)
 		}
 

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1194,10 +1194,6 @@ func (s *TransactionStreamer) writeMessages(pos arbutil.MessageIndex, messages [
 			if s.shouldSubmitEspressoTransaction(&indexToSubmitUint64) {
 				log.Info("adding transaction to list of pending tx's to submit to Espresso", "pos", indexToSubmit)
 				messagesToEnqueue = append(messagesToEnqueue, indexToSubmit)
-				if err != nil {
-					log.Error("Failed to enqueue pending transaction to Espresso", "pos", pos+arbutil.MessageIndex(idx), "err", err)
-					return err
-				}
 			}
 		}
 
@@ -1761,22 +1757,21 @@ func (s *TransactionStreamer) ResubmitEspressoTransactions(ctx context.Context, 
 
 func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) error {
 	s.espressoPendingTxnPosMutex.Lock()
+	defer s.espressoPendingTxnPosMutex.Unlock()
+
 	pendingTxnsPos, err := s.getEspressoPendingTxnsPos()
 	if err != nil {
-		s.espressoPendingTxnPosMutex.Unlock()
 		return err
 	}
 	if len(pendingTxnsPos) > 0 {
 		fetcher := func(pos arbutil.MessageIndex) ([]byte, error) {
 			msg, err := s.GetMessage(pos)
 			if err != nil {
-				s.espressoPendingTxnPosMutex.Unlock()
 				return nil, err
 			}
 			if pos > 1 {
 				prevMsg, err := s.GetMessage(pos - 1)
 				if err != nil {
-					s.espressoPendingTxnPosMutex.Unlock()
 					return nil, err
 				}
 				if prevMsg.DelayedMessagesRead+1 == msg.DelayedMessagesRead {
@@ -1790,7 +1785,6 @@ func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) er
 			}
 			b, err := rlp.EncodeToBytes(msg)
 			if err != nil {
-				s.espressoPendingTxnPosMutex.Unlock()
 				return nil, err
 			}
 			return b, nil
@@ -1798,21 +1792,12 @@ func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) er
 		payload, msgCnt := arbutil.BuildRawHotShotPayload(pendingTxnsPos, fetcher, s.espressoMaxTransactionSize)
 		batch := s.db.NewBatch()
 		pendingTxnsPos = pendingTxnsPos[msgCnt:]
+
 		err = s.setEspressoPendingTxnsPos(batch, pendingTxnsPos)
 
 		if err != nil {
-			s.espressoPendingTxnPosMutex.Unlock()
 			return fmt.Errorf("failed to set the pending txn list in the db batch: %w", err)
 		}
-
-		err = batch.Write()
-
-		if err != nil {
-			s.espressoPendingTxnPosMutex.Unlock()
-			return fmt.Errorf("failed to write pending txn list batch to db: %w", err)
-		}
-
-		s.espressoPendingTxnPosMutex.Unlock()
 
 		if msgCnt == 0 {
 			return fmt.Errorf("failed to build the hotshot transaction: a large message has exceeded the size limit or failed to get a message from storage")
@@ -1836,12 +1821,10 @@ func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) er
 			return fmt.Errorf("failed to submit transaction to espresso: %w", err)
 		}
 
-		batch = s.db.NewBatch()
-		submittedPos := pendingTxnsPos[:msgCnt]
-
 		s.espressoSubmittedTxnsMutex.Lock()
 		defer s.espressoSubmittedTxnsMutex.Unlock()
 
+		submittedPos := pendingTxnsPos[:msgCnt]
 		submittedTxns, err := s.getEspressoSubmittedTxns()
 		if err != nil {
 			return fmt.Errorf("failed to get the submitted txns: %w", err)

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1506,6 +1506,8 @@ func (s *TransactionStreamer) checkSubmittedTransactionForFinality(ctx context.C
 	hasInterrupted := false
 	dataArray := []espressoTypes.TransactionQueryData{}
 	for _, submittedTx := range submittedTxns {
+	posArray := []int{}
+	for i, submittedTx := range submittedTxns {
 		hash := submittedTx.Hash
 		submittedTxHash, err := tagged_base64.Parse(hash)
 		if err != nil || submittedTxHash == nil {
@@ -1523,17 +1525,21 @@ func (s *TransactionStreamer) checkSubmittedTransactionForFinality(ctx context.C
 			} else {
 				newSubmittedTxns = append(newSubmittedTxns, submittedTx)
 			}
+			log.Info("encountered an error trying to check espresso for a submitted txn", "err")
 			hasInterrupted = true
 		}
 		log.Info("transaction checked", "hash", hash, "data", data)
 
 		if !hasInterrupted {
+			// This is essentially the same as checking that data is nil.
 			dataArray = append(dataArray, data)
+			posArray = append(posArray, i)
 		}
 	}
 
 	for i, data := range dataArray {
 		submittedTx := submittedTxns[i]
+		submittedTx := submittedTxns[posArray[i]]
 		height := data.BlockHeight
 
 		resp, err := s.espressoClient.FetchTransactionsInBlock(ctx, height, s.chainConfig.ChainID.Uint64())
@@ -1546,7 +1552,7 @@ func (s *TransactionStreamer) checkSubmittedTransactionForFinality(ctx context.C
 		if !validated {
 			// This may seem redundant as we have a resubmission loop, but hitting this code path means that we were able to find the submitted tx hash across a quorom of
 			// the query nodes, and got a result for what block it should be in. However, we were unable to validate that the payload was in the block.
-			log.Warn("Transaction payload not found in block, attempt to resubmit", "height", height, "tx", submittedTx.Hash)
+			log.Warn("Transaction payload not found in block,The txn should be re-submitted", "height", height, "tx", submittedTx.Hash)
 			resubmittedTxn, err := s.resubmitTransaction(ctx, submittedTx)
 			if err != nil {
 				log.Error("failed to resubmit transaction", "err", err)

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1505,7 +1505,6 @@ func (s *TransactionStreamer) checkSubmittedTransactionForFinality(ctx context.C
 	}
 	hasInterrupted := false
 	dataArray := []espressoTypes.TransactionQueryData{}
-	for _, submittedTx := range submittedTxns {
 	posArray := []int{}
 	for i, submittedTx := range submittedTxns {
 		hash := submittedTx.Hash
@@ -1538,7 +1537,6 @@ func (s *TransactionStreamer) checkSubmittedTransactionForFinality(ctx context.C
 	}
 
 	for i, data := range dataArray {
-		submittedTx := submittedTxns[i]
 		submittedTx := submittedTxns[posArray[i]]
 		height := data.BlockHeight
 

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1559,9 +1559,15 @@ func (s *TransactionStreamer) checkSubmittedTransactionForFinality(ctx context.C
 			newSubmittedTxns = append(newSubmittedTxns, *resubmittedTxn)
 			continue
 		}
+		max := submittedTx.Pos[0]
+		for _, pos := range submittedTx.Pos {
+			if pos > max {
+				max = pos
+			}
+		}
 
-		if submittedTx.Pos[len(submittedTx.Pos)-1] > lastConfirmedPos {
-			lastConfirmedPos = submittedTx.Pos[len(submittedTx.Pos)-1]
+		if max > lastConfirmedPos {
+			lastConfirmedPos = max
 		}
 
 	}

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1499,6 +1499,11 @@ func (s *TransactionStreamer) checkSubmittedTransactionForFinality(ctx context.C
 	batch := s.db.NewBatch()
 	newSubmittedTxns := []arbutil.SubmittedEspressoTx{}
 	lastConfirmedPos := arbutil.MessageIndex(0)
+	if lastConfirmedPosInDb, _ := s.getLastConfirmedPos(); lastConfirmedPosInDb != nil {
+		lastConfirmedPos = *lastConfirmedPosInDb
+	}
+	hasInterrupted := false
+	dataArray := []espressoTypes.TransactionQueryData{}
 	for _, submittedTx := range submittedTxns {
 		hash := submittedTx.Hash
 		submittedTxHash, err := tagged_base64.Parse(hash)
@@ -1511,16 +1516,23 @@ func (s *TransactionStreamer) checkSubmittedTransactionForFinality(ctx context.C
 			resubmittedTxn, err := s.resubmitTransactionIfPastDelay(ctx, submittedTx)
 			if err != nil {
 				log.Error("failed to resubmit transaction", "err", err)
-				continue
 			}
 			if resubmittedTxn != nil {
 				newSubmittedTxns = append(newSubmittedTxns, *resubmittedTxn)
 			} else {
 				newSubmittedTxns = append(newSubmittedTxns, submittedTx)
 			}
-			continue
+			hasInterrupted = true
 		}
+		log.Info("transaction checked", "hash", hash, "data", data)
 
+		if !hasInterrupted {
+			dataArray = append(dataArray, data)
+		}
+	}
+
+	for i, data := range dataArray {
+		submittedTx := submittedTxns[i]
 		height := data.BlockHeight
 
 		resp, err := s.espressoClient.FetchTransactionsInBlock(ctx, height, s.chainConfig.ChainID.Uint64())
@@ -1552,14 +1564,6 @@ func (s *TransactionStreamer) checkSubmittedTransactionForFinality(ctx context.C
 			lastConfirmedPos = submittedTx.Pos[len(submittedTx.Pos)-1]
 		}
 
-	}
-
-	if lastConfirmedPos == 0 {
-		lastConfirmedPosInDb, err := s.getLastConfirmedPos()
-		if err != nil || lastConfirmedPosInDb == nil {
-			return fmt.Errorf("failed to get last confirmed pos: %w", err)
-		}
-		lastConfirmedPos = *lastConfirmedPosInDb
 	}
 
 	log.Info("last confirmed pos", "lastConfirmedPos", lastConfirmedPos)
@@ -1791,6 +1795,7 @@ func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) er
 		}
 		payload, msgCnt := arbutil.BuildRawHotShotPayload(pendingTxnsPos, fetcher, s.espressoMaxTransactionSize)
 		batch := s.db.NewBatch()
+		submittedPos := pendingTxnsPos[:msgCnt]
 		pendingTxnsPos = pendingTxnsPos[msgCnt:]
 
 		err = s.setEspressoPendingTxnsPos(batch, pendingTxnsPos)
@@ -1824,7 +1829,6 @@ func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) er
 		s.espressoSubmittedTxnsMutex.Lock()
 		defer s.espressoSubmittedTxnsMutex.Unlock()
 
-		submittedPos := pendingTxnsPos[:msgCnt]
 		submittedTxns, err := s.getEspressoSubmittedTxns()
 		if err != nil {
 			return fmt.Errorf("failed to get the submitted txns: %w", err)

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1861,6 +1861,8 @@ func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) er
 		if err != nil {
 			return fmt.Errorf("failed to write to db: %w", err)
 		}
+	} else {
+		s.espressoPendingTxnPosMutex.Unlock()
 	}
 	return nil
 }

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1201,14 +1201,16 @@ func (s *TransactionStreamer) writeMessages(pos arbutil.MessageIndex, messages [
 			}
 		}
 
-		err = s.enqueuePendingTransaction(messagesToEnqueue)
-		if err != nil {
-			log.Error("unable to enqueue a transaction to the pending list to be submitted to espresso.", "err", err, "messages", messagesToEnqueue)
-			return err
+		if len(messagesToEnqueue) > 0 {
+			err = s.enqueuePendingTransaction(messagesToEnqueue)
+			if err != nil {
+				log.Error("unable to enqueue a transaction to the pending list to be submitted to espresso.", "err", err, "messages", messagesToEnqueue)
+				return err
+			}
+			startIdx := messagesToEnqueue[0]
+			endIdx := messagesToEnqueue[len(messagesToEnqueue)-1]
+			log.Info("Successfully enqueued range of transactions from startIdx to endIdx", "startIdx", startIdx, "endIdx", endIdx)
 		}
-		startIdx := messagesToEnqueue[0]
-		endIdx := messagesToEnqueue[len(messagesToEnqueue)-1]
-		log.Info("Successfully enqueued range of transactions from startIdx to endIdx", "startIdx", startIdx, "endIdx", endIdx)
 	}
 
 	err = batch.Write()

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -86,14 +86,15 @@ type TransactionStreamer struct {
 
 	trackBlockMetadataFrom arbutil.MessageIndex
 	// Espresso specific fields. These fields are set from batch poster
-	espressoClient               espressoClient.EspressoClient
-	lightClientReader            lightclient.LightClientReaderInterface
-	espressoTxnsPollingInterval  time.Duration
-	espressoTxnsSendingInterval  time.Duration
-	maxBlockLagBeforeEscapeHatch uint64
-	espressoMaxTransactionSize   int64
-	resubmitEspressoTxDeadline   time.Duration
-	lastSubmitFailureAt          *time.Time
+	espressoClient                   espressoClient.EspressoClient
+	lightClientReader                lightclient.LightClientReaderInterface
+	espressoTxnsPollingInterval      time.Duration
+	espressoTxnsSendingInterval      time.Duration
+	espressoTxnsResubmissionInterval time.Duration
+	maxBlockLagBeforeEscapeHatch     uint64
+	espressoMaxTransactionSize       int64
+	resubmitEspressoTxDeadline       time.Duration
+	lastSubmitFailureAt              *time.Time
 	// Public these fields for testing
 	EscapeHatchEnabled                    bool
 	UseEscapeHatch                        bool
@@ -1767,10 +1768,10 @@ func (s *TransactionStreamer) ResubmitEspressoTransactions(ctx context.Context, 
 
 func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) error {
 	s.espressoPendingTxnPosMutex.Lock()
-	defer s.espressoPendingTxnPosMutex.Unlock()
 
 	pendingTxnsPos, err := s.getEspressoPendingTxnsPos()
 	if err != nil {
+		s.espressoPendingTxnPosMutex.Unlock()
 		return err
 	}
 	if len(pendingTxnsPos) > 0 {
@@ -1807,9 +1808,10 @@ func (s *TransactionStreamer) submitEspressoTransactions(ctx context.Context) er
 		err = s.setEspressoPendingTxnsPos(batch, pendingTxnsPos)
 
 		if err != nil {
+			s.espressoPendingTxnPosMutex.Unlock()
 			return fmt.Errorf("failed to set the pending txn list in the db batch: %w", err)
 		}
-
+		s.espressoPendingTxnPosMutex.Unlock()
 		if msgCnt == 0 {
 			return fmt.Errorf("failed to build the hotshot transaction: a large message has exceeded the size limit or failed to get a message from storage")
 		}
@@ -1951,7 +1953,7 @@ func (s *TransactionStreamer) submitTransactionsToEspresso(ctx context.Context, 
 }
 
 func (s *TransactionStreamer) pollToResubmitEspressoTransactions(ctx context.Context, ignored struct{}) time.Duration {
-	retryRate := s.espressoTxnsSendingInterval * 2
+	retryRate := s.espressoTxnsResubmissionInterval * 2
 	submittedTxns, err := s.getEspressoSubmittedTxns()
 	if err != nil {
 		log.Warn("resubmitting espresso transactions failed: unable to get submitted transactions, will retry: %w", err)
@@ -1972,7 +1974,7 @@ func (s *TransactionStreamer) pollToResubmitEspressoTransactions(ctx context.Con
 		// Reset the last submit failure time because we successfully resubmitted the transactions
 		s.lastSubmitFailureAt = nil
 	}
-	return s.espressoTxnsSendingInterval
+	return s.espressoTxnsResubmissionInterval
 }
 
 func (s *TransactionStreamer) shouldSubmitEspressoTransaction(pos *uint64) bool {

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -89,6 +89,7 @@ type TransactionStreamer struct {
 	espressoClient               espressoClient.EspressoClient
 	lightClientReader            lightclient.LightClientReaderInterface
 	espressoTxnsPollingInterval  time.Duration
+	espressoTxnsSendingInterval  time.Duration
 	maxBlockLagBeforeEscapeHatch uint64
 	espressoMaxTransactionSize   int64
 	resubmitEspressoTxDeadline   time.Duration
@@ -1940,7 +1941,7 @@ func (s *TransactionStreamer) pollSubmittedTransactionForFinality(ctx context.Co
  */
 func (s *TransactionStreamer) submitTransactionsToEspresso(ctx context.Context, ignored struct{}) time.Duration {
 	// When encountering an error during the initial attempt at submitting a transaction, double the amount of our polling interval and try again.
-	retryRate := s.espressoTxnsPollingInterval * 2
+	retryRate := s.espressoTxnsSendingInterval * 2
 	shouldSubmit := s.shouldSubmitEspressoTransaction(nil)
 	// Only submit the transaction if escape hatch is not enabled
 	if shouldSubmit {
@@ -1951,13 +1952,13 @@ func (s *TransactionStreamer) submitTransactionsToEspresso(ctx context.Context, 
 			return retryRate
 		}
 	}
-	return s.espressoTxnsPollingInterval
+	return s.espressoTxnsSendingInterval
 }
 
 func (s *TransactionStreamer) pollToResubmitEspressoTransactions(ctx context.Context, ignored struct{}) time.Duration {
 	s.espressoSubmittedTxnsMutex.Lock()
 	defer s.espressoSubmittedTxnsMutex.Unlock()
-	retryRate := s.espressoTxnsPollingInterval * 2
+	retryRate := s.espressoTxnsSendingInterval * 2
 	submittedTxns, err := s.getEspressoSubmittedTxns()
 	if err != nil {
 		log.Warn("resubmitting espresso transactions failed: unable to get submitted transactions, will retry: %w", err)
@@ -1978,7 +1979,7 @@ func (s *TransactionStreamer) pollToResubmitEspressoTransactions(ctx context.Con
 		// Reset the last submit failure time because we successfully resubmitted the transactions
 		s.lastSubmitFailureAt = nil
 	}
-	return s.espressoTxnsPollingInterval
+	return s.espressoTxnsSendingInterval
 }
 
 func (s *TransactionStreamer) shouldSubmitEspressoTransaction(pos *uint64) bool {

--- a/espressostreamer/espresso_streamer_test.go
+++ b/espressostreamer/espresso_streamer_test.go
@@ -302,6 +302,10 @@ func (m *mockEspressoClient) FetchTransactionByHash(ctx context.Context, hash *t
 	panic("not implemented")
 }
 
+func (m *mockEspressoClient) FetchExplorerTransactionByHash(ctx context.Context, hash *types.TaggedBase64) (types.ExplorerTransactionQueryData, error) {
+	panic("not implemented")
+}
+
 func (m *mockEspressoClient) FetchVidCommonByHeight(ctx context.Context, blockHeight uint64) (types.VidCommon, error) {
 	panic("not implemented")
 }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ replace github.com/offchainlabs/bold => ./bold
 require (
 	cloud.google.com/go/storage v1.43.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
-	github.com/EspressoSystems/espresso-network/sdks/go v0.2.2
+	github.com/EspressoSystems/espresso-network/sdks/go v0.2.4
 	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible
 	github.com/Shopify/toxiproxy v2.1.4+incompatible
 	github.com/alicebob/miniredis/v2 v2.32.1

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
-github.com/EspressoSystems/espresso-network/sdks/go v0.2.2 h1:a8QtZ9C0CgYfk+FEOQf4aSBNfP2keLLOcE9c7mSz1fY=
-github.com/EspressoSystems/espresso-network/sdks/go v0.2.2/go.mod h1:aJX3rhV7d3QQ3dvmEFIKDfQvSFP9aUnFNENGpXPwELM=
+github.com/EspressoSystems/espresso-network/sdks/go v0.2.4 h1:+67eNAczRWXUoq+GNuHuIyQC9Uy6wuIe7mcUvMZOa6U=
+github.com/EspressoSystems/espresso-network/sdks/go v0.2.4/go.mod h1:nX/JxG1/Kog2T0B0Gq/KhL0xZJi2GFuanGO8bxka0vM=
 github.com/GaijinEntertainment/go-exhaustruct/v2 v2.2.0/go.mod h1:n/vLeA7V+QY84iYAGwMkkUUp9ooeuftMEvaDrSVch+Q=
 github.com/HdrHistogram/hdrhistogram-go v1.1.0/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=

--- a/system_tests/espresso-e2e/docker-compose.yaml
+++ b/system_tests/espresso-e2e/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   espresso-dev-node:
-    image: ghcr.io/espressosystems/espresso-sequencer/espresso-dev-node:jh-dev-node
+    image: ghcr.io/espressosystems/espresso-sequencer/espresso-dev-node:20250710
     ports:
       - "$ESPRESSO_SEQUENCER_API_PORT:$ESPRESSO_SEQUENCER_API_PORT"
       - "$ESPRESSO_BUILDER_PORT:$ESPRESSO_BUILDER_PORT"

--- a/system_tests/espresso-e2e/docker-compose.yaml
+++ b/system_tests/espresso-e2e/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   espresso-dev-node:
-    image: ghcr.io/espressosystems/espresso-sequencer/espresso-dev-node:20250428-dev-node-decaf-pos
+    image: ghcr.io/espressosystems/espresso-sequencer/espresso-dev-node:jh-dev-node
     ports:
       - "$ESPRESSO_SEQUENCER_API_PORT:$ESPRESSO_SEQUENCER_API_PORT"
       - "$ESPRESSO_BUILDER_PORT:$ESPRESSO_BUILDER_PORT"


### PR DESCRIPTION
Closes # Molten mainnet incident
### This PR:
Does some refactoring of the mutex lock behavior in the transaction streamer to some tasks hold the lock for less time.
### This PR does not:
Add new tests or attempt to modify existing critical logic.

### Key places to review:
transaction_streamer.go

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210789165199213