### PR TITLE
Fix espresso streamer resetting

### DIFF
--- a/espressostreamer/espresso_streamer.go
+++ b/espressostreamer/espresso_streamer.go
@@ -121,6 +121,9 @@ func (s *EspressoStreamer) GetMessageCount() uint64 {
 }
 
 func (s *EspressoStreamer) Reset(currentMessagePos uint64, currentHostshotBlock uint64) {
+	s.messageLock.Lock()
+	defer s.messageLock.Unlock()
+
 	s.currentMessagePos = currentMessagePos
 	s.nextHotshotBlockNum = currentHostshotBlock
 	s.messageWithMetadataAndPos = []*MessageWithMetadataAndPos{}


### PR DESCRIPTION
This lock is necessary because:

- The batcher resets the message buffer to empty.
- The pulling task concurrently appends messages to that same buffer.
- The pulling task can repopulate the buffer immediately after the reset, effectively overriding it.
- This race leads the batcher to compute an incorrect early HotShot block number.