### PR TITLE
Caff node fixes

### DIFF
--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -386,7 +386,7 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 	delayedMessagesRead := n.executionEngine.Bc().CurrentBlock().Nonce.Uint64()
 	// we store delayedmessagecount-1 because that is the index of the delayed message
 	// that needs to be read
-	err = n.delayedMessageFetcher.storeDelayedMessageCount(n.db, delayedMessagesRead-1)
+	err = n.delayedMessageFetcher.storeDelayedMessageLatestIndex(n.db, delayedMessagesRead-1)
 	if err != nil {
 		log.Error("failed to store delayed message count", "err", err)
 		return err

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -243,7 +243,11 @@ func (n *EspressoCaffNode) peekMessage(ctx context.Context) (*espressostreamer.M
 	}
 
 	// Check if its a delayed message, if so fetch from the database
-	delayedMessageToProcessIndex := n.executionEngine.Bc().CurrentBlock().Nonce.Uint64()
+	delayedMessageToProcessIndex, err := n.executionEngine.NextDelayedMessageNumber()
+	if err != nil {
+		log.Error("failed to get next delayed message number", "err", err)
+		return nil, err
+	}
 	if delayedMessageToProcessIndex == messageWithMetadataAndPos.MessageWithMeta.DelayedMessagesRead-1 {
 		messageWithMetadataAndPosDelayed, err := n.delayedMessageFetcher.processDelayedMessage(messageWithMetadataAndPos)
 		if err != nil {
@@ -340,6 +344,14 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to start batcher address monitor: %w", err)
 	}
+	err = n.forceInclusionChecker.Start(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to start force inclusion checker: %w", err)
+	}
+	err = n.stateChecker.Start(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to start state checker: %w", err)
+	}
 
 	// This is +1 because the current block is the block after the last processed block
 	currentBlockNum := n.executionEngine.Bc().CurrentBlock().Number.Uint64() + 1
@@ -379,6 +391,7 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 		log.Error("failed to store delayed message count", "err", err)
 		return err
 	}
+	log.Debug("stored delayed message count", "delayedMessagesRead", delayedMessagesRead-1)
 
 	// Start the delayed message fetcher
 	started := n.delayedMessageFetcher.Start(ctx)

--- a/arbnode/espresso_caff_node_test.go
+++ b/arbnode/espresso_caff_node_test.go
@@ -91,7 +91,7 @@ func (m *MockEspressoStreamer) ReadNextHotshotBlockFromDb(db ethdb.Database) (ui
 type MockDelayedMessageFetcher struct{}
 
 // This function isn't a proper implementation for the tests, but this gets the test to compile.
-func (m *MockDelayedMessageFetcher) getDelayedMessageCountAtBlock(blockNumber uint64) (uint64, error) {
+func (m *MockDelayedMessageFetcher) getDelayedMessageLatestIndexAtBlock(blockNumber uint64) (uint64, error) {
 	return 1, nil
 }
 
@@ -113,7 +113,7 @@ func (m *MockDelayedMessageFetcher) Start(ctx context.Context) bool {
 	return true
 }
 
-func (m *MockDelayedMessageFetcher) storeDelayedMessageCount(db ethdb.Database, count uint64) error {
+func (m *MockDelayedMessageFetcher) storeDelayedMessageLatestIndex(db ethdb.Database, count uint64) error {
 	return nil
 }
 

--- a/arbnode/espresso_delayed_message_fetcher.go
+++ b/arbnode/espresso_delayed_message_fetcher.go
@@ -81,7 +81,7 @@ func (d *DelayedMessageFetcher) backfill(ctx context.Context) error {
 			log.Error("failed to get delayed messages in range", "err", err, "fromBlock", fromBlock, "endBlock", toBlock)
 			return err
 		}
-		fromBlock = toBlock
+		fromBlock = toBlock + 1
 	}
 
 	err = batch.Write()
@@ -322,9 +322,10 @@ func (d *DelayedMessageFetcher) getDelayedMessagesInRange(ctx context.Context, b
 		if err != nil {
 			return err
 		}
-		if seqNum > delayedCount+1 {
-			// We need to panic the node here because something has gone seriously wrong
-			log.Crit("Caff node is skipping delayed messages", "seqNum", seqNum, "delayedCount", delayedCount)
+		if seqNum == 0 {
+			// init message
+			log.Debug("caff node: skip storing init message")
+			continue
 		}
 		delayedCount++
 		err = d.storeDelayedMessage(batch, delayedCount, *msg)
@@ -333,12 +334,8 @@ func (d *DelayedMessageFetcher) getDelayedMessagesInRange(ctx context.Context, b
 		}
 	}
 
-	// If they are the same, in next increment we would like to have the next block
-	if startBlock == toBlock {
-		toBlock++
-	}
 	// Store the from block in the database
-	err = storeCurrentFromBlock(batch, toBlock)
+	err = storeCurrentFromBlock(batch, toBlock+1)
 	if err != nil {
 		log.Error("failed to store current from block", "err", err, "fromBlock", toBlock)
 		return err
@@ -431,6 +428,7 @@ func (f *DelayedMessageFetcher) storeDelayedMessage(batch ethdb.Batch, seqNum ui
 	if err != nil {
 		return err
 	}
+	log.Debug("stored delayed message", "seqNum", seqNum)
 
 	return batch.Put(key, encodedMsg)
 }

--- a/arbnode/espresso_delayed_message_fetcher.go
+++ b/arbnode/espresso_delayed_message_fetcher.go
@@ -2,7 +2,6 @@ package arbnode
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/big"
 
@@ -40,9 +39,9 @@ type DelayedMessageFetcher struct {
 
 type DelayedMessageFetcherInterface interface {
 	Start(ctx context.Context) bool
-	storeDelayedMessageCount(db ethdb.Database, count uint64) error
+	storeDelayedMessageLatestIndex(db ethdb.Database, count uint64) error
 	processDelayedMessage(messageWithMetadataAndPos *espressostreamer.MessageWithMetadataAndPos) (*espressostreamer.MessageWithMetadataAndPos, error)
-	getDelayedMessageCountAtBlock(blockNumber uint64) (uint64, error)
+	getDelayedMessageLatestIndexAtBlock(blockNumber uint64) (uint64, error)
 }
 
 var _ DelayedMessageFetcherInterface = new(DelayedMessageFetcher)
@@ -138,8 +137,10 @@ func (d *DelayedMessageFetcher) processNewHeader(ctx context.Context, header *ty
 	var endBlock uint64
 	var err error
 	if endBlock, err = d.getL1BlockWithinSafetyTolerance(ctx, header); err != nil {
-		log.Warn("delayed message fetcher backfill failed", "err", err)
 		return err
+	}
+	if endBlock == 0 {
+		return nil
 	}
 	batch := d.db.NewBatch()
 
@@ -168,7 +169,7 @@ func (f *DelayedMessageFetcher) processDelayedMessage(messageWithMetadataAndPos 
 	delayedMessagesRead := messageWithMetadataAndPos.MessageWithMeta.DelayedMessagesRead
 
 	// Get the delayed message count store in the database
-	delayedCount, err := getDelayedMessageCount(f.db)
+	delayedCount, err := getDelayedMessageLatestIndex(f.db)
 	if err != nil {
 		log.Error("Failed to get delayed message count from db", "err", err)
 		return nil, err
@@ -264,9 +265,9 @@ func (d *DelayedMessageFetcher) getL1BlockNumber(ctx context.Context) (uint64, e
 	return d.l1Reader.Client().BlockNumber(ctx)
 }
 
-// getDelayedMessageCountAtBlock is a wrapper function for the delayedBridge.GetMessageCount function. This allows users of the DelayedMessageFetcher
+// getDelayedMessageLatestIndexAtBlock is a wrapper function for the delayedBridge.GetMessageCount function. This allows users of the DelayedMessageFetcher
 // to query for the message count at a block.
-func (f *DelayedMessageFetcher) getDelayedMessageCountAtBlock(blockNumber uint64) (uint64, error) {
+func (f *DelayedMessageFetcher) getDelayedMessageLatestIndexAtBlock(blockNumber uint64) (uint64, error) {
 	count, err := f.delayedBridge.GetMessageCount(context.Background(), new(big.Int).SetUint64(blockNumber))
 	if err != nil {
 		return 0, err
@@ -310,10 +311,10 @@ func (d *DelayedMessageFetcher) getDelayedMessagesInRange(ctx context.Context, b
 
 	log.Debug("sequencer delayed messages found", "delayedMessages", msgs)
 
-	// Get the delayed message count store in the database
-	delayedCount, err := getDelayedMessageCount(d.db)
+	// Get the delayed message index stored in the database
+	lastDelayedMessageIndex, err := getDelayedMessageLatestIndex(d.db)
 	if err != nil {
-		log.Error("Failed to get delayed message count from db", "err", err)
+		log.Error("Failed to get delayed message index from db", "err", err)
 		return err
 	}
 
@@ -327,8 +328,15 @@ func (d *DelayedMessageFetcher) getDelayedMessagesInRange(ctx context.Context, b
 			log.Debug("caff node: skip storing init message")
 			continue
 		}
-		delayedCount++
-		err = d.storeDelayedMessage(batch, delayedCount, *msg)
+		// the next seqNum is the index of the delayed message which needs to be processed next
+		// so it always needs to be equal to the delayed message indext + 1
+		if seqNum != lastDelayedMessageIndex+1 {
+			// We need to panic the node here because something has gone seriously wrong
+			log.Crit("Caff node is skipping delayed messages", "seqNum", seqNum, "lastDelayedMessageIndex", lastDelayedMessageIndex)
+		}
+
+		lastDelayedMessageIndex++
+		err = d.storeDelayedMessage(batch, lastDelayedMessageIndex, *msg)
 		if err != nil {
 			return err
 		}
@@ -344,8 +352,8 @@ func (d *DelayedMessageFetcher) getDelayedMessagesInRange(ctx context.Context, b
 	return nil
 }
 
-// getDelayedMessageCount returns the delayed message count from the database
-func getDelayedMessageCount(db ethdb.Database) (uint64, error) {
+// getDelayedMessageLatestIndex returns the delayed message index from the database
+func getDelayedMessageLatestIndex(db ethdb.Database) (uint64, error) {
 	var delayedCount uint64
 	delayedCountBytes, err := db.Get([]byte(DelayedMessageCountKey))
 	if err != nil {
@@ -372,7 +380,7 @@ func (d *DelayedMessageFetcher) getL1BlockWithinSafetyTolerance(ctx context.Cont
 	// If we have already processed this header, we can skip it
 	if header.Number.Uint64() < fromBlock {
 		log.Warn("L1 block number is less than from block", "l1Block", header.Number.Uint64(), "fromBlock", fromBlock)
-		return 0, errors.New("l1 block number is less than from block")
+		return 0, nil
 	}
 	if d.waitForFinalization {
 		// if we have configured to wait for finalizations, fetch the latest finalized block number.
@@ -382,7 +390,8 @@ func (d *DelayedMessageFetcher) getL1BlockWithinSafetyTolerance(ctx context.Cont
 		}
 
 		if blockNumber < fromBlock {
-			return 0, fmt.Errorf("finalized block has already been processed current finalized block number: %v, fromBlock: %v", blockNumber, fromBlock)
+			log.Warn("finalized block has already been processed", "current finalized block number", blockNumber, "fromBlock", fromBlock)
+			return 0, nil
 		}
 		return blockNumber, nil
 	} else if d.waitForConfirmations {
@@ -424,7 +433,7 @@ func (f *DelayedMessageFetcher) storeDelayedMessage(batch ethdb.Batch, seqNum ui
 		return fmt.Errorf("failed to encode delayed message: %w", err)
 	}
 	// Also update the delayed message count in the database
-	err = f.storeDelayedMessageCount(f.db, seqNum)
+	err = f.storeDelayedMessageLatestIndex(f.db, seqNum)
 	if err != nil {
 		return err
 	}
@@ -433,8 +442,8 @@ func (f *DelayedMessageFetcher) storeDelayedMessage(batch ethdb.Batch, seqNum ui
 	return batch.Put(key, encodedMsg)
 }
 
-// storeDelayedMessageCount stores the delayed message count in the database
-func (f *DelayedMessageFetcher) storeDelayedMessageCount(db ethdb.Database, count uint64) error {
+// storeDelayedMessageLatestIndex stores the delayed message index in the database
+func (f *DelayedMessageFetcher) storeDelayedMessageLatestIndex(db ethdb.Database, count uint64) error {
 	countBytes, err := rlp.EncodeToBytes(count)
 	if err != nil {
 		return fmt.Errorf("failed to encode delayed message count: %w", err)

--- a/arbnode/espresso_force_inclusion_checker.go
+++ b/arbnode/espresso_force_inclusion_checker.go
@@ -110,7 +110,7 @@ func (f *ForceInclusionChecker) checkIfMessageCanBeForceIncluded(ctx context.Con
 	}
 	log.Debug("Force inclusion tolerance bad block number", "blockNumber", badBlockNumber)
 	// Check the delayed message count at this block number
-	count, err := f.delayedMessageFetcher.getDelayedMessageCountAtBlock(badBlockNumber)
+	count, err := f.delayedMessageFetcher.getDelayedMessageLatestIndexAtBlock(badBlockNumber)
 	if err != nil {
 		return fmt.Errorf("error getting delayed message count at block %d: %w", badBlockNumber, err)
 	}

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -58,9 +58,9 @@ func createCaffNode(
 	nodeConfig.EspressoCaffNode.FromBlock = 1
 
 	nodeConfig.EspressoCaffNode.StateChecker = arbnode.StateCheckerConfig{
-		PollingInterval:        time.Second * 1,
+		PollingInterval:        time.Second * 100,
 		ErrorToleranceDuration: time.Hour * 1, // Set it to a larger value. That makes the state checker not shut down
-		TrustedNodeUrl:         fmt.Sprintf("http://localhost:%d", 8945),
+		TrustedNodeUrl:         fmt.Sprintf("http://bad-url:%d", 8945),
 	}
 
 	nodeConfig.EspressoCaffNode.ForceInclusionChecker = arbnode.ForceInclusionCheckerConfig{


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
- Starts state checker and force inclusion checker
- Fixes a bug that the init message will be stored as index 1 delayed message
- Fixes a rare case where fetcher fetches fromBlock/toBlock for twice and it gets increased `delayedCount` using same messages

### This PR does not:
- add any test for these fixes. Not sure how much effort will be involved.

### How I tested this PR:
With the image built from this branch, [this test script](https://github.com/EspressoSystems/nitro-testnode/blob/jh/testing-caff-node/regression-tests/caff-node-e2e-test.bash) is happy. This test[ enables state checker
](https://github.com/EspressoSystems/nitro-testnode/blob/cc65a8830bdf60890d3b5434a8d517bcad6352a9/scripts/config.ts#L483-L486) and sets the [blocksToRead](https://github.com/EspressoSystems/nitro-testnode/blob/cc65a8830bdf60890d3b5434a8d517bcad6352a9/scripts/config.ts#L464) to `1`. So it does test above fixes.
```
➜  nitro-testnode git:(jh/testing-caff-node) ✗ echo $?
0
➜  nitro-testnode git:(jh/testing-caff-node) ✗ history | grep regression | tail -1
10795  ./regression-tests/caff-node-e2e-test.bash
```

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->
<!-- [ ] For integration projects, make sure it won't break backward compatibility. -->

<!-- Details on maintaining backward compatibility for integration projects: -->
<!-- * Try to keep changes additive: add new, optional methods, flags, or parameters instead of modifying or removing existing functionality. -->
<!-- * If modification is necessary, it should be either a clear bug fix or guarded by a config/feature flag.  -->
<!-- * Follow Open Closed Principle and Interface Segregation Principle, clients should not be forced to depend on interfaces they do not use. -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210910200240412