### PR TITLE
Send pending transactions after restart

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -1924,11 +1924,11 @@ func (b *BatchPoster) MaybePostSequencerBatch(ctx context.Context) (bool, error)
 		if b.espressoStreamer != nil {
 			b.resetStreamerToParentChainOrConfigHotshotBlock(batchPosition.MessageCount, ctx)
 			if b.espressoRestarting {
-				b.espressoRestarting = false
 				cnt, err := b.streamer.GetMessageCount()
 				if err != nil {
 					return false, err
 				}
+				// Submit transactions that were already in tx streamer
 				if cnt > batchPosition.MessageCount {
 					queue := []arbutil.MessageIndex{}
 					for i := batchPosition.MessageCount; i < cnt; i++ {
@@ -1939,6 +1939,7 @@ func (b *BatchPoster) MaybePostSequencerBatch(ctx context.Context) (bool, error)
 						return false, err
 					}
 				}
+				b.espressoRestarting = false
 			}
 		}
 		latestHeader, err := b.l1Reader.LastHeader(ctx)

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -145,6 +145,7 @@ type BatchPoster struct {
 
 	espressoStreamer           *espressostreamer.EspressoStreamer
 	espressoBatcherAddrMonitor *BatcherAddrMonitor
+	espressoRestarting         bool
 }
 
 type l1BlockBound int
@@ -506,6 +507,8 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 		bytesType:                 bytesType,
 		bytes32ArrayType:          bytes32ArrayType,
 		blobsAttestationArguments: blobsAttestationArguments,
+
+		espressoRestarting: true,
 	}
 	b.messagesPerBatch, err = arbmath.NewMovingAverage[uint64](20)
 	if err != nil {
@@ -1920,6 +1923,23 @@ func (b *BatchPoster) MaybePostSequencerBatch(ctx context.Context) (bool, error)
 	if b.building == nil || b.building.startMsgCount != batchPosition.MessageCount {
 		if b.espressoStreamer != nil {
 			b.resetStreamerToParentChainOrConfigHotshotBlock(batchPosition.MessageCount, ctx)
+			if b.espressoRestarting {
+				b.espressoRestarting = false
+				cnt, err := b.streamer.GetMessageCount()
+				if err != nil {
+					return false, err
+				}
+				if cnt > batchPosition.MessageCount {
+					queue := []arbutil.MessageIndex{}
+					for i := batchPosition.MessageCount; i < cnt; i++ {
+						queue = append(queue, arbutil.MessageIndex(i))
+					}
+					err = b.streamer.espressoSubmitter.EnqueuePendingTransaction(queue)
+					if err != nil {
+						return false, err
+					}
+				}
+			}
 		}
 		latestHeader, err := b.l1Reader.LastHeader(ctx)
 		if err != nil {

--- a/espresso/submitter/polling_espresso_submitter.go
+++ b/espresso/submitter/polling_espresso_submitter.go
@@ -117,7 +117,7 @@ func NewPollingEspressoSubmitter(options ...EspressoSubmitterConfigOption) (Espr
 	}, nil
 }
 
-func (s *PollingEspressoSubmitter) enqueuePendingTransaction(pos []arbutil.MessageIndex) error {
+func (s *PollingEspressoSubmitter) EnqueuePendingTransaction(pos []arbutil.MessageIndex) error {
 	// Store the pos in the database to be used later to submit the message
 	// to hotshot for finalization.
 	err := s.SubmitEspressoTransactionPos(pos)
@@ -723,7 +723,7 @@ func (s *PollingEspressoSubmitter) NotifyNewPendingMessages(firstMsgIdx arbutil.
 	}
 
 	if len(messagesToEnqueue) > 0 {
-		err := s.enqueuePendingTransaction(messagesToEnqueue)
+		err := s.EnqueuePendingTransaction(messagesToEnqueue)
 		if err != nil {
 			log.Error("unable to enqueue a transaction to the pending list to be submitted to espresso.", "err", err, "messages", messagesToEnqueue)
 			return err

--- a/espresso/submitter/submitter.go
+++ b/espresso/submitter/submitter.go
@@ -25,6 +25,7 @@ type EspressoSubmitter interface {
 	NotifyNewPendingMessages(pos arbutil.MessageIndex, messages []arbostypes.MessageWithMetadataAndBlockInfo) error
 	GetKeyManager() espresso_key_manager.EspressoKeyManagerInterface
 	RegisterSigner() error
+	EnqueuePendingTransaction(pos []arbutil.MessageIndex) error
 }
 
 // EspressoSubmitterConfig holds the configuration options for implementations


### PR DESCRIPTION
Add a flag indicating if a restart just happened.

- If it is true, then the batcher will send messages that haven't been posted to L1 to HotShot

I think this PR also fixes problems that blocked #700 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211369382052166