### PR TITLE
Fix backfilling in batcher monitor

### DIFF
--- a/arbnode/espresso_batcher_addr_monitor.go
+++ b/arbnode/espresso_batcher_addr_monitor.go
@@ -228,7 +228,10 @@ func (b *BatcherAddrMonitor) logsToBatcherAddrEvents(ctx context.Context, logs [
 		}
 		if !bytes.Equal(data[:4], seqInboxABI.Methods["setIsBatchPoster"].ID) {
 			// Encountering an unknown method, caff node needs to update
-			return nil, fmt.Errorf("failed to parse a log: invalid method: %x", data[:4])
+			// Note: if the method id is `0x27f28813`, it is the create rollup method.
+			// cast sig "createRollup(((uint64,uint64,address,uint256,bytes32,address,address,uint256,string,uint64,(uint256,uint256,uint256,uint256),address),address[],uint256,address,bool,uint256,address[],address))"
+			// that means the addr monitor is somehow fetching events from the genesis block, which is not expected.
+			return nil, fmt.Errorf("failed to parse a log: invalid method: %x, %d", data[:4], l1Height)
 		}
 		args, err := seqInboxABI.Methods["setIsBatchPoster"].Inputs.Unpack(data[4:])
 		if err != nil {
@@ -369,6 +372,10 @@ func (b *BatcherAddrMonitor) backfill(ctx context.Context) error {
 	log.Info("batcher addr monitor backfilling")
 	for retry < allowedRetry {
 		if lastProcessedHeight >= latestParentHeight {
+			// Already backfilled to the current known latest height.
+			// However, the latest height might actually be a bit behind,
+			// so update it to match lastProcessedHeight before exiting.
+			latestParentHeight = lastProcessedHeight
 			break
 		}
 

--- a/arbnode/espresso_force_inclusion_checker.go
+++ b/arbnode/espresso_force_inclusion_checker.go
@@ -143,7 +143,7 @@ func (f *ForceInclusionChecker) Start(ctx context.Context) error {
 			return f.config.PollingInterval
 		}
 		if errors.Is(err, ForceInclusionErr) {
-			log.Error("rorce inclusion error", "err", err)
+			log.Error("force inclusion error", "err", err)
 			f.fatalErrChan <- err
 			return 0
 		}


### PR DESCRIPTION
The parent reader might be behind. In this case, batcher monitor shouldn't take its latest header height as the last processed height.