### PR TITLE
Update instructions for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ make build-replay-env
 gotestsum --format standard-verbose --packages="$packages" -- -v -timeout 15m -p 1 ./system_tests/... -run 'TestEspressoE2E'
 ```
 
+Alternatively to steps 3 and 4 you can run:
+```bash
+just espresso-tests
+```
+
 Note: The E2E tests typically take around 10-15 minutes to complete.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Arbitrum One successfully migrated from the Classic Arbitrum stack onto Nitro on
 - Docker daemon running
 
 ### Build Steps
+
+0. Clone repository
+```bash
+git clone --recurse-submodules git@github.com:EspressoSystems/nitro-espresso-integration.git 
+```
+
 1. For MacOS Users Only:
 ```bash
 bash ./scripts/build-wasm-on-macos-with-nix

--- a/flake.nix
+++ b/flake.nix
@@ -176,6 +176,10 @@
                 # Needed to avoid some error on Linux related to glibc
                 git
 
+
+                # just
+                just
+
                 pre-commit
               ] ++ lib.optionals stdenv.isDarwin [
                 apple-sdk_11

--- a/flake.nix
+++ b/flake.nix
@@ -176,7 +176,6 @@
                 # Needed to avoid some error on Linux related to glibc
                 git
 
-
                 # just
                 just
 

--- a/flake.nix
+++ b/flake.nix
@@ -173,6 +173,9 @@
                 # provides abigen
                 go-ethereum
 
+                # Needed to avoid some error on Linux related to glibc
+                git
+
                 pre-commit
               ] ++ lib.optionals stdenv.isDarwin [
                 apple-sdk_11

--- a/justfile
+++ b/justfile
@@ -1,0 +1,6 @@
+build:
+    make build
+    make build-replay-env
+
+espresso-tests: build
+    gotestsum --format standard-verbose --packages="\$packages" -- -v -timeout 15m -p 1 ./system_tests/... -run 'TestEspressoE2E'


### PR DESCRIPTION
No ticket is associated to this PR.

### This PR:
Updates the `README.md` section about running the Espresso integration tests. It also make some minor updates to flake.nix that I needed in order to run the tests. Finally it adds a justfile to run the tests in a more convenient way.

### This PR does not:
Change any code.


### Key places to review:
All changes.


### How to test this PR:  

```
just espresso-tests
```
