### PR TITLE
Remove panics from state checker

### DIFF
--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -348,9 +348,12 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to start force inclusion checker: %w", err)
 	}
-	err = n.stateChecker.Start(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to start state checker: %w", err)
+
+	if n.stateChecker != nil {
+		err = n.stateChecker.Start(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to start state checker: %w", err)
+		}
 	}
 
 	// This is +1 because the current block is the block after the last processed block

--- a/arbnode/espresso_state_checker.go
+++ b/arbnode/espresso_state_checker.go
@@ -54,7 +54,8 @@ func NewStateChecker(
 	fatalErrChan chan error,
 ) *StateChecker {
 	if config.TrustedNodeUrl == "" {
-		log.Crit("trusted node url is empty, please configure the state checker")
+		log.Warn("trusted node url is empty, state checker will not start")
+
 	}
 
 	client, err := ethclient.DialContext(context.Background(), config.TrustedNodeUrl)
@@ -64,7 +65,8 @@ func NewStateChecker(
 	myUrl := fmt.Sprintf("http://localhost:%d", httpPort)
 	myClient, err := ethclient.DialContext(context.Background(), myUrl)
 	if err != nil {
-		panic(err)
+		log.Warn("failed to dial my node for state checker, state checker will not start", "err", err)
+		return nil
 	}
 
 	return &StateChecker{

--- a/arbnode/espresso_state_checker.go
+++ b/arbnode/espresso_state_checker.go
@@ -55,7 +55,7 @@ func NewStateChecker(
 ) *StateChecker {
 	if config.TrustedNodeUrl == "" {
 		log.Warn("trusted node url is empty, state checker will not start")
-
+		return nil
 	}
 
 	client, err := ethclient.DialContext(context.Background(), config.TrustedNodeUrl)


### PR DESCRIPTION
Removing panics because they mess up the database which we saw during testing yesterday, now it prints out a warning saying the state checker is not configured