### PR TITLE
Fix db batch double commit

### DIFF
--- a/arbnode/espresso_delayed_message_fetcher.go
+++ b/arbnode/espresso_delayed_message_fetcher.go
@@ -84,6 +84,11 @@ func (d *DelayedMessageFetcher) backfill(ctx context.Context) error {
 		fromBlock = toBlock
 	}
 
+	err = batch.Write()
+	if err != nil {
+		return err
+	}
+
 	log.Info("Backfilled delayed messages")
 	return nil
 }
@@ -148,6 +153,11 @@ func (d *DelayedMessageFetcher) processNewHeader(ctx context.Context, header *ty
 	err = d.getDelayedMessagesInRange(ctx, batch, fromBlock, endBlock)
 	if err != nil {
 		log.Error("failed to get delayed messages in range", "err", err, "fromBlock", fromBlock, "endBlock", endBlock)
+		return err
+	}
+
+	err = batch.Write()
+	if err != nil {
 		return err
 	}
 
@@ -334,10 +344,6 @@ func (d *DelayedMessageFetcher) getDelayedMessagesInRange(ctx context.Context, b
 		return err
 	}
 
-	err = batch.Write()
-	if err != nil {
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
- Fix a bug that in the `backfill` session, a db batch is committed twice and it panics the node

I moved the `batch.Write` out of `getDelayedMessagesInRange` and user should write the batch after calling this function.

This makes processes more intuitive. The batch creation and batch writing stay in the same function, which reduces some mental burden of memorizing an inner function will write a batch.

### This PR does not:
add a test for this bugfix. We should do it. However it requires some effort.