### PR TITLE
Use Batch Put for storing delayed message index

### DIFF
--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -391,13 +391,18 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 	delayedMessagesRead := n.executionEngine.Bc().CurrentBlock().Nonce.Uint64()
 	// we store delayedmessagecount-1 because that is the index of the delayed message
 	// that needs to be read
-	err = n.delayedMessageFetcher.storeDelayedMessageLatestIndex(n.db, delayedMessagesRead-1)
+	batch := n.db.NewBatch()
+	err = n.delayedMessageFetcher.storeDelayedMessageLatestIndex(batch, delayedMessagesRead-1)
 	if err != nil {
 		log.Error("failed to store delayed message count", "err", err)
 		return err
 	}
 	log.Debug("stored delayed message count", "delayedMessagesRead", delayedMessagesRead-1)
-
+	err = batch.Write()
+	if err != nil {
+		log.Error("failed to write batch", "err", err)
+		return err
+	}
 	// Start the delayed message fetcher
 	started := n.delayedMessageFetcher.Start(ctx)
 	if !started {

--- a/arbnode/espresso_caff_node_test.go
+++ b/arbnode/espresso_caff_node_test.go
@@ -113,7 +113,7 @@ func (m *MockDelayedMessageFetcher) Start(ctx context.Context) bool {
 	return true
 }
 
-func (m *MockDelayedMessageFetcher) storeDelayedMessageLatestIndex(db ethdb.Database, count uint64) error {
+func (m *MockDelayedMessageFetcher) storeDelayedMessageLatestIndex(batch ethdb.Batch, count uint64) error {
 	return nil
 }
 

--- a/arbnode/espresso_delayed_message_fetcher.go
+++ b/arbnode/espresso_delayed_message_fetcher.go
@@ -40,7 +40,7 @@ type DelayedMessageFetcher struct {
 
 type DelayedMessageFetcherInterface interface {
 	Start(ctx context.Context) bool
-	storeDelayedMessageLatestIndex(db ethdb.Database, count uint64) error
+	storeDelayedMessageLatestIndex(batch ethdb.Batch, count uint64) error
 	processDelayedMessage(messageWithMetadataAndPos *espressostreamer.MessageWithMetadataAndPos) (*espressostreamer.MessageWithMetadataAndPos, error)
 	getDelayedMessageLatestIndexAtBlock(blockNumber uint64) (uint64, error)
 }
@@ -442,7 +442,7 @@ func (f *DelayedMessageFetcher) storeDelayedMessage(batch ethdb.Batch, seqNum ui
 		return fmt.Errorf("failed to encode delayed message: %w", err)
 	}
 	// Also update the delayed message count in the database
-	err = f.storeDelayedMessageLatestIndex(f.db, seqNum)
+	err = f.storeDelayedMessageLatestIndex(batch, seqNum)
 	if err != nil {
 		return err
 	}
@@ -452,12 +452,12 @@ func (f *DelayedMessageFetcher) storeDelayedMessage(batch ethdb.Batch, seqNum ui
 }
 
 // storeDelayedMessageLatestIndex stores the delayed message index in the database
-func (f *DelayedMessageFetcher) storeDelayedMessageLatestIndex(db ethdb.Database, count uint64) error {
+func (f *DelayedMessageFetcher) storeDelayedMessageLatestIndex(batch ethdb.Batch, count uint64) error {
 	countBytes, err := rlp.EncodeToBytes(count)
 	if err != nil {
 		return fmt.Errorf("failed to encode delayed message count: %w", err)
 	}
-	return db.Put([]byte(DelayedMessageCountKey), countBytes)
+	return batch.Put([]byte(DelayedMessageCountKey), countBytes)
 }
 
 func NewDelayedMessageFetcher(


### PR DESCRIPTION
# Description
This PR fixes a race condition which happened because we were using db.Put instead of batch.Put in code while storing the delayed message index