### PR TITLE
Fix the check for old seqNum

### DIFF
--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -66,12 +66,14 @@ var DefaultEspressoCaffNodeConfig = EspressoCaffNodeConfig{
 	EspressoSGXVerifierAddr: "",
 	BatchPosterAddr:         "",
 	RecordPerformance:       false,
-	WaitForFinalization:     true,
-	WaitForConfirmations:    false,
-	RequiredBlockDepth:      6,
-	BlocksToRead:            10000,
-	Dangerous:               DefaultDangerousCaffNodeConfig,
-	FromBlock:               1,
+	// Setting these values to the default
+	// values set by Arbitrum
+	WaitForFinalization:  false,
+	WaitForConfirmations: true,
+	RequiredBlockDepth:   20,
+	BlocksToRead:         10000,
+	Dangerous:            DefaultDangerousCaffNodeConfig,
+	FromBlock:            1,
 }
 
 func EspressoCaffNodeConfigAddOptions(prefix string, f *flag.FlagSet) {

--- a/arbnode/espresso_delayed_message_fetcher.go
+++ b/arbnode/espresso_delayed_message_fetcher.go
@@ -328,11 +328,9 @@ func (d *DelayedMessageFetcher) getDelayedMessagesInRange(ctx context.Context, b
 			log.Debug("caff node: skip storing init message")
 			continue
 		}
-		// the next seqNum is the index of the delayed message which needs to be processed next
-		// so it always needs to be equal to the delayed message indext + 1
-		if seqNum != lastDelayedMessageIndex+1 {
-			// We need to panic the node here because something has gone seriously wrong
-			log.Crit("Caff node is skipping delayed messages", "seqNum", seqNum, "lastDelayedMessageIndex", lastDelayedMessageIndex)
+
+		if seqNum <= lastDelayedMessageIndex {
+			log.Warn("Caff node already has processed delayed message", "seqNum", seqNum, "lastDelayedMessageIndex", lastDelayedMessageIndex)
 		}
 
 		lastDelayedMessageIndex++

--- a/arbnode/espresso_delayed_message_fetcher.go
+++ b/arbnode/espresso_delayed_message_fetcher.go
@@ -331,6 +331,7 @@ func (d *DelayedMessageFetcher) getDelayedMessagesInRange(ctx context.Context, b
 
 		if seqNum <= lastDelayedMessageIndex {
 			log.Warn("Caff node already has processed delayed message", "seqNum", seqNum, "lastDelayedMessageIndex", lastDelayedMessageIndex)
+			continue
 		}
 
 		lastDelayedMessageIndex++

--- a/arbnode/espresso_force_inclusion_checker.go
+++ b/arbnode/espresso_force_inclusion_checker.go
@@ -34,18 +34,20 @@ type ForceInclusionCheckerConfig struct {
 }
 
 var DefaultEspressoForceInclusionCheckerConfig = ForceInclusionCheckerConfig{
-	RetryTime:                time.Second * 2,
-	PollingInterval:          time.Minute * 8,
-	BlockThresholdTolerance:  20,
-	SecondThresholdTolerance: 200,
+	RetryTime:       time.Second * 2,
+	PollingInterval: time.Minute * 8,
+	// We are setting the default value to 20 hours for ETH l1
+	BlockThresholdTolerance: 72000,
+	//  We are setting the default value to 20 hours for ETH l1 which is 72000/(12 second blocks)=6000
+	SecondThresholdTolerance: 6000,
 	ErrorToleranceDuration:   time.Minute * 8,
 }
 
 func EspressoForceInclusionConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Duration(prefix+".retry-time", DefaultEspressoForceInclusionCheckerConfig.RetryTime, "retry time after a failure")
 	f.Duration(prefix+".polling-interval", DefaultEspressoForceInclusionCheckerConfig.PollingInterval, "time after a success")
-	f.Uint64(prefix+".block-threshold-tolerance", DefaultEspressoForceInclusionCheckerConfig.BlockThresholdTolerance, "block threshold tolerance")
-	f.Uint64(prefix+".second-threshold-tolerance", DefaultEspressoForceInclusionCheckerConfig.SecondThresholdTolerance, "second threshold tolerance")
+	f.Uint64(prefix+".block-threshold-tolerance", DefaultEspressoForceInclusionCheckerConfig.BlockThresholdTolerance, "block threshold tolerance for ETH L1")
+	f.Uint64(prefix+".second-threshold-tolerance", DefaultEspressoForceInclusionCheckerConfig.SecondThresholdTolerance, "second threshold tolerance for ETH L1")
 	f.Duration(prefix+".error-tolerance-duration", DefaultEspressoForceInclusionCheckerConfig.ErrorToleranceDuration, "error tolerance duration")
 }
 


### PR DESCRIPTION
The old check was causing a panic when the caff node was trying to process old messages which can happen when we want caff node to start from an older from block, now instead of panicking we continue