### PR TITLE
Remove break loop condition in batcher

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -2081,7 +2081,6 @@ func (b *BatchPoster) MaybePostSequencerBatch(ctx context.Context) (bool, error)
 	}
 
 	var getNextMessage func() (*arbostypes.MessageWithMetadata, error)
-	var breakLoopWhenErrorOccurs bool
 
 	if b.espressoStreamer == nil {
 		getNextMessage = func() (*arbostypes.MessageWithMetadata, error) {
@@ -2091,7 +2090,6 @@ func (b *BatchPoster) MaybePostSequencerBatch(ctx context.Context) (bool, error)
 			}
 			return msg, nil
 		}
-		breakLoopWhenErrorOccurs = false
 	} else {
 		getNextMessage = func() (*arbostypes.MessageWithMetadata, error) {
 			espressoMsg := b.espressoStreamer.Next(ctx)
@@ -2100,7 +2098,6 @@ func (b *BatchPoster) MaybePostSequencerBatch(ctx context.Context) (bool, error)
 			}
 			return &espressoMsg.MessageWithMeta, nil
 		}
-		breakLoopWhenErrorOccurs = true
 	}
 
 	if b.building.firstDelayedMsg != nil {
@@ -2114,11 +2111,8 @@ func (b *BatchPoster) MaybePostSequencerBatch(ctx context.Context) (bool, error)
 	for b.building.msgCount < msgCount {
 		msg, err := getNextMessage()
 		if err != nil {
-			if breakLoopWhenErrorOccurs {
-				log.Error("error getting next message", "err", err, "pos", b.building.msgCount)
-				break
-			}
-			return false, err
+			log.Error("error getting next message", "err", err, "pos", b.building.msgCount)
+			break
 		}
 
 		if msg.Message.Header.BlockNumber < l1BoundMinBlockNumberWithBypass || msg.Message.Header.Timestamp < l1BoundMinTimestampWithBypass {


### PR DESCRIPTION
I believe we had a wrong impression that when getting error advancing message in transaction streamer, it should return error. But upstream doesn't do so: https://github.com/OffchainLabs/nitro/blob/a7c9f1e72c00d9f783808d330e916520b3d0d92f/arbnode/batch_poster.go#L1523

Though our code won't hit that but this PR removes some unnecessary diffs, which should be good to reviewing, auditing and syncing with upstream.