### PR TITLE
Celestia: Fix error cases where submitted transaction tracking is lost

### DIFF
--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1684,6 +1684,8 @@ func (s *TransactionStreamer) checkSubmittedTransactionForFinality(ctx context.C
 		resp, err := s.espressoClient.FetchTransactionsInBlock(ctx, height, s.chainConfig.ChainID.Uint64())
 		if err != nil {
 			log.Warn("Failed to fetch transactions in block referenced in fetch transaction by hash", "height", height, "error", err)
+			// Keep our submitted transaction in the list so we keep checking it
+			newSubmittedTxns = append(newSubmittedTxns, submittedTx)
 			continue
 		}
 
@@ -1693,13 +1695,11 @@ func (s *TransactionStreamer) checkSubmittedTransactionForFinality(ctx context.C
 			// the query nodes, and got a result for what block it should be in. However, we were unable to validate that the payload was in the block.
 			log.Warn("Transaction payload not found in block,The txn should be re-submitted", "height", height, "tx", submittedTx.Hash)
 			resubmittedTxn, err := s.resubmitTransaction(ctx, submittedTx)
-			if err != nil {
+			if err != nil || resubmittedTxn == nil {
+				// resubmittedTxn should never be nil, but we check it just in case
 				log.Error("failed to resubmit transaction", "err", err)
-				continue
-			}
-			if resubmittedTxn == nil {
-				// This should never happen
-				log.Error("failed to resubmit transaction", "err", err)
+				// Let's not lose track of our submitted transaction
+				newSubmittedTxns = append(newSubmittedTxns, submittedTx)
 				continue
 			}
 			newSubmittedTxns = append(newSubmittedTxns, *resubmittedTxn)


### PR DESCRIPTION
<!-- Closes #<ISSUE_NUMBER> -->
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->
Fixes a few edge cases that have been identified that would result in the submission process losing track of submitted transactions.

- [transaction was mapped to a block, but block data could not be retrieved](https://github.com/EspressoSystems/nitro-espresso-integration/blob/e4faeab313a04800c050c0dd9992a4c93097c8f7/arbnode/transaction_streamer.go#L1687)
- [Resubmission Attempt Fails](https://github.com/EspressoSystems/nitro-espresso-integration/blob/e4faeab313a04800c050c0dd9992a4c93097c8f7/arbnode/transaction_streamer.go#L1698)
- [Somehow the returned transaction detail is nil](https://github.com/EspressoSystems/nitro-espresso-integration/blob/e4faeab313a04800c050c0dd9992a4c93097c8f7/arbnode/transaction_streamer.go#L1703)

<!-- ### This PR does not: -->
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->

<!-- ### Key places to review: -->
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->
<!-- [ ] For integration projects, make sure it won't break backward compatibility. -->

<!-- Details on maintaining backward compatibility for integration projects: -->
<!-- * Try to keep changes additive: add new, optional methods, flags, or parameters instead of modifying or removing existing functionality. -->
<!-- * If modification is necessary, it should be either a clear bug fix or guarded by a config/feature flag.  -->
<!-- * Follow Open Closed Principle and Interface Segregation Principle, clients should not be forced to depend on interfaces they do not use. -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
