### PR TITLE
Small fixes to Caff node and Batch poster

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -207,7 +207,6 @@ type BatchPosterConfig struct {
 	gasRefunder  common.Address
 	l1BlockBound l1BlockBound
 	// Espresso specific flags
-	EspressoTeeVerifierAddress       string                                   `koanf:"espresso-tee-verifier-address"`
 	EspressoTeeType                  string                                   `koanf:"espresso-tee-type"`
 	EspressoRegisterSignerConfig     espressotee.EspressoRegisterSignerConfig `koanf:"espresso-register-signer-config"`
 	LightClientAddress               string                                   `koanf:"light-client-address"`
@@ -662,45 +661,39 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 				return nil, err
 			}
 
-			cfg.EspressoTeeVerifierAddress = espresssoTEEVerifierAddress.Hex()
+			teeVerifier, err := espressogen.NewIEspressoTEEVerifier(
+				espresssoTEEVerifierAddress,
+				opts.L1Reader.Client())
+			if err != nil {
+				return nil, err
+			}
+			verifier := espressotee.NewEspressoTEEVerifier(teeVerifier, opts.L1Reader.Client(), espresssoTEEVerifierAddress)
 
-			if cfg.EspressoTeeVerifierAddress != "" {
-				// Setup tee verifier interface
-				espressoTeeVerifierAddress := common.HexToAddress(cfg.EspressoTeeVerifierAddress)
-				teeVerifier, err := espressogen.NewIEspressoTEEVerifier(
-					espressoTeeVerifierAddress,
-					opts.L1Reader.Client())
+			var teeType espressotee.TEE
+			configTee := cfg.EspressoTeeType
+			teeType, err = teeType.FromString(configTee)
+			if err != nil {
+				return nil, fmt.Errorf("unsupported tee type in config: %s", configTee)
+			}
+
+			var nitroVerifier espressotee.EspressoNitroTEEVerifierInterface
+			if teeType == espresso_key_manager.NITRO {
+				log.Info("setting up nitro verifier", "tee type", teeType)
+				nitroVerifier, err = setupNitroVerifier(teeVerifier, opts.L1Reader.Client())
 				if err != nil {
 					return nil, err
 				}
-				verifier := espressotee.NewEspressoTEEVerifier(teeVerifier, opts.L1Reader.Client(), espressoTeeVerifierAddress)
-
-				var teeType espressotee.TEE
-				configTee := cfg.EspressoTeeType
-				teeType, err = teeType.FromString(configTee)
-				if err != nil {
-					return nil, fmt.Errorf("unsupported tee type in config: %s", configTee)
-				}
-
-				var nitroVerifier espressotee.EspressoNitroTEEVerifierInterface
-				if teeType == espresso_key_manager.NITRO {
-					log.Info("setting up nitro verifier", "tee type", teeType)
-					nitroVerifier, err = setupNitroVerifier(teeVerifier, opts.L1Reader.Client())
-					if err != nil {
-						return nil, err
-					}
-				}
-
-				if b.dataPoster.Auth() == nil {
-					panic("TransactOpts is nil")
-				}
-				submitterOptions = append(
-					submitterOptions,
-					submitter.WithKeyManager(
-						espresso_key_manager.NewEspressoKeyManager(verifier, nitroVerifier, b.dataPoster, opts.DataSigner, teeType, cfg.EspressoRegisterSignerConfig),
-					),
-				)
 			}
+
+			if b.dataPoster.Auth() == nil {
+				panic("TransactOpts is nil")
+			}
+			submitterOptions = append(
+				submitterOptions,
+				submitter.WithKeyManager(
+					espresso_key_manager.NewEspressoKeyManager(verifier, nitroVerifier, b.dataPoster, opts.DataSigner, teeType, cfg.EspressoRegisterSignerConfig),
+				),
+			)
 
 			submitter, err := submitter.NewPollingEspressoSubmitter(
 				submitterOptions...,

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -341,7 +341,8 @@ var DefaultBatchPosterConfig = BatchPosterConfig{
 	// Espresso Specific config //
 
 	// Hotshot currently produces blocks at average of 2 seconds
-	EspressoTxnsPollingInterval: 2 * time.Second,
+	// We set it to 1 second to get updates more often than blocks are produced
+	EspressoTxnsPollingInterval: time.Second,
 	// We should send to espresso at a speed faster than the speed nitro is producing messages
 	EspressoTxnsSendingInterval:      125 * time.Millisecond,
 	EspressoTxnsResubmissionInterval: 2 * time.Second,
@@ -350,7 +351,7 @@ var DefaultBatchPosterConfig = BatchPosterConfig{
 	HotShotUrls:                      []string{},
 	EspressoTeeType:                  "SGX",
 	EspressoRegisterSignerConfig:     espressotee.DefaultEspressoRegisterSignerConfig,
-	// EspressoTXSXLimit is 1 MB
+	// EspressoTxSizeLimit is 1 MB, to have some buffer we set it to 900 KB
 	EspressoTxSizeLimit: 900 * 1024,
 
 	HotShotBlock:             1,

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -232,9 +232,6 @@ func (c *BatchPosterConfig) Validate() error {
 		return fmt.Errorf("invalid gas refunder address \"%v\"", c.GasRefunderAddress)
 	}
 	c.gasRefunder = common.HexToAddress(c.GasRefunderAddress)
-	if len(c.EspressoTeeVerifierAddress) > 0 && !common.IsHexAddress(c.EspressoTeeVerifierAddress) {
-		return fmt.Errorf("invalid espresso tee verifier address \"%v\"", c.EspressoTeeVerifierAddress)
-	}
 	if c.MaxSize <= 40 {
 		return errors.New("MaxBatchSize too small")
 	}
@@ -281,7 +278,6 @@ func BatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.String(prefix+".l1-block-bound", DefaultBatchPosterConfig.L1BlockBound, "only post messages to batches when they're within the max future block/timestamp as of this L1 block tag (\"safe\", \"finalized\", \"latest\", or \"ignore\" to ignore this check)")
 	f.Duration(prefix+".l1-block-bound-bypass", DefaultBatchPosterConfig.L1BlockBoundBypass, "post batches even if not within the layer 1 future bounds if we're within this margin of the max delay")
 	f.Bool(prefix+".use-access-lists", DefaultBatchPosterConfig.UseAccessLists, "post batches with access lists to reduce gas usage (disabled for L3s)")
-	f.String(prefix+".espresso-tee-verifier-address", DefaultBatchPosterConfig.EspressoTeeVerifierAddress, "The Espresso TEE Verifier contract address")
 	f.String(prefix+".espresso-tee-type", DefaultBatchPosterConfig.EspressoTeeType, "the Trusted Execution Environment (TEE) that Batch poster is running in")
 	f.StringSlice(prefix+".hotshot-urls", DefaultBatchPosterConfig.HotShotUrls, "specifies the hotshot urls if we are batching in espresso mode")
 	f.Uint64(prefix+".hotshot-block", DefaultBatchPosterConfig.HotShotBlock, "specifies the hotshot block number to start the espresso streamer on")
@@ -339,18 +335,24 @@ var DefaultBatchPosterConfig = BatchPosterConfig{
 	CheckBatchCorrectness:          true,
 	MaxEmptyBatchDelay:             3 * 24 * time.Hour,
 	// 5 minutes considering 12-second blocks,
-	DelayBufferAlwaysUpdatable:       true,
-	ParentChainEip7623:               "auto",
-	DelayBufferThresholdMargin:       25, // 5 minutes considering 12-second blocks
-	EspressoTxnsPollingInterval:      time.Second,
-	EspressoTxnsSendingInterval:      time.Second,
+	DelayBufferAlwaysUpdatable: true,
+	ParentChainEip7623:         "auto",
+	DelayBufferThresholdMargin: 25, // 5 minutes considering 12-second blocks
+
+	// Espresso Specific config //
+
+	// Hotshot currently produces blocks at average of 2 seconds
+	EspressoTxnsPollingInterval: 2 * time.Second,
+	// We should send to espresso at a speed faster than the speed nitro is producing messages
+	EspressoTxnsSendingInterval:      125 * time.Millisecond,
 	EspressoTxnsResubmissionInterval: 2 * time.Second,
 	ResubmitEspressoTxDeadline:       10 * time.Minute,
 	LightClientAddress:               "",
 	HotShotUrls:                      []string{},
 	EspressoTeeType:                  "SGX",
 	EspressoRegisterSignerConfig:     espressotee.DefaultEspressoRegisterSignerConfig,
-	EspressoTxSizeLimit:              200 * 1024,
+	// EspressoTXSXLimit is 1 MB
+	EspressoTxSizeLimit: 900 * 1024,
 
 	HotShotBlock:             1,
 	HotShotFirstPostingBlock: 1,
@@ -653,6 +655,14 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 				submitter.WithResubmitEspressoTxDeadline(cfg.ResubmitEspressoTxDeadline),
 				submitter.WithMaxTransactionSize(cfg.EspressoTxSizeLimit),
 			)
+
+			// Get the espressoTEEVerifier address for the sequencer inbox contract
+			espresssoTEEVerifierAddress, err := seqInbox.EspressoTEEVerifier(&bind.CallOpts{})
+			if err != nil {
+				return nil, err
+			}
+
+			cfg.EspressoTeeVerifierAddress = espresssoTEEVerifierAddress.Hex()
 
 			if cfg.EspressoTeeVerifierAddress != "" {
 				// Setup tee verifier interface

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -193,7 +193,7 @@ func NewEspressoCaffNode(
 	}
 
 	delayedMessageFetcher := NewDelayedMessageFetcher(delayedBridge, l1Reader, db, blocksToRead,
-		configFetcher().WaitForFinalization, configFetcher().WaitForConfirmations, configFetcher().RequiredBlockDepth, fromBlock, sequencerInbox)
+		configFetcher().WaitForFinalization, configFetcher().WaitForConfirmations, configFetcher().RequiredBlockDepth, fromBlock, sequencerInbox, fatalErrChan)
 
 	seqInbox, err := bridgegen.NewSequencerInbox(sequencerInbox.address, l1Reader.Client())
 	if err != nil {

--- a/arbnode/espresso_delayed_message_fetcher.go
+++ b/arbnode/espresso_delayed_message_fetcher.go
@@ -338,8 +338,10 @@ func (d *DelayedMessageFetcher) getDelayedMessagesInRange(ctx context.Context, b
 		if seqNum > lastDelayedMessageIndex+1 {
 			// Delayed message fetcher expects to fetch messages strictly in order. If a missing message is detected here,
 			// it indicates a break in sequential fetching. Recovery is not handled by this fetcher and would require additional logic.
-			log.Error("Caff node is missing a delayed message", "seqNum", seqNum, "lastDelayedMessageIndex", lastDelayedMessageIndex)
-			d.fatalErrChan <- fmt.Errorf("Caff node is missing a delayed message", "seqNum", seqNum, "lastDelayedMessageIndex", lastDelayedMessageIndex)
+			err := fmt.Errorf("caff node is missing a delayed message with seqNum: %d, lastDelayedMessageIndex: %d", seqNum, lastDelayedMessageIndex)
+			log.Error(err.Error())
+			d.fatalErrChan <- err
+			return err
 		}
 
 		lastDelayedMessageIndex++

--- a/arbnode/espresso_delayed_message_fetcher.go
+++ b/arbnode/espresso_delayed_message_fetcher.go
@@ -35,6 +35,7 @@ type DelayedMessageFetcher struct {
 	waitForFinalization  bool
 	waitForConfirmations bool
 	requiredBlockDepth   uint64
+	fatalErrChan         chan error
 }
 
 type DelayedMessageFetcherInterface interface {
@@ -337,7 +338,8 @@ func (d *DelayedMessageFetcher) getDelayedMessagesInRange(ctx context.Context, b
 		if seqNum > lastDelayedMessageIndex+1 {
 			// Delayed message fetcher expects to fetch messages strictly in order. If a missing message is detected here,
 			// it indicates a break in sequential fetching. Recovery is not handled by this fetcher and would require additional logic.
-			log.Crit("Caff node is missing a delayed message", "seqNum", seqNum, "lastDelayedMessageIndex", lastDelayedMessageIndex)
+			log.Error("Caff node is missing a delayed message", "seqNum", seqNum, "lastDelayedMessageIndex", lastDelayedMessageIndex)
+			d.fatalErrChan <- fmt.Errorf("Caff node is missing a delayed message", "seqNum", seqNum, "lastDelayedMessageIndex", lastDelayedMessageIndex)
 		}
 
 		lastDelayedMessageIndex++
@@ -466,6 +468,7 @@ func NewDelayedMessageFetcher(
 	requiredBlockDepth uint64,
 	fromBlock uint64,
 	sequencerInbox *SequencerInbox,
+	fatalErrChan chan error,
 ) *DelayedMessageFetcher {
 
 	return &DelayedMessageFetcher{
@@ -478,6 +481,7 @@ func NewDelayedMessageFetcher(
 		requiredBlockDepth:   requiredBlockDepth,
 		maxBlocksToRead:      blocksToRead,
 		sequencerInbox:       sequencerInbox,
+		fatalErrChan:         fatalErrChan,
 	}
 }
 

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -691,6 +691,8 @@ func TestEspressoForceInclusionChecker(t *testing.T) {
 
 	reader := builder.L2.ConsensusNode.L1Reader
 
+	fatalErrChan := make(chan error)
+
 	delayedMessageFetcher := arbnode.NewDelayedMessageFetcher(
 		delayedBridge,
 		reader,
@@ -701,9 +703,8 @@ func TestEspressoForceInclusionChecker(t *testing.T) {
 		10,
 		0,
 		seqInboxInterface,
+		fatalErrChan,
 	)
-
-	fatalErrChan := make(chan error)
 
 	forceInclusionChecker := arbnode.NewForceInclusionChecker(mockSeqInbox, config, reader, delayedMessageFetcher, fatalErrChan)
 	err = forceInclusionChecker.Start(ctx)

--- a/system_tests/espresso/espresso_transaction_streamer_throughput_test.go
+++ b/system_tests/espresso/espresso_transaction_streamer_throughput_test.go
@@ -127,7 +127,7 @@ func TestEspressoTransactionStreamerToEspressoThroughput(t *testing.T) {
 			},
 			messageThroughput: expected[float64]{
 				value:   4,   // 4 messages/s
-				epsilon: 0.1, // 0.1 message/s tolerance
+				epsilon: 0.2, // 0.2 message/s tolerance
 			},
 			sizeThroughput: expected[float64]{
 				value:   4 * generate.DefaultMoltenMessageSize, // 4 messages/s * 3KiB per message
@@ -160,7 +160,7 @@ func TestEspressoTransactionStreamerToEspressoThroughput(t *testing.T) {
 			},
 			messageThroughput: expected[float64]{
 				value:   4,   // 4 messages/s
-				epsilon: 0.1, // 0.1 message/s tolerance
+				epsilon: 0.2, // 0.2 message/s tolerance
 			},
 			sizeThroughput: expected[float64]{
 				value:   4 * generate.DefaultMoltenMessageSize, // 4 messages/s * 3KiB per message

--- a/system_tests/espresso_sovereign_sequencer_test.go
+++ b/system_tests/espresso_sovereign_sequencer_test.go
@@ -40,7 +40,6 @@ func createL1AndL2Node(
 	builder.nodeConfig.BatchPoster.MaxDelay = -1000 * time.Hour
 	builder.nodeConfig.BatchPoster.LightClientAddress = lightClientAddress
 	builder.nodeConfig.BatchPoster.HotShotUrls = []string{hotShotUrl, hotShotUrl}
-	builder.nodeConfig.BatchPoster.EspressoTeeVerifierAddress = "0xA46C59ce2FCaF445F96f66F0411e06A94D34BF45"
 	builder.nodeConfig.BatchPoster.EspressoRegisterSignerConfig.MaxBaseFee = 10000000000 // 100 GWEI for tests
 
 	// validator config


### PR DESCRIPTION
# Description
- This PR fixes some of the batch poster defaults
- Uses sequencer inbox to get the EspressoTEEVerifier address so that we dont have to hardcode it
- Fixes a bug in Caff node which was causing unclean shutdowns

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211224209707470