### PR TITLE
Support of Authenticated Storage in Caff Node

### DIFF
--- a/arbnode/espresso_batcher_addr_monitor.go
+++ b/arbnode/espresso_batcher_addr_monitor.go
@@ -489,3 +489,7 @@ func (b *BatcherAddrMonitor) Start(ctx context.Context) error {
 
 	return nil
 }
+
+func (b *BatcherAddrMonitor) StopAndWait() {
+	b.StopWaiter.StopAndWait()
+}

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -217,7 +217,7 @@ func NewEspressoCaffNode(
 			return nil, fmt.Errorf("failed to read l1 block from db: %w", err)
 		}
 
-		if configFetcher().EspressoTeeType != "" {
+		if configFetcher().EspressoTeeType != "" && fromBlock != 0 {
 			fromBlockHash, err := getHashOverUint64(fromBlock)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get hash of from block: %w", err)
@@ -497,7 +497,7 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 			return fmt.Errorf("failed to read next hotshot block: %w", err)
 		}
 
-		if n.configFetcher().EspressoTeeType != "" {
+		if n.configFetcher().EspressoTeeType != "" && nextHotshotBlock != 0 {
 			hotshotBlockHash, err := getHashOverUint64(nextHotshotBlock)
 			if err != nil {
 				return fmt.Errorf("failed to get hash of hotshot block: %w", err)

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -29,8 +29,6 @@ import (
 	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
 
-var BlockSignaturePrefix = []byte("blockSignature")
-
 type EspressoCaffNodeConfig struct {
 	Enable                  bool                    `koanf:"enable"`
 	EspressoTeeType         string                  `koanf:"espresso-tee-type"`
@@ -390,7 +388,7 @@ func (n *EspressoCaffNode) createBlock(ctx context.Context) (returnValue bool) {
 		log.Error("failed to get signature for block", "err", err)
 		return false
 	}
-	err = n.storeBlockSignature(batch, block.NumberU64(), blockSignature)
+	err = storeBlockSignature(batch, block.NumberU64(), blockSignature)
 	if err != nil {
 		log.Error("failed to store signature for block", "err", err)
 		return false
@@ -416,19 +414,6 @@ func (n *EspressoCaffNode) createBlock(ctx context.Context) (returnValue bool) {
 	n.espressoStreamer.RecordTimeDurationBetweenHotshotAndCurrentBlock(messageWithMetadataAndPos.HotshotHeight, time.Now())
 
 	return true
-}
-
-func (n *EspressoCaffNode) storeBlockSignature(batch ethdb.Batch, blockNumber uint64, blockSignature []byte) error {
-	if n.snapshotSigner == nil {
-		return nil
-	}
-	key := dbKey(BlockSignaturePrefix, (blockNumber))
-	return batch.Put(key, blockSignature)
-}
-
-func (n *EspressoCaffNode) getBlockSignature(db ethdb.Database, blockNumber uint64) ([]byte, error) {
-	key := dbKey(BlockSignaturePrefix, (blockNumber))
-	return db.Get(key)
 }
 
 func (n *EspressoCaffNode) GetEspressoStreamer() espressostreamer.EspressoStreamerInterface {
@@ -472,7 +457,7 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 		publicKeyBytes := crypto.FromECDSAPub(n.snapshotPublicKey)
 
 		// Get the block signature
-		blockSignature, err := n.getBlockSignature(n.db, currentBlock.NumberU64())
+		blockSignature, err := getBlockSignature(n.db, currentBlock.NumberU64())
 		if err != nil {
 			return fmt.Errorf("failed to get block signature: %w", err)
 		}

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -214,19 +214,22 @@ func NewEspressoCaffNode(
 		if err != nil {
 			return nil, fmt.Errorf("failed to read l1 block from db: %w", err)
 		}
-
 		if configFetcher().EspressoTeeType != "" && fromBlock != 0 {
 			fromBlockHash, err := getHashOverUint64(fromBlock)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get hash of from block: %w", err)
 			}
-
-			if !(crypto.VerifySignature(fromBlockSignature, fromBlockHash, fromBlockSignature)) {
+			// By default, the signature is 65 bytes which contains R, S, V but VerifySignature expects 64 bytes
+			// so we need to strip V which is the last byte
+			if len(fromBlockSignature) > 64 {
+				fromBlockSignature = fromBlockSignature[:64]
+			}
+			publicKeyBytes := crypto.FromECDSAPub(snapshotPublicKey)
+			if !(crypto.VerifySignature(publicKeyBytes, fromBlockHash, fromBlockSignature)) {
 				return nil, fmt.Errorf("failed to verify signature over from block")
 			}
 		}
 	}
-
 	if fromBlock == 0 {
 		fromBlock = configFetcher().FromBlock
 		if fromBlock == 0 {
@@ -307,7 +310,6 @@ func (n *EspressoCaffNode) peekMessage(ctx context.Context) (*espressostreamer.M
 
 // Creates a block from the next message in the queue.
 func (n *EspressoCaffNode) createBlock(ctx context.Context) (returnValue bool) {
-
 	lastBlockHeader := n.currentBlock.Header()
 
 	messageWithMetadataAndPos, fromBlock, err := n.peekMessage(ctx)
@@ -375,6 +377,7 @@ func (n *EspressoCaffNode) createBlock(ctx context.Context) (returnValue bool) {
 			log.Error("Failed to get signature for from block", "err", err)
 			return false
 		}
+
 		err = storeFromBlockWithSignature(batch, fromBlock, fromBlockSignature)
 		if err != nil {
 			log.Error("failed to store signature for from block", "err", err)
@@ -421,7 +424,6 @@ func (n *EspressoCaffNode) GetEspressoStreamer() espressostreamer.EspressoStream
 }
 
 func (n *EspressoCaffNode) Start(ctx context.Context) error {
-	log.Info("Starting espresso caff node")
 	n.StopWaiter.Start(ctx, n)
 	err := n.espressoStreamer.Start(ctx)
 	if err != nil {
@@ -447,7 +449,7 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 	currentBlockHeader := n.executionEngine.Bc().CurrentBlock()
 	currentBlock := n.executionEngine.Bc().GetBlock(currentBlockHeader.Hash(), currentBlockHeader.Number.Uint64())
 
-	if n.configFetcher().EspressoTeeType != "" {
+	if n.configFetcher().EspressoTeeType != "" && currentBlock.NumberU64() > 0 {
 		blockhash, err := getHashOverInterface(currentBlock)
 		if err != nil {
 			log.Error("failed to get hash of current block", "err", err)
@@ -461,7 +463,11 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to get block signature: %w", err)
 		}
-
+		// By default, the signature is 65 bytes which contains R, S, V but VerifySignature expects 64 bytes
+		// so we need to strip V which is the last byte
+		if len(blockSignature) > 64 {
+			blockSignature = blockSignature[:64]
+		}
 		if !crypto.VerifySignature(publicKeyBytes, blockhash, blockSignature) {
 			return fmt.Errorf("failed to verify signature over the stored current block")
 		}
@@ -490,13 +496,16 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 				return fmt.Errorf("failed to get hash of hotshot block: %w", err)
 			}
 			publicKeyBytes := crypto.FromECDSAPub(n.snapshotPublicKey)
-
+			// By default, the signature is 65 bytes which contains R, S, V but VerifySignature expects 64 bytes
+			// so we need to strip V which is the last byte
+			if len(nextHotshotBlockSignature) > 64 {
+				nextHotshotBlockSignature = nextHotshotBlockSignature[:64]
+			}
 			if !crypto.VerifySignature(publicKeyBytes, hotshotBlockHash, nextHotshotBlockSignature) {
 				return fmt.Errorf("failed to verify signature over hotshot block number")
 			}
 		}
 	}
-
 	if nextHotshotBlock == 0 {
 		// No next hotshot block found, so we need to start from config.CaffNodeConfig.NextHotshotBlock
 		nextHotshotBlock = n.configFetcher().NextHotshotBlock
@@ -504,6 +513,7 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 			return errors.New("no next hotshot block found in database or dangerous.ignore-database-hotshot-block is set to true, please set config.CaffNodeConfig.NextHotshotBlock")
 		}
 	}
+
 	// The reason we do the reset here is because database is only initialized after Caff node is initialized
 	// so if we want to read the current position from the database, we need to reset the streamer
 	// during the start of the espresso streamer and caff node
@@ -539,4 +549,12 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (n *EspressoCaffNode) StopAndWait() {
+	n.StopWaiter.StopAndWait()
+	n.batcherAddrMonitor.StopAndWait()
+	n.delayedMessageFetcher.StopAndWait()
+	n.espressoStreamer.StopAndWait()
+	n.forceInclusionChecker.StopAndWait()
 }

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -2,7 +2,7 @@ package arbnode
 
 import (
 	"context"
-	"encoding/binary"
+	"crypto/ecdsa"
 	"errors"
 	"fmt"
 	"path"
@@ -18,7 +18,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/offchainlabs/bold/solgen/go/bridgegen"
 	"github.com/offchainlabs/nitro/arbos"
@@ -34,6 +33,7 @@ var BlockSignaturePrefix = []byte("blockSignature")
 
 type EspressoCaffNodeConfig struct {
 	Enable                  bool                    `koanf:"enable"`
+	EspressoTeeType         string                  `koanf:"espresso-tee-type"`
 	HotShotUrls             []string                `koanf:"hotshot-urls"`
 	NextHotshotBlock        uint64                  `koanf:"next-hotshot-block"`
 	FromBlock               uint64                  `koanf:"from-block"`
@@ -93,6 +93,7 @@ var DefaultEspressoCaffNodeConfig = EspressoCaffNodeConfig{
 	Dangerous:               DefaultDangerousCaffNodeConfig,
 	FromBlock:               1,
 	KeyPairAttestationsPath: "caff_node_key_pair_attestations",
+	EspressoTeeType:         "",
 }
 
 func EspressoCaffNodeConfigAddOptions(prefix string, f *flag.FlagSet) {
@@ -112,6 +113,7 @@ func EspressoCaffNodeConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Uint64(prefix+".blocks-to-read", DefaultEspressoCaffNodeConfig.BlocksToRead, "Configures the number of blocks to read from the parent chain for delayed messages")
 	f.Uint64(prefix+".from-block", DefaultEspressoCaffNodeConfig.FromBlock, "Configures the block number to start reading delayed messages from")
 	f.String(prefix+".key-pair-attestations-path", DefaultEspressoCaffNodeConfig.KeyPairAttestationsPath, "Path to attestation documents with KMSKeyID, EncryptedPrivateKey attestations")
+	f.String(prefix+".espresso-tee-type", DefaultEspressoCaffNodeConfig.EspressoTeeType, "Configures the type of espresso tee to use")
 	DangerousCaffNodeConfigAddOptions(prefix+".dangerous", f)
 
 	EspressoForceInclusionConfigAddOptions(prefix+".force-inclusion-checker", f)
@@ -128,9 +130,10 @@ type EspressoCaffNodeConfigFetcher func() *EspressoCaffNodeConfig
 type EspressoCaffNode struct {
 	stopwaiter.StopWaiter
 
-	executionEngine  *gethexec.ExecutionEngine
-	snapshotSigner   signature.DataSignerFunc
-	espressoStreamer espressostreamer.EspressoStreamerInterface
+	executionEngine   *gethexec.ExecutionEngine
+	snapshotPublicKey *ecdsa.PublicKey
+	snapshotSigner    signature.DataSignerFunc
+	espressoStreamer  espressostreamer.EspressoStreamerInterface
 
 	configFetcher EspressoCaffNodeConfigFetcher
 	db            ethdb.Database
@@ -146,12 +149,9 @@ type EspressoCaffNode struct {
 	currentBlock       *types.Block
 }
 
-// TODO: Check everything is using batch.Put to write to db
-// TODO: Check that we are hashing and storing signature for all things which are being stored in the database
-// TODO: Fix espresso_caff_node_test.go to process from block
-
 func NewEspressoCaffNode(
 	configFetcher EspressoCaffNodeConfigFetcher,
+	snapshotPublicKey *ecdsa.PublicKey,
 	snapshotSigner signature.DataSignerFunc,
 	execEngine *gethexec.ExecutionEngine,
 	delayedBridge *DelayedBridge,
@@ -162,14 +162,20 @@ func NewEspressoCaffNode(
 	sequencerInbox *SequencerInbox,
 	fatalErrChan chan error,
 	httpPort int,
-) *EspressoCaffNode {
+) (*EspressoCaffNode, error) {
 	if !configFetcher().Enable {
-		return nil
+		return nil, nil
 	}
 
 	if l1Reader == nil {
-		log.Crit("l1Reader is nil")
-		return nil
+		return nil, fmt.Errorf("l1 reader is nil")
+	}
+
+	if configFetcher().EspressoTeeType != "" {
+		// Check that snapsnotSigner and snapshotPublicKey are not nil
+		if snapshotSigner == nil || snapshotPublicKey == nil {
+			return nil, fmt.Errorf("snapshotSigner and snapshotPublicKey are required for espresso tee type")
+		}
 	}
 
 	// For backward compatibility, the espresso streamer should be able to verify legacy where we signed
@@ -179,12 +185,11 @@ func NewEspressoCaffNode(
 		common.HexToAddress(configFetcher().EspressoSGXVerifierAddr),
 	)
 	if err != nil {
-		log.Crit("failed to create espressoTEEVerifier", "err", err)
-		return nil
+		return nil, fmt.Errorf("failed to create espressoTEEVerifier: %w", err)
 	}
 	client, err := espressoClient.NewMultipleNodesClient(configFetcher().HotShotUrls)
 	if err != nil {
-		log.Crit("Failed to create hotshot client", "err", err)
+		return nil, fmt.Errorf("failed to create hotshot client: %w", err)
 	}
 
 	batcherAddrMonitor := NewBatcherAddrMonitor(
@@ -205,18 +210,29 @@ func NewEspressoCaffNode(
 	)
 
 	fromBlock := configFetcher().FromBlock
+	var fromBlockSignature []byte
 	if !configFetcher().Dangerous.IgnoreDatabaseFromBlock {
-		fromBlock, err = readCurrentFromBlockFromDb(db)
+		fromBlock, fromBlockSignature, err = readCurrentFromBlockFromDb(db)
 		if err != nil {
-			log.Crit("failed to read l1 block from db", "err", err)
+			return nil, fmt.Errorf("failed to read l1 block from db: %w", err)
 		}
-		// TODO: verify the signature of the from block
+
+		if configFetcher().EspressoTeeType != "" {
+			fromBlockHash, err := getHashOverUint64(fromBlock)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get hash of from block: %w", err)
+			}
+
+			if !(crypto.VerifySignature(fromBlockSignature, fromBlockHash, fromBlockSignature)) {
+				return nil, fmt.Errorf("failed to verify signature over from block")
+			}
+		}
 	}
 
 	if fromBlock == 0 {
 		fromBlock = configFetcher().FromBlock
 		if fromBlock == 0 {
-			log.Crit("fromBlock is 0, please provide a valid block number")
+			return nil, fmt.Errorf("fromBlock is 0, please provide a valid block number")
 		}
 	}
 
@@ -225,8 +241,7 @@ func NewEspressoCaffNode(
 
 	seqInbox, err := bridgegen.NewSequencerInbox(sequencerInbox.address, l1Reader.Client())
 	if err != nil {
-		log.Crit("failed to create sequencer inbox", "err", err)
-		return nil
+		return nil, fmt.Errorf("failed to create sequencer inbox: %w", err)
 	}
 
 	forceInclusionChecker := NewForceInclusionChecker(
@@ -246,6 +261,7 @@ func NewEspressoCaffNode(
 	return &EspressoCaffNode{
 		configFetcher:         configFetcher,
 		executionEngine:       execEngine,
+		snapshotPublicKey:     snapshotPublicKey,
 		snapshotSigner:        snapshotSigner,
 		delayedMessageFetcher: delayedMessageFetcher,
 		espressoStreamer:      espressoStreamer,
@@ -254,7 +270,7 @@ func NewEspressoCaffNode(
 		forceInclusionChecker: forceInclusionChecker,
 		stateChecker:          stateChecker,
 		batcherAddrMonitor:    batcherAddrMonitor,
-	}
+	}, nil
 }
 
 // peekMessage wraps the espressoStreamer.Peek() method, to handle producing delayed messages by checking they are within the nodes safety tolerance.
@@ -342,7 +358,7 @@ func (n *EspressoCaffNode) createBlock(ctx context.Context) (returnValue bool) {
 	batch := n.db.NewBatch()
 
 	// Store hotshot block with signature if snapshot signer is configured
-	hotshotBlockSignature, err := n.getSignatureForHotshotBlock(hotshotBlockNumber)
+	hotshotBlockSignature, err := generateSignatureFromUint64(n.snapshotSigner, hotshotBlockNumber)
 	if err != nil {
 		log.Error("Failed to get signature for hotshot block", "err", err)
 		return false
@@ -356,7 +372,7 @@ func (n *EspressoCaffNode) createBlock(ctx context.Context) (returnValue bool) {
 	// Store from block with signature if snapshot signer is configured
 	// fromBlock will only be stored when we process a delayed message
 	if fromBlock != 0 {
-		fromBlockSignature, err := n.getSignatureForFromBlock(fromBlock)
+		fromBlockSignature, err := generateSignatureFromUint64(n.snapshotSigner, fromBlock)
 		if err != nil {
 			log.Error("Failed to get signature for from block", "err", err)
 			return false
@@ -369,7 +385,7 @@ func (n *EspressoCaffNode) createBlock(ctx context.Context) (returnValue bool) {
 	}
 
 	// Store block with signature if snapshot signer is configured
-	blockSignature, err := n.getSignatureForBlock(block)
+	blockSignature, err := generateSignatureOverInterface(n.snapshotSigner, block)
 	if err != nil {
 		log.Error("failed to get signature for block", "err", err)
 		return false
@@ -402,62 +418,15 @@ func (n *EspressoCaffNode) createBlock(ctx context.Context) (returnValue bool) {
 	return true
 }
 
-func (n *EspressoCaffNode) getSignatureForFromBlock(fromBlock uint64) ([]byte, error) {
-	if n.snapshotSigner == nil {
-		return []byte{}, nil
-	}
-	fromBlockBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(fromBlockBytes, fromBlock)
-	fromBlockHash := crypto.Keccak256Hash(fromBlockBytes)
-	fromBlockSignature, err := n.snapshotSigner(fromBlockHash.Bytes())
-	if err != nil {
-		log.Error("failed to sign from block", "err", err)
-		return []byte{}, err
-	}
-	return fromBlockSignature, nil
-}
-
-func (n *EspressoCaffNode) getSignatureForHotshotBlock(hotshotBlock uint64) ([]byte, error) {
-	if n.snapshotSigner == nil {
-		return []byte{}, nil
-	}
-	hotshotBlockBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(hotshotBlockBytes, hotshotBlock)
-	hotshotBlockHash := crypto.Keccak256Hash(hotshotBlockBytes)
-	hotshotBlockSignature, err := n.snapshotSigner(hotshotBlockHash.Bytes())
-	if err != nil {
-		log.Error("failed to sign hotshot block", "err", err)
-		return []byte{}, err
-	}
-	return hotshotBlockSignature, nil
-}
-
-func (n *EspressoCaffNode) getSignatureForBlock(block *types.Block) ([]byte, error) {
-	if n.snapshotSigner == nil {
-		return []byte{}, nil
-	}
-	// Get bytes of the block
-	blockBytes, err := rlp.EncodeToBytes(block)
-	if err != nil {
-		log.Error("failed to encode block", "err", err)
-		return []byte{}, err
-	}
-	blockHash := crypto.Keccak256Hash(blockBytes)
-	blockSignature, err := n.snapshotSigner(blockHash.Bytes())
-	if err != nil {
-		log.Error("failed to sign block", "err", err)
-		return []byte{}, err
-	}
-	return blockSignature, nil
-}
-
 func (n *EspressoCaffNode) storeBlockSignature(batch ethdb.Batch, blockSignature []byte) error {
 	if n.snapshotSigner == nil {
 		return nil
 	}
-
 	return batch.Put(BlockSignaturePrefix, blockSignature)
+}
 
+func (n *EspressoCaffNode) getBlockSignature(db ethdb.Database) ([]byte, error) {
+	return db.Get(BlockSignaturePrefix)
 }
 
 func (n *EspressoCaffNode) GetEspressoStreamer() espressostreamer.EspressoStreamerInterface {
@@ -490,7 +459,27 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 	// This is +1 because the current block is the block after the last processed block
 	currentBlockHeader := n.executionEngine.Bc().CurrentBlock()
 	currentBlock := n.executionEngine.Bc().GetBlock(currentBlockHeader.Hash(), currentBlockHeader.Number.Uint64())
-	// TODO: verify the signature of the current block
+
+	if n.configFetcher().EspressoTeeType != "" {
+		blockhash, err := getHashOverInterface(currentBlock)
+		if err != nil {
+			log.Error("failed to get hash of current block", "err", err)
+			return fmt.Errorf("failed to get hash of current block: %w", err)
+		}
+
+		publicKeyBytes := crypto.FromECDSAPub(n.snapshotPublicKey)
+
+		// Get the block signature
+		blockSignature, err := n.getBlockSignature(n.db)
+		if err != nil {
+			return fmt.Errorf("failed to get block signature: %w", err)
+		}
+
+		if !crypto.VerifySignature(publicKeyBytes, blockhash, blockSignature) {
+			return fmt.Errorf("failed to verify signature over the stored current block")
+		}
+	}
+
 	n.currentBlock = currentBlock
 
 	currentBlockNum := currentBlockHeader.Number.Uint64() + 1
@@ -498,14 +487,27 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to convert block number to message index: %w", err)
 	}
+
 	var nextHotshotBlock uint64
+	var nextHotshotBlockSignature []byte
 
 	if !n.configFetcher().Dangerous.IgnoreDatabaseHotshotBlock {
-		nextHotshotBlock, err = n.espressoStreamer.ReadNextHotshotBlockFromDb(n.db)
+		nextHotshotBlock, nextHotshotBlockSignature, err = n.espressoStreamer.ReadNextHotshotBlockFromDb(n.db)
 		if err != nil {
 			return fmt.Errorf("failed to read next hotshot block: %w", err)
 		}
-		// TODO: verify the signature of the hotshot block
+
+		if n.configFetcher().EspressoTeeType != "" {
+			hotshotBlockHash, err := getHashOverUint64(nextHotshotBlock)
+			if err != nil {
+				return fmt.Errorf("failed to get hash of hotshot block: %w", err)
+			}
+			publicKeyBytes := crypto.FromECDSAPub(n.snapshotPublicKey)
+
+			if !crypto.VerifySignature(publicKeyBytes, hotshotBlockHash, nextHotshotBlockSignature) {
+				return fmt.Errorf("failed to verify signature over hotshot block number")
+			}
+		}
 	}
 
 	if nextHotshotBlock == 0 {

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -2,6 +2,7 @@ package arbnode
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"path"
@@ -13,8 +14,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/offchainlabs/bold/solgen/go/bridgegen"
 	"github.com/offchainlabs/nitro/arbos"
@@ -25,6 +29,8 @@ import (
 	"github.com/offchainlabs/nitro/util/signature"
 	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
+
+var BlockSignaturePrefix = []byte("blockSignature")
 
 type EspressoCaffNodeConfig struct {
 	Enable                  bool                    `koanf:"enable"`
@@ -137,7 +143,12 @@ type EspressoCaffNode struct {
 	stateChecker          *StateChecker
 
 	batcherAddrMonitor *BatcherAddrMonitor
+	currentBlock       *types.Block
 }
+
+// TODO: Check everything is using batch.Put to write to db
+// TODO: Check that we are hashing and storing signature for all things which are being stored in the database
+// TODO: Fix espresso_caff_node_test.go to process from block
 
 func NewEspressoCaffNode(
 	configFetcher EspressoCaffNodeConfigFetcher,
@@ -199,6 +210,7 @@ func NewEspressoCaffNode(
 		if err != nil {
 			log.Crit("failed to read l1 block from db", "err", err)
 		}
+		// TODO: verify the signature of the from block
 	}
 
 	if fromBlock == 0 {
@@ -208,7 +220,7 @@ func NewEspressoCaffNode(
 		}
 	}
 
-	delayedMessageFetcher := NewDelayedMessageFetcher(delayedBridge, l1Reader, db, blocksToRead,
+	delayedMessageFetcher := NewDelayedMessageFetcher(delayedBridge, l1Reader, blocksToRead,
 		configFetcher().WaitForFinalization, configFetcher().WaitForConfirmations, configFetcher().RequiredBlockDepth, fromBlock, sequencerInbox, fatalErrChan)
 
 	seqInbox, err := bridgegen.NewSequencerInbox(sequencerInbox.address, l1Reader.Client())
@@ -254,37 +266,37 @@ func NewEspressoCaffNode(
 //
 //	This function will either produce a message, or an error. When an error is produced, the messageWithMetadataAndPos will be nil.
 //	If the message is populated, the error will be nil.
-func (n *EspressoCaffNode) peekMessage(ctx context.Context) (*espressostreamer.MessageWithMetadataAndPos, error) {
+func (n *EspressoCaffNode) peekMessage(ctx context.Context) (*espressostreamer.MessageWithMetadataAndPos, uint64, error) {
 	messageWithMetadataAndPos := n.espressoStreamer.Peek(ctx)
 
 	if messageWithMetadataAndPos == nil {
-		return nil, nil
+		return nil, 0, nil
 	}
 
 	// Check if its a delayed message, if so fetch from the database
 	delayedMessageToProcessIndex, err := n.executionEngine.NextDelayedMessageNumber()
 	if err != nil {
 		log.Error("failed to get next delayed message number", "err", err)
-		return nil, err
+		return nil, 0, err
 	}
 	if delayedMessageToProcessIndex == messageWithMetadataAndPos.MessageWithMeta.DelayedMessagesRead-1 {
-		messageWithMetadataAndPosDelayed, err := n.delayedMessageFetcher.processDelayedMessage(messageWithMetadataAndPos)
+		messageWithMetadataAndPosDelayed, fromBlock, err := n.delayedMessageFetcher.processDelayedMessage(messageWithMetadataAndPos)
 		if err != nil {
 			log.Error("unable to get the next delayed message", "err", err)
-			return nil, err
+			return nil, 0, err
 		}
-		return messageWithMetadataAndPosDelayed, nil
+		return messageWithMetadataAndPosDelayed, fromBlock, nil
 	}
 
-	return messageWithMetadataAndPos, nil
+	return messageWithMetadataAndPos, 0, nil
 }
 
 // Creates a block from the next message in the queue.
 func (n *EspressoCaffNode) createBlock(ctx context.Context) (returnValue bool) {
 
-	lastBlockHeader := n.executionEngine.Bc().CurrentBlock()
+	lastBlockHeader := n.currentBlock.Header()
 
-	messageWithMetadataAndPos, err := n.peekMessage(ctx)
+	messageWithMetadataAndPos, fromBlock, err := n.peekMessage(ctx)
 	if err != nil {
 		log.Warn("unable to get next message", "err", err)
 		return false
@@ -327,9 +339,44 @@ func (n *EspressoCaffNode) createBlock(ctx context.Context) (returnValue bool) {
 	log.Info("Produced block", "block", block.Hash(), "blockNumber", block.Number(), "receipts", len(receipts))
 
 	hotshotBlockNumber := n.espressoStreamer.GetCurrentEarliestHotShotBlockNumber()
-	err = n.espressoStreamer.StoreHotshotBlock(n.db, hotshotBlockNumber)
+	batch := n.db.NewBatch()
+
+	// Store hotshot block with signature if snapshot signer is configured
+	hotshotBlockSignature, err := n.getSignatureForHotshotBlock(hotshotBlockNumber)
 	if err != nil {
-		log.Warn("Failed to store hotshot block. This should be an ephemeral error", "err", err)
+		log.Error("Failed to get signature for hotshot block", "err", err)
+		return false
+	}
+	err = n.espressoStreamer.StoreHotshotBlockWithSignature(batch, hotshotBlockNumber, hotshotBlockSignature)
+	if err != nil {
+		log.Warn("Failed to store signature for hotshot block. This should be an ephemeral error", "err", err)
+		return false
+	}
+
+	// Store from block with signature if snapshot signer is configured
+	// fromBlock will only be stored when we process a delayed message
+	if fromBlock != 0 {
+		fromBlockSignature, err := n.getSignatureForFromBlock(fromBlock)
+		if err != nil {
+			log.Error("Failed to get signature for from block", "err", err)
+			return false
+		}
+		err = storeFromBlockWithSignature(batch, fromBlock, fromBlockSignature)
+		if err != nil {
+			log.Error("failed to store signature for from block", "err", err)
+			return false
+		}
+	}
+
+	// Store block with signature if snapshot signer is configured
+	blockSignature, err := n.getSignatureForBlock(block)
+	if err != nil {
+		log.Error("failed to get signature for block", "err", err)
+		return false
+	}
+	err = n.storeBlockSignature(batch, blockSignature)
+	if err != nil {
+		log.Error("failed to store signature for block", "err", err)
 		return false
 	}
 
@@ -339,6 +386,13 @@ func (n *EspressoCaffNode) createBlock(ctx context.Context) (returnValue bool) {
 		return false
 	}
 
+	// Write the batch to the database
+	if err := batch.Write(); err != nil {
+		log.Error("caff node create block failed to write block to db", "err", err)
+		return false
+	}
+
+	n.currentBlock = block
 	n.espressoStreamer.Advance()
 
 	n.executionEngine.Bc().SetFinalized(block.Header())
@@ -346,6 +400,64 @@ func (n *EspressoCaffNode) createBlock(ctx context.Context) (returnValue bool) {
 	n.espressoStreamer.RecordTimeDurationBetweenHotshotAndCurrentBlock(messageWithMetadataAndPos.HotshotHeight, time.Now())
 
 	return true
+}
+
+func (n *EspressoCaffNode) getSignatureForFromBlock(fromBlock uint64) ([]byte, error) {
+	if n.snapshotSigner == nil {
+		return []byte{}, nil
+	}
+	fromBlockBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(fromBlockBytes, fromBlock)
+	fromBlockHash := crypto.Keccak256Hash(fromBlockBytes)
+	fromBlockSignature, err := n.snapshotSigner(fromBlockHash.Bytes())
+	if err != nil {
+		log.Error("failed to sign from block", "err", err)
+		return []byte{}, err
+	}
+	return fromBlockSignature, nil
+}
+
+func (n *EspressoCaffNode) getSignatureForHotshotBlock(hotshotBlock uint64) ([]byte, error) {
+	if n.snapshotSigner == nil {
+		return []byte{}, nil
+	}
+	hotshotBlockBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(hotshotBlockBytes, hotshotBlock)
+	hotshotBlockHash := crypto.Keccak256Hash(hotshotBlockBytes)
+	hotshotBlockSignature, err := n.snapshotSigner(hotshotBlockHash.Bytes())
+	if err != nil {
+		log.Error("failed to sign hotshot block", "err", err)
+		return []byte{}, err
+	}
+	return hotshotBlockSignature, nil
+}
+
+func (n *EspressoCaffNode) getSignatureForBlock(block *types.Block) ([]byte, error) {
+	if n.snapshotSigner == nil {
+		return []byte{}, nil
+	}
+	// Get bytes of the block
+	blockBytes, err := rlp.EncodeToBytes(block)
+	if err != nil {
+		log.Error("failed to encode block", "err", err)
+		return []byte{}, err
+	}
+	blockHash := crypto.Keccak256Hash(blockBytes)
+	blockSignature, err := n.snapshotSigner(blockHash.Bytes())
+	if err != nil {
+		log.Error("failed to sign block", "err", err)
+		return []byte{}, err
+	}
+	return blockSignature, nil
+}
+
+func (n *EspressoCaffNode) storeBlockSignature(batch ethdb.Batch, blockSignature []byte) error {
+	if n.snapshotSigner == nil {
+		return nil
+	}
+
+	return batch.Put(BlockSignaturePrefix, blockSignature)
+
 }
 
 func (n *EspressoCaffNode) GetEspressoStreamer() espressostreamer.EspressoStreamerInterface {
@@ -376,7 +488,12 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 	}
 
 	// This is +1 because the current block is the block after the last processed block
-	currentBlockNum := n.executionEngine.Bc().CurrentBlock().Number.Uint64() + 1
+	currentBlockHeader := n.executionEngine.Bc().CurrentBlock()
+	currentBlock := n.executionEngine.Bc().GetBlock(currentBlockHeader.Hash(), currentBlockHeader.Number.Uint64())
+	// TODO: verify the signature of the current block
+	n.currentBlock = currentBlock
+
+	currentBlockNum := currentBlockHeader.Number.Uint64() + 1
 	currentMessagePos, err := n.executionEngine.BlockNumberToMessageIndex(currentBlockNum)
 	if err != nil {
 		return fmt.Errorf("failed to convert block number to message index: %w", err)
@@ -388,6 +505,7 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to read next hotshot block: %w", err)
 		}
+		// TODO: verify the signature of the hotshot block
 	}
 
 	if nextHotshotBlock == 0 {
@@ -408,11 +526,8 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 	delayedMessagesRead := n.executionEngine.Bc().CurrentBlock().Nonce.Uint64()
 	// we store delayedmessagecount-1 because that is the index of the delayed message
 	// that needs to be read
-	err = n.delayedMessageFetcher.storeDelayedMessageLatestIndex(n.db, delayedMessagesRead-1)
-	if err != nil {
-		log.Error("failed to store delayed message count", "err", err)
-		return err
-	}
+	n.delayedMessageFetcher.storeDelayedMessageLatestIndex(delayedMessagesRead - 1)
+
 	log.Debug("stored delayed message count", "delayedMessagesRead", delayedMessagesRead-1)
 
 	// Start the delayed message fetcher

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -390,7 +390,7 @@ func (n *EspressoCaffNode) createBlock(ctx context.Context) (returnValue bool) {
 		log.Error("failed to get signature for block", "err", err)
 		return false
 	}
-	err = n.storeBlockSignature(batch, blockSignature)
+	err = n.storeBlockSignature(batch, block.NumberU64(), blockSignature)
 	if err != nil {
 		log.Error("failed to store signature for block", "err", err)
 		return false
@@ -418,15 +418,17 @@ func (n *EspressoCaffNode) createBlock(ctx context.Context) (returnValue bool) {
 	return true
 }
 
-func (n *EspressoCaffNode) storeBlockSignature(batch ethdb.Batch, blockSignature []byte) error {
+func (n *EspressoCaffNode) storeBlockSignature(batch ethdb.Batch, blockNumber uint64, blockSignature []byte) error {
 	if n.snapshotSigner == nil {
 		return nil
 	}
-	return batch.Put(BlockSignaturePrefix, blockSignature)
+	key := dbKey(BlockSignaturePrefix, (blockNumber))
+	return batch.Put(key, blockSignature)
 }
 
-func (n *EspressoCaffNode) getBlockSignature(db ethdb.Database) ([]byte, error) {
-	return db.Get(BlockSignaturePrefix)
+func (n *EspressoCaffNode) getBlockSignature(db ethdb.Database, blockNumber uint64) ([]byte, error) {
+	key := dbKey(BlockSignaturePrefix, (blockNumber))
+	return db.Get(key)
 }
 
 func (n *EspressoCaffNode) GetEspressoStreamer() espressostreamer.EspressoStreamerInterface {
@@ -470,7 +472,7 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 		publicKeyBytes := crypto.FromECDSAPub(n.snapshotPublicKey)
 
 		// Get the block signature
-		blockSignature, err := n.getBlockSignature(n.db)
+		blockSignature, err := n.getBlockSignature(n.db, currentBlock.NumberU64())
 		if err != nil {
 			return fmt.Errorf("failed to get block signature: %w", err)
 		}

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 
@@ -127,10 +126,10 @@ type EspressoCaffNodeConfigFetcher func() *EspressoCaffNodeConfig
 type EspressoCaffNode struct {
 	stopwaiter.StopWaiter
 
-	executionEngine  *gethexec.ExecutionEngine
-	snapshotAddress  *common.Address
-	snapshotSigner   signature.DataSignerFunc
-	espressoStreamer espressostreamer.EspressoStreamerInterface
+	executionEngine       *gethexec.ExecutionEngine
+	snapshotSignerAddress *common.Address
+	snapshotSigner        signature.DataSignerFunc
+	espressoStreamer      espressostreamer.EspressoStreamerInterface
 
 	configFetcher EspressoCaffNodeConfigFetcher
 	db            ethdb.Database
@@ -148,7 +147,7 @@ type EspressoCaffNode struct {
 
 func NewEspressoCaffNode(
 	configFetcher EspressoCaffNodeConfigFetcher,
-	snapshotAddress *common.Address,
+	snapshotSignerAddress *common.Address,
 	snapshotSigner signature.DataSignerFunc,
 	execEngine *gethexec.ExecutionEngine,
 	delayedBridge *DelayedBridge,
@@ -170,7 +169,7 @@ func NewEspressoCaffNode(
 
 	if configFetcher().EspressoTeeType != "" {
 		// Check that snapsnotSigner is not nil
-		if snapshotSigner == nil || snapshotAddress == nil {
+		if snapshotSigner == nil || snapshotSignerAddress == nil {
 			return nil, fmt.Errorf("snapshotSigner and snapshotPublicKey are required for espresso tee type")
 		}
 	}
@@ -219,20 +218,9 @@ func NewEspressoCaffNode(
 				return nil, fmt.Errorf("failed to get hash of from block: %w", err)
 			}
 
-			publicKeyBytes, err := crypto.Ecrecover(fromBlockHash, fromBlockSignature)
+			err = verifySignature(db, fromBlockSignature, fromBlockHash, *snapshotSignerAddress)
 			if err != nil {
-				return nil, fmt.Errorf("failed to recover public key from signature: %w", err)
-			}
-			pubKey, err := crypto.UnmarshalPubkey(publicKeyBytes)
-			if err != nil || pubKey == nil {
-				return nil, fmt.Errorf("failed to unmarshal public key: %w", err)
-			}
-			// Public Key to address
-			publicKeyAddress := crypto.PubkeyToAddress(*pubKey)
-			// TODO: In follow up PRs, we should allows any valid PCR0 address registered in the contract
-			// to be able to decrypt the snapshot
-			if publicKeyAddress != *snapshotAddress {
-				return nil, fmt.Errorf("public key address does not match from address")
+				return nil, fmt.Errorf("failed to verify from block signature: %w", err)
 			}
 		}
 	}
@@ -268,7 +256,7 @@ func NewEspressoCaffNode(
 	return &EspressoCaffNode{
 		configFetcher:         configFetcher,
 		executionEngine:       execEngine,
-		snapshotAddress:       snapshotAddress,
+		snapshotSignerAddress: snapshotSignerAddress,
 		snapshotSigner:        snapshotSigner,
 		delayedMessageFetcher: delayedMessageFetcher,
 		espressoStreamer:      espressoStreamer,
@@ -392,12 +380,12 @@ func (n *EspressoCaffNode) createBlock(ctx context.Context) (returnValue bool) {
 	}
 
 	// Store block with signature if snapshot signer is configured
-	blockSignature, err := generateSignatureOverInterface(n.snapshotSigner, block)
+	blockSignature, err := generateSignatureOverHash(n.snapshotSigner, block.Hash().Bytes())
 	if err != nil {
 		log.Error("failed to get signature for block", "err", err)
 		return false
 	}
-	err = storeBlockSignature(batch, block.NumberU64(), blockSignature)
+	err = storeBlockSignature(batch, block.Hash(), blockSignature)
 	if err != nil {
 		log.Error("failed to store signature for block", "err", err)
 		return false
@@ -456,34 +444,18 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 	currentBlock := n.executionEngine.Bc().GetBlock(currentBlockHeader.Hash(), currentBlockHeader.Number.Uint64())
 
 	if n.configFetcher().EspressoTeeType != "" && currentBlock.NumberU64() > 0 {
-		blockhash, err := getHashOverInterface(currentBlock)
-		if err != nil {
-			log.Error("failed to get hash of current block", "err", err)
-			return fmt.Errorf("failed to get hash of current block: %w", err)
-		}
+		blockhash := currentBlock.Hash()
 
 		// Get the block signature
-		blockSignature, err := getBlockSignature(n.db, currentBlock.NumberU64())
+		blockSignature, err := getBlockSignature(n.db, blockhash)
 		if err != nil {
 			return fmt.Errorf("failed to get block signature: %w", err)
 		}
 
-		publicKeyBytes, err := crypto.Ecrecover(blockhash, blockSignature)
+		err = verifySignature(n.db, blockSignature, blockhash.Bytes(), *n.snapshotSignerAddress)
 		if err != nil {
-			return fmt.Errorf("failed to recover public key from signature: %w", err)
+			return fmt.Errorf("failed to verify block signature: %w", err)
 		}
-		pubKey, err := crypto.UnmarshalPubkey(publicKeyBytes)
-		if err != nil || pubKey == nil {
-			return fmt.Errorf("failed to unmarshal public key: %w", err)
-		}
-		// Public Key to address
-		publicKeyAddress := crypto.PubkeyToAddress(*pubKey)
-		// TODO: In follow up PRs, we should allows any valid PCR0 address registered in the contract
-		// to be able to decrypt the snapshot
-		if publicKeyAddress != *n.snapshotAddress {
-			return fmt.Errorf("snapshot address does not match from address")
-		}
-
 	}
 
 	// TODO: In follow up PRs, think about how to handle the case when on initial startup we dont have a signature over the
@@ -511,20 +483,9 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 				return fmt.Errorf("failed to get hash of hotshot block: %w", err)
 			}
 
-			publicKeyBytes, err := crypto.Ecrecover(hotshotBlockHash, nextHotshotBlockSignature)
+			err = verifySignature(n.db, nextHotshotBlockSignature, hotshotBlockHash, *n.snapshotSignerAddress)
 			if err != nil {
-				return fmt.Errorf("failed to recover public key from signature for hotshot block: %w", err)
-			}
-			pubKey, err := crypto.UnmarshalPubkey(publicKeyBytes)
-			if err != nil || pubKey == nil {
-				return fmt.Errorf("failed to unmarshal public key for hotshot block: %w", err)
-			}
-			// Public Key to address
-			publicKeyAddress := crypto.PubkeyToAddress(*pubKey)
-			// TODO: In follow up PRs, we should allows any valid PCR0 address registered in the contract
-			// to be able to decrypt the snapshot
-			if publicKeyAddress != *n.snapshotAddress {
-				return fmt.Errorf("public key address does not match from address for hotshot block")
+				return fmt.Errorf("failed to verify signature for hotshot block: %w", err)
 			}
 		}
 	}

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -2,7 +2,6 @@ package arbnode
 
 import (
 	"context"
-	"crypto/ecdsa"
 	"errors"
 	"fmt"
 	"path"
@@ -128,10 +127,10 @@ type EspressoCaffNodeConfigFetcher func() *EspressoCaffNodeConfig
 type EspressoCaffNode struct {
 	stopwaiter.StopWaiter
 
-	executionEngine   *gethexec.ExecutionEngine
-	snapshotPublicKey *ecdsa.PublicKey
-	snapshotSigner    signature.DataSignerFunc
-	espressoStreamer  espressostreamer.EspressoStreamerInterface
+	executionEngine  *gethexec.ExecutionEngine
+	snapshotAddress  *common.Address
+	snapshotSigner   signature.DataSignerFunc
+	espressoStreamer espressostreamer.EspressoStreamerInterface
 
 	configFetcher EspressoCaffNodeConfigFetcher
 	db            ethdb.Database
@@ -149,7 +148,7 @@ type EspressoCaffNode struct {
 
 func NewEspressoCaffNode(
 	configFetcher EspressoCaffNodeConfigFetcher,
-	snapshotPublicKey *ecdsa.PublicKey,
+	snapshotAddress *common.Address,
 	snapshotSigner signature.DataSignerFunc,
 	execEngine *gethexec.ExecutionEngine,
 	delayedBridge *DelayedBridge,
@@ -170,8 +169,8 @@ func NewEspressoCaffNode(
 	}
 
 	if configFetcher().EspressoTeeType != "" {
-		// Check that snapsnotSigner and snapshotPublicKey are not nil
-		if snapshotSigner == nil || snapshotPublicKey == nil {
+		// Check that snapsnotSigner is not nil
+		if snapshotSigner == nil || snapshotAddress == nil {
 			return nil, fmt.Errorf("snapshotSigner and snapshotPublicKey are required for espresso tee type")
 		}
 	}
@@ -219,14 +218,21 @@ func NewEspressoCaffNode(
 			if err != nil {
 				return nil, fmt.Errorf("failed to get hash of from block: %w", err)
 			}
-			// By default, the signature is 65 bytes which contains R, S, V but VerifySignature expects 64 bytes
-			// so we need to strip V which is the last byte
-			if len(fromBlockSignature) > 64 {
-				fromBlockSignature = fromBlockSignature[:64]
+
+			publicKeyBytes, err := crypto.Ecrecover(fromBlockHash, fromBlockSignature)
+			if err != nil {
+				return nil, fmt.Errorf("failed to recover public key from signature: %w", err)
 			}
-			publicKeyBytes := crypto.FromECDSAPub(snapshotPublicKey)
-			if !(crypto.VerifySignature(publicKeyBytes, fromBlockHash, fromBlockSignature)) {
-				return nil, fmt.Errorf("failed to verify signature over from block")
+			pubKey, err := crypto.UnmarshalPubkey(publicKeyBytes)
+			if err != nil || pubKey == nil {
+				return nil, fmt.Errorf("failed to unmarshal public key: %w", err)
+			}
+			// Public Key to address
+			publicKeyAddress := crypto.PubkeyToAddress(*pubKey)
+			// TODO: In follow up PRs, we should allows any valid PCR0 address registered in the contract
+			// to be able to decrypt the snapshot
+			if publicKeyAddress != *snapshotAddress {
+				return nil, fmt.Errorf("public key address does not match from address")
 			}
 		}
 	}
@@ -262,7 +268,7 @@ func NewEspressoCaffNode(
 	return &EspressoCaffNode{
 		configFetcher:         configFetcher,
 		executionEngine:       execEngine,
-		snapshotPublicKey:     snapshotPublicKey,
+		snapshotAddress:       snapshotAddress,
 		snapshotSigner:        snapshotSigner,
 		delayedMessageFetcher: delayedMessageFetcher,
 		espressoStreamer:      espressoStreamer,
@@ -456,23 +462,32 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 			return fmt.Errorf("failed to get hash of current block: %w", err)
 		}
 
-		publicKeyBytes := crypto.FromECDSAPub(n.snapshotPublicKey)
-
 		// Get the block signature
 		blockSignature, err := getBlockSignature(n.db, currentBlock.NumberU64())
 		if err != nil {
 			return fmt.Errorf("failed to get block signature: %w", err)
 		}
-		// By default, the signature is 65 bytes which contains R, S, V but VerifySignature expects 64 bytes
-		// so we need to strip V which is the last byte
-		if len(blockSignature) > 64 {
-			blockSignature = blockSignature[:64]
+
+		publicKeyBytes, err := crypto.Ecrecover(blockhash, blockSignature)
+		if err != nil {
+			return fmt.Errorf("failed to recover public key from signature: %w", err)
 		}
-		if !crypto.VerifySignature(publicKeyBytes, blockhash, blockSignature) {
-			return fmt.Errorf("failed to verify signature over the stored current block")
+		pubKey, err := crypto.UnmarshalPubkey(publicKeyBytes)
+		if err != nil || pubKey == nil {
+			return fmt.Errorf("failed to unmarshal public key: %w", err)
 		}
+		// Public Key to address
+		publicKeyAddress := crypto.PubkeyToAddress(*pubKey)
+		// TODO: In follow up PRs, we should allows any valid PCR0 address registered in the contract
+		// to be able to decrypt the snapshot
+		if publicKeyAddress != *n.snapshotAddress {
+			return fmt.Errorf("snapshot address does not match from address")
+		}
+
 	}
 
+	// TODO: In follow up PRs, think about how to handle the case when on initial startup we dont have a signature over the
+	// from block?
 	n.currentBlock = currentBlock
 
 	currentBlockNum := currentBlockHeader.Number.Uint64() + 1
@@ -495,14 +510,21 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("failed to get hash of hotshot block: %w", err)
 			}
-			publicKeyBytes := crypto.FromECDSAPub(n.snapshotPublicKey)
-			// By default, the signature is 65 bytes which contains R, S, V but VerifySignature expects 64 bytes
-			// so we need to strip V which is the last byte
-			if len(nextHotshotBlockSignature) > 64 {
-				nextHotshotBlockSignature = nextHotshotBlockSignature[:64]
+
+			publicKeyBytes, err := crypto.Ecrecover(hotshotBlockHash, nextHotshotBlockSignature)
+			if err != nil {
+				return fmt.Errorf("failed to recover public key from signature for hotshot block: %w", err)
 			}
-			if !crypto.VerifySignature(publicKeyBytes, hotshotBlockHash, nextHotshotBlockSignature) {
-				return fmt.Errorf("failed to verify signature over hotshot block number")
+			pubKey, err := crypto.UnmarshalPubkey(publicKeyBytes)
+			if err != nil || pubKey == nil {
+				return fmt.Errorf("failed to unmarshal public key for hotshot block: %w", err)
+			}
+			// Public Key to address
+			publicKeyAddress := crypto.PubkeyToAddress(*pubKey)
+			// TODO: In follow up PRs, we should allows any valid PCR0 address registered in the contract
+			// to be able to decrypt the snapshot
+			if publicKeyAddress != *n.snapshotAddress {
+				return fmt.Errorf("public key address does not match from address for hotshot block")
 			}
 		}
 	}

--- a/arbnode/espresso_caff_node_test.go
+++ b/arbnode/espresso_caff_node_test.go
@@ -80,7 +80,11 @@ func (m *MockEspressoStreamer) Reset(currentMessagePos uint64, currentHostshotBl
 func (m *MockEspressoStreamer) RecordTimeDurationBetweenHotshotAndCurrentBlock(nextHotshotBlock uint64, blockProductionTime time.Time) {
 }
 
-func (m *MockEspressoStreamer) StoreHotshotBlock(db ethdb.Database, nextHotshotBlock uint64) error {
+func (m *MockEspressoStreamer) StoreHotshotBlock(batch ethdb.Batch, nextHotshotBlock uint64) error {
+	return nil
+}
+
+func (m *MockEspressoStreamer) StoreHotshotBlockWithSignature(batch ethdb.Batch, nextHotshotBlock uint64, signature []byte) error {
 	return nil
 }
 
@@ -95,7 +99,7 @@ func (m *MockDelayedMessageFetcher) getDelayedMessageLatestIndexAtBlock(blockNum
 	return 1, nil
 }
 
-func (m *MockDelayedMessageFetcher) processDelayedMessage(messageWithMetadataAndPos *espressostreamer.MessageWithMetadataAndPos) (*espressostreamer.MessageWithMetadataAndPos, error) {
+func (m *MockDelayedMessageFetcher) processDelayedMessage(messageWithMetadataAndPos *espressostreamer.MessageWithMetadataAndPos) (*espressostreamer.MessageWithMetadataAndPos, uint64, error) {
 	if messageWithMetadataAndPos.MessageWithMeta.DelayedMessagesRead == 2 {
 		return &espressostreamer.MessageWithMetadataAndPos{
 			MessageWithMeta: arbostypes.MessageWithMetadata{
@@ -104,17 +108,17 @@ func (m *MockDelayedMessageFetcher) processDelayedMessage(messageWithMetadataAnd
 			},
 			Pos:           messageWithMetadataAndPos.Pos,
 			HotshotHeight: messageWithMetadataAndPos.HotshotHeight,
-		}, nil
+		}, 0, nil
 	}
-	return messageWithMetadataAndPos, nil
+	return messageWithMetadataAndPos, 0, nil
 }
 
 func (m *MockDelayedMessageFetcher) Start(ctx context.Context) bool {
 	return true
 }
 
-func (m *MockDelayedMessageFetcher) storeDelayedMessageLatestIndex(db ethdb.Database, count uint64) error {
-	return nil
+func (m *MockDelayedMessageFetcher) storeDelayedMessageLatestIndex(count uint64) {
+	return
 }
 
 func TestEspressoCaffNodeShouldReadDelayedMessageFromL1(t *testing.T) {
@@ -151,7 +155,7 @@ func TestEspressoCaffNodeShouldReadDelayedMessageFromL1(t *testing.T) {
 	caffNode.espressoStreamer = &MockEspressoStreamer{delayedPos: 3, currPos: 0}
 	caffNode.delayedMessageFetcher = &MockDelayedMessageFetcher{}
 	ctx := context.Background()
-	msg1, err := caffNode.peekMessage(ctx)
+	msg1, _, err := caffNode.peekMessage(ctx)
 	require.NoError(t, err)
 
 	require.Equal(t, msg1.MessageWithMeta.DelayedMessagesRead, uint64(1))
@@ -159,21 +163,21 @@ func TestEspressoCaffNodeShouldReadDelayedMessageFromL1(t *testing.T) {
 	require.Equal(t, msg1.Pos, uint64(0))
 	caffNode.espressoStreamer.Advance()
 
-	msg2, err := caffNode.peekMessage(ctx)
+	msg2, _, err := caffNode.peekMessage(ctx)
 	require.NoError(t, err)
 	require.Equal(t, msg2.MessageWithMeta.DelayedMessagesRead, uint64(1))
 	require.Equal(t, msg2.MessageWithMeta.Message, &arbostypes.EmptyTestIncomingMessage)
 	require.Equal(t, msg2.Pos, uint64(1))
 	caffNode.espressoStreamer.Advance()
 
-	msg3, err := caffNode.peekMessage(ctx)
+	msg3, _, err := caffNode.peekMessage(ctx)
 	require.NoError(t, err)
 	require.Equal(t, msg3.MessageWithMeta.DelayedMessagesRead, uint64(1))
 	require.Equal(t, msg3.MessageWithMeta.Message, &arbostypes.EmptyTestIncomingMessage)
 	require.Equal(t, msg3.Pos, uint64(2))
 	caffNode.espressoStreamer.Advance()
 
-	msg4, err := caffNode.peekMessage(ctx)
+	msg4, _, err := caffNode.peekMessage(ctx)
 	require.NoError(t, err)
 	require.Equal(t, msg4.MessageWithMeta.DelayedMessagesRead, uint64(2))
 	require.Equal(t, msg4.MessageWithMeta.Message, arbostypes.InvalidL1Message)

--- a/arbnode/espresso_caff_node_test.go
+++ b/arbnode/espresso_caff_node_test.go
@@ -88,8 +88,8 @@ func (m *MockEspressoStreamer) StoreHotshotBlockWithSignature(batch ethdb.Batch,
 	return nil
 }
 
-func (m *MockEspressoStreamer) ReadNextHotshotBlockFromDb(db ethdb.Database) (uint64, error) {
-	return m.dbHotShot, nil
+func (m *MockEspressoStreamer) ReadNextHotshotBlockFromDb(ethdb.Database) (uint64, []byte, error) {
+	return m.dbHotShot, nil, nil
 }
 
 type MockDelayedMessageFetcher struct{}

--- a/arbnode/espresso_caff_node_test.go
+++ b/arbnode/espresso_caff_node_test.go
@@ -30,6 +30,11 @@ type MockEspressoStreamer struct {
 	dbHotShot  uint64
 }
 
+// StopAndWait implements espressostreamer.EspressoStreamerInterface.
+func (m *MockEspressoStreamer) StopAndWait() {
+	panic("unimplemented")
+}
+
 var _ espressostreamer.EspressoStreamerInterface = (*MockEspressoStreamer)(nil)
 
 // SetBatcherAddressesFetcher implements espressostreamer.EspressoStreamerInterface.
@@ -118,6 +123,10 @@ func (m *MockDelayedMessageFetcher) Start(ctx context.Context) bool {
 }
 
 func (m *MockDelayedMessageFetcher) storeDelayedMessageLatestIndex(count uint64) {
+	return
+}
+
+func (m *MockDelayedMessageFetcher) StopAndWait() {
 	return
 }
 

--- a/arbnode/espresso_delayed_message_fetcher.go
+++ b/arbnode/espresso_delayed_message_fetcher.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/offchainlabs/nitro/espressostreamer"
+	"github.com/offchainlabs/nitro/util/dbutil"
 	"github.com/offchainlabs/nitro/util/headerreader"
 	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
@@ -137,7 +138,6 @@ func (d *DelayedMessageFetcher) processNewHeader(ctx context.Context, header *ty
 	if endBlock == 0 {
 		return nil
 	}
-	batch := d.db.NewBatch()
 
 	// Get the from block from the database
 	fromBlock := d.fromBlock
@@ -148,7 +148,6 @@ func (d *DelayedMessageFetcher) processNewHeader(ctx context.Context, header *ty
 		return err
 	}
 
-	err = batch.Write()
 	if err != nil {
 		return err
 	}
@@ -188,8 +187,11 @@ Reads the "current from" block from the database.
 func readCurrentFromBlockFromDb(db ethdb.Database) (uint64, []byte, error) {
 	var blockNumber uint64
 	blockNumberBytes, err := db.Get([]byte(DelayedFetcherCurrentFromBlockKey))
-	if err != nil {
+	if err != nil && !dbutil.IsErrNotFound(err) {
 		return 0, nil, fmt.Errorf("failed to get next from block: %w", err)
+	}
+	if dbutil.IsErrNotFound(err) {
+		return 0, nil, nil
 	}
 	if blockNumberBytes != nil {
 		err = rlp.DecodeBytes(blockNumberBytes, &blockNumber)
@@ -355,6 +357,7 @@ func (d *DelayedMessageFetcher) getDelayedMessagesInRange(ctx context.Context, f
 		}
 
 		lastDelayedMessageIndex++
+
 		d.delayedMessages[lastDelayedMessageIndex] = msg
 		d.delayedMessagesFromBlock[lastDelayedMessageIndex] = fromBlock
 	}
@@ -416,17 +419,18 @@ func NewDelayedMessageFetcher(
 	sequencerInbox *SequencerInbox,
 	fatalErrChan chan error,
 ) *DelayedMessageFetcher {
-
 	return &DelayedMessageFetcher{
-		fromBlock:            fromBlock,
-		delayedBridge:        delayedBridge,
-		l1Reader:             l1Reader,
-		waitForFinalization:  waitForFinalization,
-		waitForConfirmations: waitForConfirmations,
-		requiredBlockDepth:   requiredBlockDepth,
-		maxBlocksToRead:      blocksToRead,
-		sequencerInbox:       sequencerInbox,
-		fatalErrChan:         fatalErrChan,
+		fromBlock:                fromBlock,
+		delayedBridge:            delayedBridge,
+		l1Reader:                 l1Reader,
+		waitForFinalization:      waitForFinalization,
+		waitForConfirmations:     waitForConfirmations,
+		requiredBlockDepth:       requiredBlockDepth,
+		maxBlocksToRead:          blocksToRead,
+		sequencerInbox:           sequencerInbox,
+		fatalErrChan:             fatalErrChan,
+		delayedMessages:          make(map[uint64]*DelayedInboxMessage),
+		delayedMessagesFromBlock: make(map[uint64]uint64),
 	}
 }
 

--- a/arbnode/espresso_delayed_message_fetcher.go
+++ b/arbnode/espresso_delayed_message_fetcher.go
@@ -207,25 +207,10 @@ func readCurrentFromBlockFromDb(db ethdb.Database) (uint64, []byte, error) {
 	return blockNumber, fromBlockSignatureBytes, nil
 }
 
-func storeFromBlockWithSignature(batch ethdb.Batch, fromBlock uint64, fromBlockSignature []byte) error {
-
-	blockNumberBytes, err := rlp.EncodeToBytes(fromBlock)
-	if err != nil {
-		return fmt.Errorf("failed to encode next from block: %w", err)
-	}
-	if err := batch.Put(DelayedFetcherCurrentFromBlockKey, blockNumberBytes); err != nil {
-		return fmt.Errorf("failed to put from block: %w", err)
-	}
-
-	return batch.Put(DelayedFetcherCurrentFromBlockSignatureKey, fromBlockSignature)
-}
-
 /*
 Reads the delayed message from the database
 */
-func (f *DelayedMessageFetcher) readDelayedMessageAndFromBlock(seqNum uint64) (*DelayedInboxMessage, uint64, error) {
-	key := seqNum
-
+func (f *DelayedMessageFetcher) readDelayedMessageAndFromBlock(key uint64) (*DelayedInboxMessage, uint64, error) {
 	if _, ok := f.delayedMessages[key]; !ok {
 		return nil, 0, fmt.Errorf("delayed message not found")
 	}

--- a/arbnode/espresso_delayed_message_fetcher.go
+++ b/arbnode/espresso_delayed_message_fetcher.go
@@ -2,10 +2,12 @@ package arbnode
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -17,8 +19,9 @@ import (
 )
 
 var (
-	DelayedFetcherCurrentFromBlockKey = []byte("espressoDelayedFetcherCurrentFromBlock")
-	DelayedMessageCountKey            = []byte("espressoDelayedMessageCount")
+	DelayedFetcherCurrentFromBlockKey          = []byte("espressoDelayedFetcherCurrentFromBlock")
+	DelayedFetcherCurrentFromBlockSignatureKey = []byte("espressoDelayedFetcherCurrentFromBlockSignature")
+	DelayedMessageCountKey                     = []byte("espressoDelayedMessageCount")
 	// To not to mess with the existing schema, we use another prefix
 	DelayedMessagePrefix = []byte("espressoDelayed")
 )
@@ -26,22 +29,25 @@ var (
 type DelayedMessageFetcher struct {
 	stopwaiter.StopWaiter
 
-	fromBlock            uint64
-	delayedBridge        *DelayedBridge
-	sequencerInbox       *SequencerInbox
-	l1Reader             *headerreader.HeaderReader
-	maxBlocksToRead      uint64
-	db                   ethdb.Database
-	waitForFinalization  bool
-	waitForConfirmations bool
-	requiredBlockDepth   uint64
-	fatalErrChan         chan error
+	fromBlock                uint64
+	delayedBridge            *DelayedBridge
+	sequencerInbox           *SequencerInbox
+	l1Reader                 *headerreader.HeaderReader
+	maxBlocksToRead          uint64
+	db                       ethdb.Database
+	waitForFinalization      bool
+	waitForConfirmations     bool
+	requiredBlockDepth       uint64
+	fatalErrChan             chan error
+	delayedCount             uint64
+	delayedMessages          map[uint64]*DelayedInboxMessage
+	delayedMessagesFromBlock map[uint64]uint64
 }
 
 type DelayedMessageFetcherInterface interface {
 	Start(ctx context.Context) bool
-	storeDelayedMessageLatestIndex(db ethdb.Database, count uint64) error
-	processDelayedMessage(messageWithMetadataAndPos *espressostreamer.MessageWithMetadataAndPos) (*espressostreamer.MessageWithMetadataAndPos, error)
+	storeDelayedMessageLatestIndex(count uint64)
+	processDelayedMessage(messageWithMetadataAndPos *espressostreamer.MessageWithMetadataAndPos) (*espressostreamer.MessageWithMetadataAndPos, uint64, error)
 	getDelayedMessageLatestIndexAtBlock(blockNumber uint64) (uint64, error)
 }
 
@@ -49,7 +55,6 @@ var _ DelayedMessageFetcherInterface = new(DelayedMessageFetcher)
 
 /*
 backfill fetches all delayed messages until `matureL1Block` which is within the safety tolerance of the rollup
-and stores them in the database
 */
 func (d *DelayedMessageFetcher) backfill(ctx context.Context) error {
 	// Get the l1 block number based on the read mode
@@ -59,13 +64,8 @@ func (d *DelayedMessageFetcher) backfill(ctx context.Context) error {
 		return err
 	}
 
-	// Get the from block number from the delayed message fetcher
-	// config. Note: Its important in the first read we read from the config
-	// and not the database because the user might want to start reading from a `fromBlock`
-	// which is before the delayed message number stored in the database
 	fromBlock := d.fromBlock
 	log.Info("backfilling delayed messages", "fromBlock", fromBlock, "matureL1Block", matureL1Block)
-	batch := d.db.NewBatch()
 
 	// Loop through the blocks until we reach the matureL1Block
 	for fromBlock < matureL1Block {
@@ -76,17 +76,12 @@ func (d *DelayedMessageFetcher) backfill(ctx context.Context) error {
 			toBlock = fromBlock + d.maxBlocksToRead
 		}
 
-		err := d.getDelayedMessagesInRange(ctx, batch, fromBlock, toBlock)
+		err := d.getDelayedMessagesInRange(ctx, fromBlock, toBlock)
 		if err != nil {
 			log.Error("failed to get delayed messages in range", "err", err, "fromBlock", fromBlock, "endBlock", toBlock)
 			return err
 		}
 		fromBlock = toBlock + 1
-	}
-
-	err = batch.Write()
-	if err != nil {
-		return err
 	}
 
 	log.Info("Backfilled delayed messages")
@@ -146,13 +141,9 @@ func (d *DelayedMessageFetcher) processNewHeader(ctx context.Context, header *ty
 	batch := d.db.NewBatch()
 
 	// Get the from block from the database
-	fromBlock, err := readCurrentFromBlockFromDb(d.db)
-	if err != nil {
-		log.Error("failed to read from block from db", "err", err)
-		return err
-	}
+	fromBlock := d.fromBlock
 	log.Debug("getting delayed messages in range", "fromBlock", fromBlock, "endBlock", endBlock)
-	err = d.getDelayedMessagesInRange(ctx, batch, fromBlock, endBlock)
+	err = d.getDelayedMessagesInRange(ctx, fromBlock, endBlock)
 	if err != nil {
 		log.Error("failed to get delayed messages in range", "err", err, "fromBlock", fromBlock, "endBlock", endBlock)
 		return err
@@ -166,39 +157,31 @@ func (d *DelayedMessageFetcher) processNewHeader(ctx context.Context, header *ty
 	return nil
 }
 
-func (f *DelayedMessageFetcher) processDelayedMessage(messageWithMetadataAndPos *espressostreamer.MessageWithMetadataAndPos) (*espressostreamer.MessageWithMetadataAndPos, error) {
+func (d *DelayedMessageFetcher) processDelayedMessage(messageWithMetadataAndPos *espressostreamer.MessageWithMetadataAndPos) (*espressostreamer.MessageWithMetadataAndPos, uint64, error) {
 	delayedMessagesRead := messageWithMetadataAndPos.MessageWithMeta.DelayedMessagesRead
 
-	// Get the delayed message count store in the database
-	delayedCount, err := getDelayedMessageLatestIndex(f.db)
-	if err != nil {
-		log.Error("Failed to get delayed message count from db", "err", err)
-		return nil, err
-	}
-
+	delayedCount := d.delayedCount
 	// If this is delayed message, we need to get the message from L1
 	// and replace the message in the messageWithMetadataAndPos
 	delayedMessageToProcess := delayedMessagesRead - 1
 
 	if delayedMessageToProcess > delayedCount {
 		log.Warn("delayed message fetcher is lagging behind", "delayedMessagesRead", delayedMessagesRead, "delayedCount", delayedCount)
-		return nil, fmt.Errorf("delayed message fetcher is lagging behind")
+		return nil, 0, fmt.Errorf("delayed message fetcher is lagging behind")
 	}
 	log.Debug("Getting delayed message", "delayedCount", delayedMessageToProcess)
 
 	// Note: here we are using DelayedMessagesRead - 1 because that is the index of the delayed message
 	// that needs to be read
-	message, err := f.readDelayedMessage(delayedMessageToProcess)
+	message, fromBlock, err := d.readDelayedMessageAndFromBlock(delayedMessageToProcess)
 	if err != nil {
 		log.Error("failed to get delayed message", "err", err)
-		return messageWithMetadataAndPos, err
+		return messageWithMetadataAndPos, 0, err
 	}
 	messageWithMetadataAndPos.MessageWithMeta.Message = message.Message
 
-	return messageWithMetadataAndPos, nil
+	return messageWithMetadataAndPos, fromBlock, nil
 }
-
-/***** Getter Functions *****/
 
 /*
 Reads the "current from" block from the database.
@@ -207,33 +190,66 @@ func readCurrentFromBlockFromDb(db ethdb.Database) (uint64, error) {
 	var blockNumber uint64
 	blockNumberBytes, err := db.Get([]byte(DelayedFetcherCurrentFromBlockKey))
 	if err != nil && !dbutil.IsErrNotFound(err) {
-		return 0, fmt.Errorf("failed to get next hotshot block: %w", err)
+		return 0, fmt.Errorf("failed to get next from block: %w", err)
 	}
 	if blockNumberBytes != nil {
 		err = rlp.DecodeBytes(blockNumberBytes, &blockNumber)
 		if err != nil {
-			return 0, fmt.Errorf("failed to decode next hotshot block: %w", err)
+			return 0, fmt.Errorf("failed to decode next from block: %w", err)
+		}
+	}
+
+	fromBlockBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(fromBlockBytes, blockNumber)
+	blockNumberHash := crypto.Keccak256Hash(fromBlockBytes)
+
+	// Also get the signature and check that signaure is valid
+	fromBlockSignatureBytes, err := db.Get(DelayedFetcherCurrentFromBlockSignatureKey)
+	if err != nil && !dbutil.IsErrNotFound(err) {
+		return 0, fmt.Errorf("failed to get next from block signature: %w", err)
+	}
+	if fromBlockSignatureBytes != nil {
+		var fromBlockSignature []byte
+		err = rlp.DecodeBytes(fromBlockSignatureBytes, &fromBlockSignature)
+		if err != nil {
+			return 0, fmt.Errorf("failed to decode next from block signature: %w", err)
+		}
+		if !crypto.VerifySignature(fromBlockSignature, blockNumberHash.Bytes(), fromBlockSignature) {
+			return 0, fmt.Errorf("invalid signature for from block %d", blockNumber)
 		}
 	}
 
 	return blockNumber, nil
 }
 
+func storeFromBlockWithSignature(batch ethdb.Batch, fromBlock uint64, fromBlockSignature []byte) error {
+
+	if err := batch.Put(DelayedFetcherCurrentFromBlockKey, uint64ToKey(fromBlock)); err != nil {
+		return fmt.Errorf("failed to put from block: %w", err)
+	}
+	encodedFromBlockSignature, err := rlp.EncodeToBytes(fromBlockSignature)
+	if err != nil {
+		return fmt.Errorf("failed to encode from block signature: %w", err)
+	}
+
+	return batch.Put(DelayedFetcherCurrentFromBlockSignatureKey, encodedFromBlockSignature)
+}
+
 /*
 Reads the delayed message from the database
 */
-func (f *DelayedMessageFetcher) readDelayedMessage(seqNum uint64) (*DelayedInboxMessage, error) {
-	key := dbKey(DelayedMessagePrefix, seqNum)
-	encodedMsg, err := f.db.Get(key)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get delayed message: %w", err)
+func (f *DelayedMessageFetcher) readDelayedMessageAndFromBlock(seqNum uint64) (*DelayedInboxMessage, uint64, error) {
+	key := seqNum
+
+	if _, ok := f.delayedMessages[key]; !ok {
+		return nil, 0, fmt.Errorf("delayed message not found")
 	}
-	var msg DelayedInboxMessage
-	err = rlp.DecodeBytes(encodedMsg, &msg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode delayed message: %w", err)
+	delayedMessage := f.delayedMessages[key]
+	if _, ok := f.delayedMessagesFromBlock[key]; !ok {
+		return nil, 0, fmt.Errorf("delayed message from block not found")
 	}
-	return &msg, nil
+	delayedMessageFromBlock := f.delayedMessagesFromBlock[key]
+	return delayedMessage, delayedMessageFromBlock, nil
 }
 
 /*
@@ -280,21 +296,21 @@ func (f *DelayedMessageFetcher) getDelayedMessageLatestIndexAtBlock(blockNumber 
 getDelayedMessagedInRange fetches all the delayed messages in the range [startBlock, endBlock]
 and stores them in the database
 */
-func (d *DelayedMessageFetcher) getDelayedMessagesInRange(ctx context.Context, batch ethdb.Batch, startBlock uint64, toBlock uint64) error {
+func (d *DelayedMessageFetcher) getDelayedMessagesInRange(ctx context.Context, fromBlock uint64, toBlock uint64) error {
 
 	// Fetching the sequencer batches is important so that we can later parse the batch and get the sequencer batch data to store in the database
-	log.Debug("Looking for batches in range", "from", startBlock, "to", toBlock)
-	startBlockBigInt := big.NewInt(0).SetUint64(startBlock)
+	log.Debug("Looking for batches in range", "from", fromBlock, "to", toBlock)
+	fromBlockBigInt := big.NewInt(0).SetUint64(fromBlock)
 	toBlockBigInt := big.NewInt(0).SetUint64(toBlock)
 
-	sequencerBatches, err := d.sequencerInbox.LookupBatchesInRange(ctx, startBlockBigInt, toBlockBigInt)
+	sequencerBatches, err := d.sequencerInbox.LookupBatchesInRange(ctx, fromBlockBigInt, toBlockBigInt)
 	if err != nil {
 		return err
 	}
 	log.Debug("Sequencer batches found", "sequencerBatches", sequencerBatches)
 
-	log.Debug("Looking for delayed messages from range", "from", startBlock, "to", toBlock)
-	msgs, err := d.delayedBridge.LookupMessagesInRange(ctx, big.NewInt(0).SetUint64(startBlock), big.NewInt(0).SetUint64(toBlock), func(batchNum uint64) ([]byte, error) {
+	log.Debug("Looking for delayed messages from range", "from", fromBlock, "to", toBlock)
+	msgs, err := d.delayedBridge.LookupMessagesInRange(ctx, big.NewInt(0).SetUint64(fromBlock), big.NewInt(0).SetUint64(toBlock), func(batchNum uint64) ([]byte, error) {
 		if len(sequencerBatches) > 0 && batchNum >= sequencerBatches[0].SequenceNumber {
 			idx := batchNum - sequencerBatches[0].SequenceNumber
 			if idx < uint64(len(sequencerBatches)) {
@@ -312,12 +328,7 @@ func (d *DelayedMessageFetcher) getDelayedMessagesInRange(ctx context.Context, b
 
 	log.Debug("sequencer delayed messages found", "delayedMessages", msgs)
 
-	// Get the delayed message index stored in the database
-	lastDelayedMessageIndex, err := getDelayedMessageLatestIndex(d.db)
-	if err != nil {
-		log.Error("Failed to get delayed message index from db", "err", err)
-		return err
-	}
+	lastDelayedMessageIndex := d.delayedCount
 
 	for _, msg := range msgs {
 		seqNum, err := msg.Message.Header.SeqNum()
@@ -345,34 +356,14 @@ func (d *DelayedMessageFetcher) getDelayedMessagesInRange(ctx context.Context, b
 		}
 
 		lastDelayedMessageIndex++
-		err = d.storeDelayedMessage(batch, lastDelayedMessageIndex, *msg)
-		if err != nil {
-			return err
-		}
+		d.delayedMessages[lastDelayedMessageIndex] = msg
+		d.delayedMessagesFromBlock[lastDelayedMessageIndex] = fromBlock
 	}
 
 	// Store the from block in the database
-	err = storeCurrentFromBlock(batch, toBlock+1)
-	if err != nil {
-		log.Error("failed to store current from block", "err", err, "fromBlock", toBlock)
-		return err
-	}
+	d.fromBlock = toBlock + 1
 
 	return nil
-}
-
-// getDelayedMessageLatestIndex returns the delayed message index from the database
-func getDelayedMessageLatestIndex(db ethdb.Database) (uint64, error) {
-	var delayedCount uint64
-	delayedCountBytes, err := db.Get([]byte(DelayedMessageCountKey))
-	if err != nil {
-		return 0, fmt.Errorf("failed to get delayed message count: %w", err)
-	}
-	err = rlp.DecodeBytes(delayedCountBytes, &delayedCount)
-	if err != nil {
-		return 0, fmt.Errorf("failed to decode delayed message count: %w", err)
-	}
-	return delayedCount, nil
 }
 
 /*
@@ -382,10 +373,7 @@ getL1BlockWithinSafetyTolerance checks if the L1 block is within the safety tole
   - else - it returns the latest header
 */
 func (d *DelayedMessageFetcher) getL1BlockWithinSafetyTolerance(ctx context.Context, header *types.Header) (uint64, error) {
-	fromBlock, err := readCurrentFromBlockFromDb(d.db)
-	if err != nil {
-		return 0, fmt.Errorf("failed to read from block from db: %w", err)
-	}
+	fromBlock := d.fromBlock
 	// If we have already processed this header, we can skip it
 	if header.Number.Uint64() < fromBlock {
 		log.Warn("L1 block number is less than from block", "l1Block", header.Number.Uint64(), "fromBlock", fromBlock)
@@ -413,57 +401,14 @@ func (d *DelayedMessageFetcher) getL1BlockWithinSafetyTolerance(ctx context.Cont
 	return header.Number.Uint64(), nil
 }
 
-/***** Setter Functions *****/
-
-/*
-Stores the current from block in the database.
-*/
-func storeCurrentFromBlock(batch ethdb.Batch, fromBlock uint64) error {
-	blockNumberBytes, err := rlp.EncodeToBytes(fromBlock)
-	if err != nil {
-		return fmt.Errorf("failed to encode next from block: %w", err)
-	}
-
-	err = batch.Put([]byte(DelayedFetcherCurrentFromBlockKey), blockNumberBytes)
-	if err != nil {
-		return fmt.Errorf("failed to put next from block: %w", err)
-	}
-
-	return nil
-}
-
-/*
-Store the delayed message and delayed message count in the database
-*/
-func (f *DelayedMessageFetcher) storeDelayedMessage(batch ethdb.Batch, seqNum uint64, msg DelayedInboxMessage) error {
-	key := dbKey(DelayedMessagePrefix, seqNum)
-	encodedMsg, err := rlp.EncodeToBytes(msg)
-	if err != nil {
-		return fmt.Errorf("failed to encode delayed message: %w", err)
-	}
-	// Also update the delayed message count in the database
-	err = f.storeDelayedMessageLatestIndex(f.db, seqNum)
-	if err != nil {
-		return err
-	}
-	log.Debug("stored delayed message", "seqNum", seqNum)
-
-	return batch.Put(key, encodedMsg)
-}
-
 // storeDelayedMessageLatestIndex stores the delayed message index in the database
-func (f *DelayedMessageFetcher) storeDelayedMessageLatestIndex(db ethdb.Database, count uint64) error {
-	countBytes, err := rlp.EncodeToBytes(count)
-	if err != nil {
-		return fmt.Errorf("failed to encode delayed message count: %w", err)
-	}
-	return db.Put([]byte(DelayedMessageCountKey), countBytes)
+func (d *DelayedMessageFetcher) storeDelayedMessageLatestIndex(count uint64) {
+	d.delayedCount = count
 }
 
 func NewDelayedMessageFetcher(
 	delayedBridge *DelayedBridge,
 	l1Reader *headerreader.HeaderReader,
-	db ethdb.Database,
 	blocksToRead uint64,
 	waitForFinalization bool,
 	waitForConfirmations bool,
@@ -477,7 +422,6 @@ func NewDelayedMessageFetcher(
 		fromBlock:            fromBlock,
 		delayedBridge:        delayedBridge,
 		l1Reader:             l1Reader,
-		db:                   db,
 		waitForFinalization:  waitForFinalization,
 		waitForConfirmations: waitForConfirmations,
 		requiredBlockDepth:   requiredBlockDepth,

--- a/arbnode/espresso_delayed_message_fetcher.go
+++ b/arbnode/espresso_delayed_message_fetcher.go
@@ -336,6 +336,7 @@ func (d *DelayedMessageFetcher) getDelayedMessagesInRange(ctx context.Context, f
 		if err != nil {
 			return err
 		}
+		log.Info("Caff node: processing delayed message", "seqNum", seqNum)
 		if seqNum == 0 {
 			// init message
 			log.Debug("caff node: skip storing init message")
@@ -360,6 +361,7 @@ func (d *DelayedMessageFetcher) getDelayedMessagesInRange(ctx context.Context, f
 
 		d.delayedMessages[lastDelayedMessageIndex] = msg
 		d.delayedMessagesFromBlock[lastDelayedMessageIndex] = fromBlock
+		d.delayedCount += 1
 	}
 
 	// Store the from block in the database

--- a/arbnode/espresso_delayed_message_fetcher.go
+++ b/arbnode/espresso_delayed_message_fetcher.go
@@ -34,7 +34,6 @@ type DelayedMessageFetcher struct {
 	sequencerInbox           *SequencerInbox
 	l1Reader                 *headerreader.HeaderReader
 	maxBlocksToRead          uint64
-	db                       ethdb.Database
 	waitForFinalization      bool
 	waitForConfirmations     bool
 	requiredBlockDepth       uint64

--- a/arbnode/espresso_delayed_message_fetcher.go
+++ b/arbnode/espresso_delayed_message_fetcher.go
@@ -2,12 +2,10 @@ package arbnode
 
 import (
 	"context"
-	"encoding/binary"
 	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -48,6 +46,7 @@ type DelayedMessageFetcherInterface interface {
 	storeDelayedMessageLatestIndex(count uint64)
 	processDelayedMessage(messageWithMetadataAndPos *espressostreamer.MessageWithMetadataAndPos) (*espressostreamer.MessageWithMetadataAndPos, uint64, error)
 	getDelayedMessageLatestIndexAtBlock(blockNumber uint64) (uint64, error)
+	StopAndWait()
 }
 
 var _ DelayedMessageFetcherInterface = new(DelayedMessageFetcher)
@@ -147,10 +146,6 @@ func (d *DelayedMessageFetcher) processNewHeader(ctx context.Context, header *ty
 		return err
 	}
 
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -199,40 +194,30 @@ func readCurrentFromBlockFromDb(db ethdb.Database) (uint64, []byte, error) {
 		}
 	}
 
-	fromBlockBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(fromBlockBytes, blockNumber)
-	blockNumberHash := crypto.Keccak256Hash(fromBlockBytes)
-
 	// Also get the signature and check that signaure is valid
 	fromBlockSignatureBytes, err := db.Get(DelayedFetcherCurrentFromBlockSignatureKey)
-	if err != nil {
+	if err != nil && !dbutil.IsErrNotFound(err) {
 		return 0, nil, fmt.Errorf("failed to get next from block signature: %w", err)
 	}
-	if fromBlockSignatureBytes != nil {
-		var fromBlockSignature []byte
-		err = rlp.DecodeBytes(fromBlockSignatureBytes, &fromBlockSignature)
-		if err != nil {
-			return 0, nil, fmt.Errorf("failed to decode next from block signature: %w", err)
-		}
-		if !crypto.VerifySignature(fromBlockSignature, blockNumberHash.Bytes(), fromBlockSignature) {
-			return 0, nil, fmt.Errorf("invalid signature for from block %d", blockNumber)
-		}
+	if dbutil.IsErrNotFound(err) {
+		return 0, nil, nil
 	}
 
-	return blockNumber, nil, nil
+	log.Info("Read from block signature", "fromBlock", blockNumber, "fromBlockSignature", fromBlockSignatureBytes)
+	return blockNumber, fromBlockSignatureBytes, nil
 }
 
 func storeFromBlockWithSignature(batch ethdb.Batch, fromBlock uint64, fromBlockSignature []byte) error {
 
-	if err := batch.Put(DelayedFetcherCurrentFromBlockKey, uint64ToKey(fromBlock)); err != nil {
+	blockNumberBytes, err := rlp.EncodeToBytes(fromBlock)
+	if err != nil {
+		return fmt.Errorf("failed to encode next from block: %w", err)
+	}
+	if err := batch.Put(DelayedFetcherCurrentFromBlockKey, blockNumberBytes); err != nil {
 		return fmt.Errorf("failed to put from block: %w", err)
 	}
-	encodedFromBlockSignature, err := rlp.EncodeToBytes(fromBlockSignature)
-	if err != nil {
-		return fmt.Errorf("failed to encode from block signature: %w", err)
-	}
 
-	return batch.Put(DelayedFetcherCurrentFromBlockSignatureKey, encodedFromBlockSignature)
+	return batch.Put(DelayedFetcherCurrentFromBlockSignatureKey, fromBlockSignature)
 }
 
 /*
@@ -447,4 +432,8 @@ func (d *DelayedMessageFetcher) Start(ctx context.Context) bool {
 	}
 	d.startWatchDelayedMessages(ctx)
 	return true
+}
+
+func (d *DelayedMessageFetcher) StopAndWait() {
+	d.StopWaiter.StopAndWait()
 }

--- a/arbnode/espresso_delayed_message_fetcher.go
+++ b/arbnode/espresso_delayed_message_fetcher.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/offchainlabs/nitro/espressostreamer"
-	"github.com/offchainlabs/nitro/util/dbutil"
 	"github.com/offchainlabs/nitro/util/headerreader"
 	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
@@ -186,16 +185,16 @@ func (d *DelayedMessageFetcher) processDelayedMessage(messageWithMetadataAndPos 
 /*
 Reads the "current from" block from the database.
 */
-func readCurrentFromBlockFromDb(db ethdb.Database) (uint64, error) {
+func readCurrentFromBlockFromDb(db ethdb.Database) (uint64, []byte, error) {
 	var blockNumber uint64
 	blockNumberBytes, err := db.Get([]byte(DelayedFetcherCurrentFromBlockKey))
-	if err != nil && !dbutil.IsErrNotFound(err) {
-		return 0, fmt.Errorf("failed to get next from block: %w", err)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to get next from block: %w", err)
 	}
 	if blockNumberBytes != nil {
 		err = rlp.DecodeBytes(blockNumberBytes, &blockNumber)
 		if err != nil {
-			return 0, fmt.Errorf("failed to decode next from block: %w", err)
+			return 0, nil, fmt.Errorf("failed to decode next from block: %w", err)
 		}
 	}
 
@@ -205,21 +204,21 @@ func readCurrentFromBlockFromDb(db ethdb.Database) (uint64, error) {
 
 	// Also get the signature and check that signaure is valid
 	fromBlockSignatureBytes, err := db.Get(DelayedFetcherCurrentFromBlockSignatureKey)
-	if err != nil && !dbutil.IsErrNotFound(err) {
-		return 0, fmt.Errorf("failed to get next from block signature: %w", err)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to get next from block signature: %w", err)
 	}
 	if fromBlockSignatureBytes != nil {
 		var fromBlockSignature []byte
 		err = rlp.DecodeBytes(fromBlockSignatureBytes, &fromBlockSignature)
 		if err != nil {
-			return 0, fmt.Errorf("failed to decode next from block signature: %w", err)
+			return 0, nil, fmt.Errorf("failed to decode next from block signature: %w", err)
 		}
 		if !crypto.VerifySignature(fromBlockSignature, blockNumberHash.Bytes(), fromBlockSignature) {
-			return 0, fmt.Errorf("invalid signature for from block %d", blockNumber)
+			return 0, nil, fmt.Errorf("invalid signature for from block %d", blockNumber)
 		}
 	}
 
-	return blockNumber, nil
+	return blockNumber, nil, nil
 }
 
 func storeFromBlockWithSignature(batch ethdb.Batch, fromBlock uint64, fromBlockSignature []byte) error {

--- a/arbnode/espresso_force_inclusion_checker.go
+++ b/arbnode/espresso_force_inclusion_checker.go
@@ -254,3 +254,7 @@ func (f *ForceInclusionChecker) findFirstParentChainBlockBelow(ctx context.Conte
 	}
 	return 0, fmt.Errorf("no parent block found")
 }
+
+func (f *ForceInclusionChecker) StopAndWait() {
+	f.StopWaiter.StopAndWait()
+}

--- a/arbnode/espresso_utils.go
+++ b/arbnode/espresso_utils.go
@@ -3,6 +3,7 @@ package arbnode
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -79,29 +80,16 @@ func generateSignatureFromUint64(signer signature.DataSignerFunc, data uint64) (
 	return signature, nil
 }
 
-func generateSignatureOverInterface(signer signature.DataSignerFunc, data interface{}) ([]byte, error) {
+func generateSignatureOverHash(signer signature.DataSignerFunc, hash []byte) ([]byte, error) {
 	if signer == nil {
 		return nil, nil
 	}
-	hash, err := getHashOverInterface(data)
-	if err != nil {
-		return nil, err
-	}
+
 	signature, err := signer(hash)
 	if err != nil {
 		return nil, err
 	}
 	return signature, nil
-}
-
-func getHashOverInterface(data interface{}) ([]byte, error) {
-
-	dataBytes, err := rlp.EncodeToBytes(data)
-	if err != nil {
-		return nil, err
-	}
-	hash := crypto.Keccak256Hash(dataBytes)
-	return hash.Bytes(), nil
 }
 
 func getHashOverUint64(data uint64) ([]byte, error) {
@@ -111,12 +99,47 @@ func getHashOverUint64(data uint64) ([]byte, error) {
 	return hash.Bytes(), nil
 }
 
-func storeBlockSignature(batch ethdb.Batch, blockNumber uint64, blockSignature []byte) error {
+func storeBlockSignature(batch ethdb.Batch, blockHash common.Hash, blockSignature []byte) error {
+	blockNumber := binary.BigEndian.Uint64(blockHash.Bytes())
 	key := dbKey(BlockSignaturePrefix, (blockNumber))
 	return batch.Put(key, blockSignature)
 }
 
-func getBlockSignature(db ethdb.Database, blockNumber uint64) ([]byte, error) {
+func getBlockSignature(db ethdb.Database, blockHash common.Hash) ([]byte, error) {
+	blockNumber := binary.BigEndian.Uint64(blockHash.Bytes())
 	key := dbKey(BlockSignaturePrefix, (blockNumber))
 	return db.Get(key)
+}
+
+func storeFromBlockWithSignature(batch ethdb.Batch, fromBlock uint64, fromBlockSignature []byte) error {
+
+	blockNumberBytes, err := rlp.EncodeToBytes(fromBlock)
+	if err != nil {
+		return fmt.Errorf("failed to encode next from block: %w", err)
+	}
+	if err := batch.Put(DelayedFetcherCurrentFromBlockKey, blockNumberBytes); err != nil {
+		return fmt.Errorf("failed to put from block: %w", err)
+	}
+
+	return batch.Put(DelayedFetcherCurrentFromBlockSignatureKey, fromBlockSignature)
+}
+
+func verifySignature(db ethdb.Database, signature []byte, hash []byte, snapshotSignerAddress common.Address) error {
+	publicKeyBytes, err := crypto.Ecrecover(hash, signature)
+	if err != nil {
+		return fmt.Errorf("unable to recover public key")
+	}
+	pubKey, err := crypto.UnmarshalPubkey(publicKeyBytes)
+	if err != nil || pubKey == nil {
+		return fmt.Errorf("invalid public key")
+	}
+	// Public Key to address
+	publicKeyAddress := crypto.PubkeyToAddress(*pubKey)
+	// TODO: In follow up PRs, we should allows any valid PCR0 address registered in the contract
+	// to be able to decrypt the snapshot
+
+	if publicKeyAddress != snapshotSignerAddress {
+		return fmt.Errorf("invalid snapshot address")
+	}
+	return nil
 }

--- a/arbnode/espresso_utils.go
+++ b/arbnode/espresso_utils.go
@@ -63,7 +63,7 @@ func recoverAddressFromSigner(signer signature.DataSignerFunc) (common.Address, 
 	return crypto.PubkeyToAddress(*publicKey), nil
 }
 
-// Create a signatue over a uint64 value given a signer
+// Create a signature over a uint64 value given a signer
 func generateSignatureFromUint64(signer signature.DataSignerFunc, data uint64) ([]byte, error) {
 	if signer == nil {
 		return nil, nil

--- a/arbnode/espresso_utils.go
+++ b/arbnode/espresso_utils.go
@@ -6,10 +6,13 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/offchainlabs/nitro/util/signature"
 )
+
+var BlockSignaturePrefix = []byte("blockSignature")
 
 var (
 	binarySearch_LessThanTarget    = -1
@@ -106,4 +109,14 @@ func getHashOverUint64(data uint64) ([]byte, error) {
 	binary.BigEndian.PutUint64(uintBytes, data)
 	hash := crypto.Keccak256Hash(uintBytes)
 	return hash.Bytes(), nil
+}
+
+func storeBlockSignature(batch ethdb.Batch, blockNumber uint64, blockSignature []byte) error {
+	key := dbKey(BlockSignaturePrefix, (blockNumber))
+	return batch.Put(key, blockSignature)
+}
+
+func getBlockSignature(db ethdb.Database, blockNumber uint64) ([]byte, error) {
+	key := dbKey(BlockSignaturePrefix, (blockNumber))
+	return db.Get(key)
 }

--- a/arbnode/espresso_utils.go
+++ b/arbnode/espresso_utils.go
@@ -2,9 +2,11 @@ package arbnode
 
 import (
 	"context"
+	"encoding/binary"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/offchainlabs/nitro/util/signature"
 )
@@ -56,4 +58,52 @@ func recoverAddressFromSigner(signer signature.DataSignerFunc) (common.Address, 
 	}
 
 	return crypto.PubkeyToAddress(*publicKey), nil
+}
+
+// Create a signatue over a uint64 value given a signer
+func generateSignatureFromUint64(signer signature.DataSignerFunc, data uint64) ([]byte, error) {
+	if signer == nil {
+		return nil, nil
+	}
+	hash, err := getHashOverUint64(data)
+	if err != nil {
+		return nil, err
+	}
+	signature, err := signer(hash)
+	if err != nil {
+		return nil, err
+	}
+	return signature, nil
+}
+
+func generateSignatureOverInterface(signer signature.DataSignerFunc, data interface{}) ([]byte, error) {
+	if signer == nil {
+		return nil, nil
+	}
+	hash, err := getHashOverInterface(data)
+	if err != nil {
+		return nil, err
+	}
+	signature, err := signer(hash)
+	if err != nil {
+		return nil, err
+	}
+	return signature, nil
+}
+
+func getHashOverInterface(data interface{}) ([]byte, error) {
+
+	dataBytes, err := rlp.EncodeToBytes(data)
+	if err != nil {
+		return nil, err
+	}
+	hash := crypto.Keccak256Hash(dataBytes)
+	return hash.Bytes(), nil
+}
+
+func getHashOverUint64(data uint64) ([]byte, error) {
+	uintBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(uintBytes, data)
+	hash := crypto.Keccak256Hash(uintBytes)
+	return hash.Bytes(), nil
 }

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1588,6 +1588,10 @@ func (n *Node) StopAndWait() {
 	if n.BlockValidator != nil && n.BlockValidator.Started() {
 		n.BlockValidator.StopAndWait()
 	}
+	if n.EspressoCaffNode != nil {
+		n.EspressoCaffNode.StopAndWait()
+	}
+
 	if n.Staker != nil {
 		n.Staker.StopAndWait()
 	}

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -965,7 +965,7 @@ func getEspressoCaffNode(
 	ctx context.Context,
 	config *Config,
 	configFetcher ConfigFetcher,
-	snapshotAddress *common.Address,
+	snapshotSignerAddress *common.Address,
 	snapshotSigner signature.DataSignerFunc,
 	arbDb ethdb.Database,
 	exec execution.ExecutionClient,
@@ -984,7 +984,7 @@ func getEspressoCaffNode(
 		if exec, ok := exec.(*gethexec.ExecutionNode); ok {
 			espressoCaffNode, err := NewEspressoCaffNode(
 				func() *EspressoCaffNodeConfig { return &config.EspressoCaffNode },
-				snapshotAddress,
+				snapshotSignerAddress,
 				snapshotSigner,
 				exec.ExecEngine,
 				delayedBridge,
@@ -1114,7 +1114,7 @@ func createNodeImpl(
 	txOptsValidator *bind.TransactOpts,
 	txOptsBatchPoster *bind.TransactOpts,
 	dataSigner signature.DataSignerFunc,
-	snapshotAddress *common.Address,
+	snapshotSignerAddress *common.Address,
 	snapshotSigner signature.DataSignerFunc,
 	fatalErrChan chan error,
 	parentChainID *big.Int,
@@ -1179,7 +1179,7 @@ func createNodeImpl(
 		return nil, err
 	}
 
-	caffNode, err := getEspressoCaffNode(ctx, config, configFetcher, snapshotAddress, snapshotSigner, arbDb, executionClient, l1Reader, txStreamer, blobReader, broadcastServer, broadcastClients, delayedBridge, maintenanceRunner, stack, sequencerInbox, fatalErrChan)
+	caffNode, err := getEspressoCaffNode(ctx, config, configFetcher, snapshotSignerAddress, snapshotSigner, arbDb, executionClient, l1Reader, txStreamer, blobReader, broadcastServer, broadcastClients, delayedBridge, maintenanceRunner, stack, sequencerInbox, fatalErrChan)
 	if err != nil {
 		return nil, err
 	}
@@ -1355,7 +1355,7 @@ func CreateNodeExecutionClient(
 	txOptsValidator *bind.TransactOpts,
 	txOptsBatchPoster *bind.TransactOpts,
 	dataSigner signature.DataSignerFunc,
-	snapshotAddress *common.Address,
+	snapshotSignerAddress *common.Address,
 	snapshotSigner signature.DataSignerFunc,
 	fatalErrChan chan error,
 	parentChainID *big.Int,
@@ -1365,7 +1365,7 @@ func CreateNodeExecutionClient(
 	if executionClient == nil {
 		return nil, errors.New("execution client must be non-nil")
 	}
-	currentNode, err := createNodeImpl(ctx, stack, executionClient, nil, nil, nil, arbDb, configFetcher, l2Config, l1client, deployInfo, txOptsValidator, txOptsBatchPoster, dataSigner, snapshotAddress, snapshotSigner, fatalErrChan, parentChainID, blobReader, latestWasmModuleRoot)
+	currentNode, err := createNodeImpl(ctx, stack, executionClient, nil, nil, nil, arbDb, configFetcher, l2Config, l1client, deployInfo, txOptsValidator, txOptsBatchPoster, dataSigner, snapshotSignerAddress, snapshotSigner, fatalErrChan, parentChainID, blobReader, latestWasmModuleRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -1388,7 +1388,7 @@ func CreateNodeFullExecutionClient(
 	txOptsValidator *bind.TransactOpts,
 	txOptsBatchPoster *bind.TransactOpts,
 	dataSigner signature.DataSignerFunc,
-	snapshotAddress *common.Address,
+	snapshotSignerAddress *common.Address,
 	snapshotSigner signature.DataSignerFunc,
 	fatalErrChan chan error,
 	parentChainID *big.Int,
@@ -1398,7 +1398,7 @@ func CreateNodeFullExecutionClient(
 	if (executionClient == nil) || (executionSequencer == nil) || (executionRecorder == nil) || (executionBatchPoster == nil) {
 		return nil, errors.New("execution client, sequencer, recorder, and batch poster must be non-nil")
 	}
-	currentNode, err := createNodeImpl(ctx, stack, executionClient, executionSequencer, executionRecorder, executionBatchPoster, arbDb, configFetcher, l2Config, l1client, deployInfo, txOptsValidator, txOptsBatchPoster, dataSigner, snapshotAddress, snapshotSigner, fatalErrChan, parentChainID, blobReader, latestWasmModuleRoot)
+	currentNode, err := createNodeImpl(ctx, stack, executionClient, executionSequencer, executionRecorder, executionBatchPoster, arbDb, configFetcher, l2Config, l1client, deployInfo, txOptsValidator, txOptsBatchPoster, dataSigner, snapshotSignerAddress, snapshotSigner, fatalErrChan, parentChainID, blobReader, latestWasmModuleRoot)
 	if err != nil {
 		return nil, err
 	}

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -5,7 +5,6 @@ package arbnode
 
 import (
 	"context"
-	"crypto/ecdsa"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -966,7 +965,7 @@ func getEspressoCaffNode(
 	ctx context.Context,
 	config *Config,
 	configFetcher ConfigFetcher,
-	snapshotPublicKey *ecdsa.PublicKey,
+	snapshotAddress *common.Address,
 	snapshotSigner signature.DataSignerFunc,
 	arbDb ethdb.Database,
 	exec execution.ExecutionClient,
@@ -985,7 +984,7 @@ func getEspressoCaffNode(
 		if exec, ok := exec.(*gethexec.ExecutionNode); ok {
 			espressoCaffNode, err := NewEspressoCaffNode(
 				func() *EspressoCaffNodeConfig { return &config.EspressoCaffNode },
-				snapshotPublicKey,
+				snapshotAddress,
 				snapshotSigner,
 				exec.ExecEngine,
 				delayedBridge,
@@ -1115,7 +1114,7 @@ func createNodeImpl(
 	txOptsValidator *bind.TransactOpts,
 	txOptsBatchPoster *bind.TransactOpts,
 	dataSigner signature.DataSignerFunc,
-	snapshotPublicKey *ecdsa.PublicKey,
+	snapshotAddress *common.Address,
 	snapshotSigner signature.DataSignerFunc,
 	fatalErrChan chan error,
 	parentChainID *big.Int,
@@ -1180,7 +1179,7 @@ func createNodeImpl(
 		return nil, err
 	}
 
-	caffNode, err := getEspressoCaffNode(ctx, config, configFetcher, snapshotPublicKey, snapshotSigner, arbDb, executionClient, l1Reader, txStreamer, blobReader, broadcastServer, broadcastClients, delayedBridge, maintenanceRunner, stack, sequencerInbox, fatalErrChan)
+	caffNode, err := getEspressoCaffNode(ctx, config, configFetcher, snapshotAddress, snapshotSigner, arbDb, executionClient, l1Reader, txStreamer, blobReader, broadcastServer, broadcastClients, delayedBridge, maintenanceRunner, stack, sequencerInbox, fatalErrChan)
 	if err != nil {
 		return nil, err
 	}
@@ -1356,7 +1355,7 @@ func CreateNodeExecutionClient(
 	txOptsValidator *bind.TransactOpts,
 	txOptsBatchPoster *bind.TransactOpts,
 	dataSigner signature.DataSignerFunc,
-	snapshotPublicKey *ecdsa.PublicKey,
+	snapshotAddress *common.Address,
 	snapshotSigner signature.DataSignerFunc,
 	fatalErrChan chan error,
 	parentChainID *big.Int,
@@ -1366,7 +1365,7 @@ func CreateNodeExecutionClient(
 	if executionClient == nil {
 		return nil, errors.New("execution client must be non-nil")
 	}
-	currentNode, err := createNodeImpl(ctx, stack, executionClient, nil, nil, nil, arbDb, configFetcher, l2Config, l1client, deployInfo, txOptsValidator, txOptsBatchPoster, dataSigner, snapshotPublicKey, snapshotSigner, fatalErrChan, parentChainID, blobReader, latestWasmModuleRoot)
+	currentNode, err := createNodeImpl(ctx, stack, executionClient, nil, nil, nil, arbDb, configFetcher, l2Config, l1client, deployInfo, txOptsValidator, txOptsBatchPoster, dataSigner, snapshotAddress, snapshotSigner, fatalErrChan, parentChainID, blobReader, latestWasmModuleRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -1389,7 +1388,7 @@ func CreateNodeFullExecutionClient(
 	txOptsValidator *bind.TransactOpts,
 	txOptsBatchPoster *bind.TransactOpts,
 	dataSigner signature.DataSignerFunc,
-	snapshotPublicKey *ecdsa.PublicKey,
+	snapshotAddress *common.Address,
 	snapshotSigner signature.DataSignerFunc,
 	fatalErrChan chan error,
 	parentChainID *big.Int,
@@ -1399,7 +1398,7 @@ func CreateNodeFullExecutionClient(
 	if (executionClient == nil) || (executionSequencer == nil) || (executionRecorder == nil) || (executionBatchPoster == nil) {
 		return nil, errors.New("execution client, sequencer, recorder, and batch poster must be non-nil")
 	}
-	currentNode, err := createNodeImpl(ctx, stack, executionClient, executionSequencer, executionRecorder, executionBatchPoster, arbDb, configFetcher, l2Config, l1client, deployInfo, txOptsValidator, txOptsBatchPoster, dataSigner, snapshotPublicKey, snapshotSigner, fatalErrChan, parentChainID, blobReader, latestWasmModuleRoot)
+	currentNode, err := createNodeImpl(ctx, stack, executionClient, executionSequencer, executionRecorder, executionBatchPoster, arbDb, configFetcher, l2Config, l1client, deployInfo, txOptsValidator, txOptsBatchPoster, dataSigner, snapshotAddress, snapshotSigner, fatalErrChan, parentChainID, blobReader, latestWasmModuleRoot)
 	if err != nil {
 		return nil, err
 	}

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -5,6 +5,7 @@ package arbnode
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -965,6 +966,7 @@ func getEspressoCaffNode(
 	ctx context.Context,
 	config *Config,
 	configFetcher ConfigFetcher,
+	snapshotPublicKey *ecdsa.PublicKey,
 	snapshotSigner signature.DataSignerFunc,
 	arbDb ethdb.Database,
 	exec execution.ExecutionClient,
@@ -981,8 +983,9 @@ func getEspressoCaffNode(
 ) (*Node, error) {
 	if config.EspressoCaffNode.Enable {
 		if exec, ok := exec.(*gethexec.ExecutionNode); ok {
-			espressoCaffNode := NewEspressoCaffNode(
+			espressoCaffNode, err := NewEspressoCaffNode(
 				func() *EspressoCaffNodeConfig { return &config.EspressoCaffNode },
+				snapshotPublicKey,
 				snapshotSigner,
 				exec.ExecEngine,
 				delayedBridge,
@@ -994,6 +997,9 @@ func getEspressoCaffNode(
 				fatalErrChan,
 				stack.Config().HTTPPort,
 			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create espressoCaffNode: %w", err)
+			}
 
 			return &Node{
 				ArbDB:                   arbDb,
@@ -1109,6 +1115,7 @@ func createNodeImpl(
 	txOptsValidator *bind.TransactOpts,
 	txOptsBatchPoster *bind.TransactOpts,
 	dataSigner signature.DataSignerFunc,
+	snapshotPublicKey *ecdsa.PublicKey,
 	snapshotSigner signature.DataSignerFunc,
 	fatalErrChan chan error,
 	parentChainID *big.Int,
@@ -1173,7 +1180,7 @@ func createNodeImpl(
 		return nil, err
 	}
 
-	caffNode, err := getEspressoCaffNode(ctx, config, configFetcher, snapshotSigner, arbDb, executionClient, l1Reader, txStreamer, blobReader, broadcastServer, broadcastClients, delayedBridge, maintenanceRunner, stack, sequencerInbox, fatalErrChan)
+	caffNode, err := getEspressoCaffNode(ctx, config, configFetcher, snapshotPublicKey, snapshotSigner, arbDb, executionClient, l1Reader, txStreamer, blobReader, broadcastServer, broadcastClients, delayedBridge, maintenanceRunner, stack, sequencerInbox, fatalErrChan)
 	if err != nil {
 		return nil, err
 	}
@@ -1349,6 +1356,7 @@ func CreateNodeExecutionClient(
 	txOptsValidator *bind.TransactOpts,
 	txOptsBatchPoster *bind.TransactOpts,
 	dataSigner signature.DataSignerFunc,
+	snapshotPublicKey *ecdsa.PublicKey,
 	snapshotSigner signature.DataSignerFunc,
 	fatalErrChan chan error,
 	parentChainID *big.Int,
@@ -1358,7 +1366,7 @@ func CreateNodeExecutionClient(
 	if executionClient == nil {
 		return nil, errors.New("execution client must be non-nil")
 	}
-	currentNode, err := createNodeImpl(ctx, stack, executionClient, nil, nil, nil, arbDb, configFetcher, l2Config, l1client, deployInfo, txOptsValidator, txOptsBatchPoster, dataSigner, snapshotSigner, fatalErrChan, parentChainID, blobReader, latestWasmModuleRoot)
+	currentNode, err := createNodeImpl(ctx, stack, executionClient, nil, nil, nil, arbDb, configFetcher, l2Config, l1client, deployInfo, txOptsValidator, txOptsBatchPoster, dataSigner, snapshotPublicKey, snapshotSigner, fatalErrChan, parentChainID, blobReader, latestWasmModuleRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -1381,6 +1389,7 @@ func CreateNodeFullExecutionClient(
 	txOptsValidator *bind.TransactOpts,
 	txOptsBatchPoster *bind.TransactOpts,
 	dataSigner signature.DataSignerFunc,
+	snapshotPublicKey *ecdsa.PublicKey,
 	snapshotSigner signature.DataSignerFunc,
 	fatalErrChan chan error,
 	parentChainID *big.Int,
@@ -1390,7 +1399,7 @@ func CreateNodeFullExecutionClient(
 	if (executionClient == nil) || (executionSequencer == nil) || (executionRecorder == nil) || (executionBatchPoster == nil) {
 		return nil, errors.New("execution client, sequencer, recorder, and batch poster must be non-nil")
 	}
-	currentNode, err := createNodeImpl(ctx, stack, executionClient, executionSequencer, executionRecorder, executionBatchPoster, arbDb, configFetcher, l2Config, l1client, deployInfo, txOptsValidator, txOptsBatchPoster, dataSigner, snapshotSigner, fatalErrChan, parentChainID, blobReader, latestWasmModuleRoot)
+	currentNode, err := createNodeImpl(ctx, stack, executionClient, executionSequencer, executionRecorder, executionBatchPoster, arbDb, configFetcher, l2Config, l1client, deployInfo, txOptsValidator, txOptsBatchPoster, dataSigner, snapshotPublicKey, snapshotSigner, fatalErrChan, parentChainID, blobReader, latestWasmModuleRoot)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -230,7 +230,7 @@ func mainImpl() int {
 
 	var dataSigner signature.DataSignerFunc
 	var snapshotSigner signature.DataSignerFunc
-	var snapshotPublicKey *ecdsa.PublicKey
+	var snapshotAddress *common.Address
 	var l1TransactionOptsValidator *bind.TransactOpts
 	var l1TransactionOptsBatchPoster *bind.TransactOpts
 	// If sequencer and signing is enabled or batchposter is enabled without
@@ -254,7 +254,7 @@ func mainImpl() int {
 	nodeConfig.Node.EspressoCaffNode.ResolveDirectoryNames(nodeConfig.Persistent.Chain)
 
 	if nodeConfig.Node.EspressoCaffNode.Enable && nodeConfig.Node.EspressoCaffNode.EspressoTeeType != "" {
-		snapshotPublicKey, snapshotSigner, err = integrityattestation.ReadEnclavePrivateKey(nodeConfig.Node.EspressoCaffNode.KeyPairAttestationsPath)
+		snapshotAddress, snapshotSigner, err = integrityattestation.ReadEnclavePrivateKey(nodeConfig.Node.EspressoCaffNode.KeyPairAttestationsPath)
 		if err != nil {
 			flag.Usage()
 			log.Crit("error reading enclave private key for Espresso Caff node", "path", nodeConfig.Node.EspressoCaffNode.KeyPairAttestationsPath, "err", err)
@@ -578,7 +578,7 @@ func mainImpl() int {
 		l1TransactionOptsValidator,
 		l1TransactionOptsBatchPoster,
 		dataSigner,
-		snapshotPublicKey,
+		snapshotAddress,
 		snapshotSigner,
 		fatalErrChan,
 		new(big.Int).SetUint64(nodeConfig.ParentChain.ID),

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -231,6 +231,7 @@ func mainImpl() int {
 	var dataSigner signature.DataSignerFunc
 	var snapshotSigner signature.DataSignerFunc
 	var snapshotAddress *common.Address
+	var snapshotPublicKey *ecdsa.PublicKey
 	var l1TransactionOptsValidator *bind.TransactOpts
 	var l1TransactionOptsBatchPoster *bind.TransactOpts
 	// If sequencer and signing is enabled or batchposter is enabled without
@@ -254,12 +255,13 @@ func mainImpl() int {
 	nodeConfig.Node.EspressoCaffNode.ResolveDirectoryNames(nodeConfig.Persistent.Chain)
 
 	if nodeConfig.Node.EspressoCaffNode.Enable && nodeConfig.Node.EspressoCaffNode.EspressoTeeType != "" {
-		snapshotAddress, snapshotSigner, err = integrityattestation.ReadEnclavePrivateKey(nodeConfig.Node.EspressoCaffNode.KeyPairAttestationsPath)
+		snapshotPublicKey, snapshotSigner, err = integrityattestation.ReadEnclavePrivateKey(nodeConfig.Node.EspressoCaffNode.KeyPairAttestationsPath)
 		if err != nil {
 			flag.Usage()
 			log.Crit("error reading enclave private key for Espresso Caff node", "path", nodeConfig.Node.EspressoCaffNode.KeyPairAttestationsPath, "err", err)
 		}
-
+		publicKeyAddress := crypto.PubkeyToAddress(*snapshotPublicKey)
+		snapshotAddress = &publicKeyAddress
 	}
 
 	if sequencerNeedsKey || nodeConfig.Node.BatchPoster.ParentChainWallet.OnlyCreateKey {

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -230,6 +230,7 @@ func mainImpl() int {
 
 	var dataSigner signature.DataSignerFunc
 	var snapshotSigner signature.DataSignerFunc
+	var snapshotPublicKey *ecdsa.PublicKey
 	var l1TransactionOptsValidator *bind.TransactOpts
 	var l1TransactionOptsBatchPoster *bind.TransactOpts
 	// If sequencer and signing is enabled or batchposter is enabled without
@@ -252,12 +253,13 @@ func mainImpl() int {
 
 	nodeConfig.Node.EspressoCaffNode.ResolveDirectoryNames(nodeConfig.Persistent.Chain)
 
-	if nodeConfig.Node.EspressoCaffNode.Enable {
-		_, snapshotSigner, err = integrityattestation.ReadEnclavePrivateKey(nodeConfig.Node.EspressoCaffNode.KeyPairAttestationsPath)
+	if nodeConfig.Node.EspressoCaffNode.Enable && nodeConfig.Node.EspressoCaffNode.EspressoTeeType != "" {
+		snapshotPublicKey, snapshotSigner, err = integrityattestation.ReadEnclavePrivateKey(nodeConfig.Node.EspressoCaffNode.KeyPairAttestationsPath)
 		if err != nil {
 			flag.Usage()
 			log.Crit("error reading enclave private key for Espresso Caff node", "path", nodeConfig.Node.EspressoCaffNode.KeyPairAttestationsPath, "err", err)
 		}
+
 	}
 
 	if sequencerNeedsKey || nodeConfig.Node.BatchPoster.ParentChainWallet.OnlyCreateKey {
@@ -576,6 +578,7 @@ func mainImpl() int {
 		l1TransactionOptsValidator,
 		l1TransactionOptsBatchPoster,
 		dataSigner,
+		snapshotPublicKey,
 		snapshotSigner,
 		fatalErrChan,
 		new(big.Int).SetUint64(nodeConfig.ParentChain.ID),

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -230,7 +230,7 @@ func mainImpl() int {
 
 	var dataSigner signature.DataSignerFunc
 	var snapshotSigner signature.DataSignerFunc
-	var snapshotAddress *common.Address
+	var snapshotSignerAddress *common.Address
 	var snapshotPublicKey *ecdsa.PublicKey
 	var l1TransactionOptsValidator *bind.TransactOpts
 	var l1TransactionOptsBatchPoster *bind.TransactOpts
@@ -261,7 +261,7 @@ func mainImpl() int {
 			log.Crit("error reading enclave private key for Espresso Caff node", "path", nodeConfig.Node.EspressoCaffNode.KeyPairAttestationsPath, "err", err)
 		}
 		publicKeyAddress := crypto.PubkeyToAddress(*snapshotPublicKey)
-		snapshotAddress = &publicKeyAddress
+		snapshotSignerAddress = &publicKeyAddress
 	}
 
 	if sequencerNeedsKey || nodeConfig.Node.BatchPoster.ParentChainWallet.OnlyCreateKey {
@@ -580,7 +580,7 @@ func mainImpl() int {
 		l1TransactionOptsValidator,
 		l1TransactionOptsBatchPoster,
 		dataSigner,
-		snapshotAddress,
+		snapshotSignerAddress,
 		snapshotSigner,
 		fatalErrChan,
 		new(big.Int).SetUint64(nodeConfig.ParentChain.ID),

--- a/cmd/util/integrityattestation/utils.go
+++ b/cmd/util/integrityattestation/utils.go
@@ -100,7 +100,7 @@ func GetKMSEnclaveClient(cfg aws.Config) (*attestedkms.KMSEnclaveClient, error) 
 	return attestedkms.NewFromConfig(cfg, attestationDoc, privateKey), nil
 }
 
-func ReadEnclavePrivateKey(attestationsPath string) (*ecdsa.PrivateKey, signature.DataSignerFunc, error) {
+func ReadEnclavePrivateKey(attestationsPath string) (*ecdsa.PublicKey, signature.DataSignerFunc, error) {
 	if err := os.MkdirAll(attestationsPath, os.ModePerm); err != nil {
 		return nil, nil, fmt.Errorf("failed to create attestations path directory %s with error: %w", attestationsPath, err)
 	}
@@ -125,11 +125,7 @@ func ReadEnclavePrivateKey(attestationsPath string) (*ecdsa.PrivateKey, signatur
 		return nil, nil, fmt.Errorf("failed to get attested public key: %w", err)
 	}
 
-	if _, err = GetAttestedAddress(publicKey, attestationsPath); err != nil {
-		return nil, nil, fmt.Errorf("failed to get attested address: %w", err)
-	}
-
-	return privateKey, signature.DataSignerFromPrivateKey(privateKey), nil
+	return publicKey, signature.DataSignerFromPrivateKey(privateKey), nil
 }
 
 // Safely pointer dereference

--- a/cmd/util/integrityattestation/utils.go
+++ b/cmd/util/integrityattestation/utils.go
@@ -18,8 +18,6 @@ import (
 	"github.com/distributed-lab/enclave-extras/attestation"
 	"github.com/distributed-lab/enclave-extras/attestedkms"
 	"github.com/distributed-lab/enclave-extras/nsm"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/offchainlabs/nitro/util/signature"
 )
@@ -102,7 +100,7 @@ func GetKMSEnclaveClient(cfg aws.Config) (*attestedkms.KMSEnclaveClient, error) 
 	return attestedkms.NewFromConfig(cfg, attestationDoc, privateKey), nil
 }
 
-func ReadEnclavePrivateKey(attestationsPath string) (*common.Address, signature.DataSignerFunc, error) {
+func ReadEnclavePrivateKey(attestationsPath string) (*ecdsa.PublicKey, signature.DataSignerFunc, error) {
 	if err := os.MkdirAll(attestationsPath, os.ModePerm); err != nil {
 		return nil, nil, fmt.Errorf("failed to create attestations path directory %s with error: %w", attestationsPath, err)
 	}
@@ -127,9 +125,7 @@ func ReadEnclavePrivateKey(attestationsPath string) (*common.Address, signature.
 		return nil, nil, fmt.Errorf("failed to get attested public key: %w", err)
 	}
 
-	address := crypto.PubkeyToAddress(*publicKey)
-
-	return &address, signature.DataSignerFromPrivateKey(privateKey), nil
+	return publicKey, signature.DataSignerFromPrivateKey(privateKey), nil
 }
 
 // Safely pointer dereference

--- a/cmd/util/integrityattestation/utils.go
+++ b/cmd/util/integrityattestation/utils.go
@@ -18,6 +18,8 @@ import (
 	"github.com/distributed-lab/enclave-extras/attestation"
 	"github.com/distributed-lab/enclave-extras/attestedkms"
 	"github.com/distributed-lab/enclave-extras/nsm"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/offchainlabs/nitro/util/signature"
 )
@@ -100,7 +102,7 @@ func GetKMSEnclaveClient(cfg aws.Config) (*attestedkms.KMSEnclaveClient, error) 
 	return attestedkms.NewFromConfig(cfg, attestationDoc, privateKey), nil
 }
 
-func ReadEnclavePrivateKey(attestationsPath string) (*ecdsa.PublicKey, signature.DataSignerFunc, error) {
+func ReadEnclavePrivateKey(attestationsPath string) (*common.Address, signature.DataSignerFunc, error) {
 	if err := os.MkdirAll(attestationsPath, os.ModePerm); err != nil {
 		return nil, nil, fmt.Errorf("failed to create attestations path directory %s with error: %w", attestationsPath, err)
 	}
@@ -121,11 +123,13 @@ func ReadEnclavePrivateKey(attestationsPath string) (*ecdsa.PublicKey, signature
 	}
 
 	publicKey, err := GetAttestedPublicKey(privateKey, attestationsPath)
-	if err != nil {
+	if err != nil || publicKey == nil {
 		return nil, nil, fmt.Errorf("failed to get attested public key: %w", err)
 	}
 
-	return publicKey, signature.DataSignerFromPrivateKey(privateKey), nil
+	address := crypto.PubkeyToAddress(*publicKey)
+
+	return &address, signature.DataSignerFromPrivateKey(privateKey), nil
 }
 
 // Safely pointer dereference

--- a/espressostreamer/espresso_streamer.go
+++ b/espressostreamer/espresso_streamer.go
@@ -27,6 +27,7 @@ import (
 )
 
 const NextHotshotBlockKey = "nextHotshotBlock"
+const HotshotBlockSignatureKey = "hotshotBlockSignature"
 
 var (
 	ErrFailedToFetchTransactions  = errors.New("failed to fetch transactions")
@@ -48,7 +49,8 @@ type EspressoStreamerInterface interface {
 	// RecordTimeDurationBetweenHotshotAndCurrentBlock records the time duration between
 	// the next hotshot block and the current block.
 	RecordTimeDurationBetweenHotshotAndCurrentBlock(nextHotshotBlock uint64, blockProductionTime time.Time)
-	StoreHotshotBlock(db ethdb.Database, nextHotshotBlock uint64) error
+	StoreHotshotBlock(batch ethdb.Batch, nextHotshotBlock uint64) error
+	StoreHotshotBlockWithSignature(batch ethdb.Batch, nextHotshotBlock uint64, signature []byte) error
 	ReadNextHotshotBlockFromDb(db ethdb.Database) (uint64, error)
 	GetCurrentEarliestHotShotBlockNumber() uint64
 
@@ -321,15 +323,39 @@ func (s *EspressoStreamer) ReadNextHotshotBlockFromDb(db ethdb.Database) (uint64
 	return nextHotshotBlock, nil
 }
 
-func (s *EspressoStreamer) StoreHotshotBlock(db ethdb.Database, nextHotshotBlock uint64) error {
+func (s *EspressoStreamer) StoreHotshotBlock(batch ethdb.Batch, nextHotshotBlock uint64) error {
 	nextHotshotBytes, err := rlp.EncodeToBytes(nextHotshotBlock)
 	if err != nil {
 		return fmt.Errorf("failed to encode next hotshot block: %w", err)
 	}
 
-	err = db.Put([]byte(NextHotshotBlockKey), nextHotshotBytes)
+	err = batch.Put([]byte(NextHotshotBlockKey), nextHotshotBytes)
 	if err != nil {
 		return fmt.Errorf("failed to put next hotshot block: %w", err)
+	}
+
+	return nil
+}
+
+func (s *EspressoStreamer) StoreHotshotBlockWithSignature(batch ethdb.Batch, nextHotshotBlock uint64, signature []byte) error {
+	nextHotshotBytes, err := rlp.EncodeToBytes(nextHotshotBlock)
+	if err != nil {
+		return fmt.Errorf("failed to encode next hotshot block: %w", err)
+	}
+
+	err = batch.Put([]byte(NextHotshotBlockKey), nextHotshotBytes)
+	if err != nil {
+		return fmt.Errorf("failed to put next hotshot block: %w", err)
+	}
+
+	signatureBytes, err := rlp.EncodeToBytes(signature)
+	if err != nil {
+		return fmt.Errorf("failed to encode signature: %w", err)
+	}
+
+	err = batch.Put([]byte(HotshotBlockSignatureKey), signatureBytes)
+	if err != nil {
+		return fmt.Errorf("failed to put signature: %w", err)
 	}
 
 	return nil

--- a/espressostreamer/espresso_streamer.go
+++ b/espressostreamer/espresso_streamer.go
@@ -54,6 +54,7 @@ type EspressoStreamerInterface interface {
 	GetCurrentEarliestHotShotBlockNumber() uint64
 
 	SetBatcherAddressesFetcher(fetcher func(l1Height uint64) []common.Address)
+	StopAndWait()
 }
 
 type MessageWithMetadataAndPos struct {
@@ -341,12 +342,7 @@ func (s *EspressoStreamer) StoreHotshotBlockWithSignature(batch ethdb.Batch, nex
 		return fmt.Errorf("failed to put next hotshot block: %w", err)
 	}
 
-	signatureBytes, err := rlp.EncodeToBytes(signature)
-	if err != nil {
-		return fmt.Errorf("failed to encode signature: %w", err)
-	}
-
-	err = batch.Put([]byte(HotshotBlockSignatureKey), signatureBytes)
+	err = batch.Put([]byte(HotshotBlockSignatureKey), signature)
 	if err != nil {
 		return fmt.Errorf("failed to put signature: %w", err)
 	}
@@ -447,4 +443,8 @@ func (s *EspressoStreamer) Start(ctxIn context.Context) error {
 		return 0
 	})
 	return err
+}
+
+func (s *EspressoStreamer) StopAndWait() {
+	s.StopWaiter.StopAndWait()
 }

--- a/espressostreamer/espresso_streamer.go
+++ b/espressostreamer/espresso_streamer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/espressotee"
 	"github.com/offchainlabs/nitro/util"
+	"github.com/offchainlabs/nitro/util/dbutil"
 	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
 
@@ -308,8 +309,11 @@ func (s *EspressoStreamer) parseEspressoTransaction(tx espressoTypes.Bytes, l1He
 func (s *EspressoStreamer) ReadNextHotshotBlockFromDb(db ethdb.Database) (uint64, []byte, error) {
 	var nextHotshotBlock uint64
 	nextHotshotBytes, err := db.Get([]byte(NextHotshotBlockKey))
-	if err != nil {
+	if err != nil && !dbutil.IsErrNotFound(err) {
 		return 0, nil, fmt.Errorf("failed to get next hotshot block: %w", err)
+	}
+	if dbutil.IsErrNotFound(err) {
+		return 0, nil, nil
 	}
 	if nextHotshotBytes != nil {
 		err = rlp.DecodeBytes(nextHotshotBytes, &nextHotshotBlock)

--- a/espressostreamer/espresso_streamer.go
+++ b/espressostreamer/espresso_streamer.go
@@ -22,7 +22,6 @@ import (
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/espressotee"
 	"github.com/offchainlabs/nitro/util"
-	"github.com/offchainlabs/nitro/util/dbutil"
 	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
 
@@ -49,9 +48,8 @@ type EspressoStreamerInterface interface {
 	// RecordTimeDurationBetweenHotshotAndCurrentBlock records the time duration between
 	// the next hotshot block and the current block.
 	RecordTimeDurationBetweenHotshotAndCurrentBlock(nextHotshotBlock uint64, blockProductionTime time.Time)
-	StoreHotshotBlock(batch ethdb.Batch, nextHotshotBlock uint64) error
 	StoreHotshotBlockWithSignature(batch ethdb.Batch, nextHotshotBlock uint64, signature []byte) error
-	ReadNextHotshotBlockFromDb(db ethdb.Database) (uint64, error)
+	ReadNextHotshotBlockFromDb(db ethdb.Database) (uint64, []byte, error)
 	GetCurrentEarliestHotShotBlockNumber() uint64
 
 	SetBatcherAddressesFetcher(fetcher func(l1Height uint64) []common.Address)
@@ -307,34 +305,25 @@ func (s *EspressoStreamer) parseEspressoTransaction(tx espressoTypes.Bytes, l1He
 	return result, nil
 }
 
-func (s *EspressoStreamer) ReadNextHotshotBlockFromDb(db ethdb.Database) (uint64, error) {
+func (s *EspressoStreamer) ReadNextHotshotBlockFromDb(db ethdb.Database) (uint64, []byte, error) {
 	var nextHotshotBlock uint64
 	nextHotshotBytes, err := db.Get([]byte(NextHotshotBlockKey))
-	if err != nil && !dbutil.IsErrNotFound(err) {
-		return 0, fmt.Errorf("failed to get next hotshot block: %w", err)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to get next hotshot block: %w", err)
 	}
 	if nextHotshotBytes != nil {
 		err = rlp.DecodeBytes(nextHotshotBytes, &nextHotshotBlock)
 		if err != nil {
-			return 0, fmt.Errorf("failed to decode next hotshot block: %w", err)
+			return 0, nil, fmt.Errorf("failed to decode next hotshot block: %w", err)
 		}
 	}
-
-	return nextHotshotBlock, nil
-}
-
-func (s *EspressoStreamer) StoreHotshotBlock(batch ethdb.Batch, nextHotshotBlock uint64) error {
-	nextHotshotBytes, err := rlp.EncodeToBytes(nextHotshotBlock)
+	// Also need the signature over hotshot block
+	hotshotBlockSignature, err := db.Get([]byte(HotshotBlockSignatureKey))
 	if err != nil {
-		return fmt.Errorf("failed to encode next hotshot block: %w", err)
+		return 0, nil, fmt.Errorf("failed to get signature over hotshot block: %w", err)
 	}
 
-	err = batch.Put([]byte(NextHotshotBlockKey), nextHotshotBytes)
-	if err != nil {
-		return fmt.Errorf("failed to put next hotshot block: %w", err)
-	}
-
-	return nil
+	return nextHotshotBlock, hotshotBlockSignature, nil
 }
 
 func (s *EspressoStreamer) StoreHotshotBlockWithSignature(batch ethdb.Batch, nextHotshotBlock uint64, signature []byte) error {

--- a/system_tests/bold_challenge_protocol_test.go
+++ b/system_tests/bold_challenge_protocol_test.go
@@ -634,7 +634,7 @@ func createTestNodeOnL1ForBoldProtocol(
 	Require(t, err)
 	currentNode, err = arbnode.CreateNodeFullExecutionClient(
 		ctx, l2stack, execNode, execNode, execNode, execNode, l2arbDb, NewFetcherFromConfig(nodeConfig), l2blockchain.Config(), l1client,
-		addresses, sequencerTxOptsPtr, sequencerTxOptsPtr, dataSigner, dataSigner, fatalErrChan, parentChainId,
+		addresses, sequencerTxOptsPtr, sequencerTxOptsPtr, dataSigner, nil, nil, fatalErrChan, parentChainId,
 		nil, // Blob reader.
 		locator.LatestWasmModuleRoot(),
 	)
@@ -845,7 +845,7 @@ func create2ndNodeWithConfigForBoldProtocol(
 	Require(t, err)
 	locator, err := server_common.NewMachineLocator("")
 	Require(t, err)
-	l2node, err := arbnode.CreateNodeFullExecutionClient(ctx, l2stack, execNode, execNode, execNode, execNode, l2arbDb, NewFetcherFromConfig(nodeConfig), l2blockchain.Config(), l1client, addresses, &txOpts, &txOpts, dataSigner, dataSigner, fatalErrChan, l1ChainId, nil /* blob reader */, locator.LatestWasmModuleRoot())
+	l2node, err := arbnode.CreateNodeFullExecutionClient(ctx, l2stack, execNode, execNode, execNode, execNode, l2arbDb, NewFetcherFromConfig(nodeConfig), l2blockchain.Config(), l1client, addresses, &txOpts, &txOpts, dataSigner, nil, nil, fatalErrChan, l1ChainId, nil /* blob reader */, locator.LatestWasmModuleRoot())
 	Require(t, err)
 
 	l2client := ClientForStack(t, l2stack)

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -696,7 +696,6 @@ func TestEspressoForceInclusionChecker(t *testing.T) {
 	delayedMessageFetcher := arbnode.NewDelayedMessageFetcher(
 		delayedBridge,
 		reader,
-		builder.L2.ConsensusNode.ArbDB,
 		100,
 		false,
 		false,

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -282,7 +282,6 @@ func TestEspressoCaffNode(t *testing.T) {
 	Require(t, err)
 
 	// start the trusted node
-
 	trustedPort := 9000
 	trustedCleanup := mockTrustedNode(t, ctx, trustedPort)
 	defer trustedCleanup()

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -172,7 +172,7 @@ func AssertEventOrdering(t *testing.T, firstEventFunc func() error, secondEventF
 	}
 }
 
-func TestEspressoCaffNode(t *testing.T) {
+func TestEspressoCaffNodeInitial(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -191,6 +191,8 @@ func TestEspressoCaffNode(t *testing.T) {
 	err = waitForEspressoNode(ctx)
 	Require(t, err)
 
+	log.Info("Starting the caff node")
+
 	err = checkTransferTxOnL2(t, ctx, builder.L2, "User14", builder.L2Info)
 	Require(t, err)
 	err = checkTransferTxOnL2(t, ctx, builder.L2, "User15", builder.L2Info)
@@ -207,6 +209,7 @@ func TestEspressoCaffNode(t *testing.T) {
 		WrapL2ForDelayed(t, delayedTx, builder.L1Info, "Faucet", 100000),
 	})
 
+	log.Info("Sent delayed tx")
 	err = waitForWith(ctx, 240*time.Second, 10*time.Second, func() bool {
 		balance := builder.L2.GetBalance(t, addr)
 		log.Info("waiting for balance", "account", newAccount, "addr", addr, "balance", balance)
@@ -214,7 +217,7 @@ func TestEspressoCaffNode(t *testing.T) {
 	})
 	Require(t, err)
 
-	log.Info("Starting the caff node")
+	log.Info("Starting the caff node -2")
 	// don't make the caff node wait for finalization during the default test.
 	builder.nodeConfig.EspressoCaffNode.WaitForFinalization = false
 	// start the node
@@ -230,6 +233,8 @@ func TestEspressoCaffNode(t *testing.T) {
 		return balance1.Cmp(transferAmount) > 0 && balance2.Cmp(transferAmount) > 0
 	})
 	Require(t, err)
+
+	log.Info("Completed waiting for balance after wait for finalize as false")
 
 	err = waitForWith(ctx, 240*time.Second, 10*time.Second, func() bool {
 		balance := builderCaffNode.GetBalance(t, addr)
@@ -282,6 +287,7 @@ func TestEspressoCaffNode(t *testing.T) {
 	err = rpcClient.CallContext(ctx, nil, "eth_getBlockByNumber", "safe", false)
 	Require(t, err)
 
+	log.Info("Starting the trusted node")
 	// start the trusted node
 	trustedPort := 9000
 	trustedCleanup := mockTrustedNode(t, ctx, trustedPort)

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -31,6 +31,7 @@ func createCaffNode(
 	t *testing.T,
 	existing *NodeBuilder,
 	dangerous bool,
+	withSnapshotSigner bool,
 ) (*NodeBuilder, func(), error) {
 	builder := NewNodeBuilder(ctx).DefaultConfig(t, false)
 	nodeConfig := builder.nodeConfig
@@ -85,7 +86,13 @@ func createCaffNode(
 		nodeConfig.EspressoCaffNode.Dangerous.IgnoreDatabaseHotshotBlock = true
 		nodeConfig.EspressoCaffNode.NextHotshotBlock = 0
 	}
-	cleanup, err := builder.BuildEspressoCaffNode(t, existing)
+
+	if withSnapshotSigner {
+		nodeConfig.EspressoCaffNode.EspressoTeeType = "SGX"
+	}
+
+	cleanup, err := builder.BuildEspressoCaffNode(t, existing, withSnapshotSigner)
+	builder.L1 = existing.L1
 	return builder, cleanup, err
 }
 
@@ -217,7 +224,7 @@ func TestEspressoCaffNode(t *testing.T) {
 	// don't make the caff node wait for finalization during the default test.
 	builder.nodeConfig.EspressoCaffNode.WaitForFinalization = false
 	// start the node
-	builder, cleanupCaffNode, err := createCaffNode(ctx, t, builder, false)
+	builder, cleanupCaffNode, err := createCaffNode(ctx, t, builder, false, false)
 	Require(t, err)
 	builderCaffNode := builder.L2
 	defer cleanupCaffNode()
@@ -363,7 +370,7 @@ func TestEspressoCaffNodeDelayedMessagesConfirmations(t *testing.T) {
 
 	// start the node
 	log.Info("Starting the caff node")
-	builder2, cleanupCaffNode, err := createCaffNode(ctx, t, builder, false)
+	builder2, cleanupCaffNode, err := createCaffNode(ctx, t, builder, false, false)
 	Require(t, err)
 	builderCaffNode := builder2.L2
 	defer cleanupCaffNode()
@@ -421,7 +428,7 @@ func TestEspressoCaffNodeDelayedMessagesFinalized(t *testing.T) {
 	builder.nodeConfig.EspressoCaffNode.WaitForFinalization = true
 	// start the node
 	log.Info("Starting the caff node")
-	builder2, cleanupCaffNode, err := createCaffNode(ctx, t, builder, false)
+	builder2, cleanupCaffNode, err := createCaffNode(ctx, t, builder, false, false)
 	Require(t, err)
 	builderCaffNode := builder2.L2
 	defer cleanupCaffNode()
@@ -473,7 +480,7 @@ func TestEspressoCaffNodeUnfinalizedDelayedMessages(t *testing.T) {
 
 	// start the node
 	log.Info("Starting the caff node")
-	builder2, cleanupCaffNode, err := createCaffNode(ctx, t, builder, false)
+	builder2, cleanupCaffNode, err := createCaffNode(ctx, t, builder, false, false)
 	Require(t, err)
 	builderCaffNode := builder2.L2
 	defer cleanupCaffNode()
@@ -498,6 +505,108 @@ func TestEspressoCaffNodeUnfinalizedDelayedMessages(t *testing.T) {
 	if tx3[0].BlockNumber.Int64() <= finalizedHeader.Number.Int64() {
 		t.Fatal("Tx finalized before appearing in the caff node")
 	}
+	Require(t, err)
+}
+
+// Test 1: Check if restart works on EspressoCaffNode without any TEE type specified, this will make sure that if fromBlock and hotshotBlock
+// dont have signatures the node will still restart and work
+func TestEspressoCaffNodeRestart(t *testing.T) {
+	ctx, _, _, _, cancel, valNodeCleanup, builder, cleanup, cleanEspresso := Setup(t)
+	defer cancel()
+	defer valNodeCleanup()
+	defer cleanup()
+	defer cleanEspresso()
+
+	// Set caff node config variables
+	builder.nodeConfig.EspressoCaffNode.WaitForConfirmations = true
+	builder.nodeConfig.EspressoCaffNode.RequiredBlockDepth = 6
+	builder.nodeConfig.EspressoCaffNode.WaitForFinalization = false
+
+	// start the node
+	builderCaffNode, _, err := createCaffNode(ctx, t, builder, false, false)
+	Require(t, err)
+
+	err = checkTransferTxOnL2(t, ctx, builder.L2, "User14", builder.L2Info)
+	Require(t, err)
+	err = checkTransferTxOnL2(t, ctx, builder.L2, "User15", builder.L2Info)
+	Require(t, err)
+
+	err = waitForWith(ctx, 10*time.Minute, 10*time.Second, func() bool {
+		balance1 := builderCaffNode.L2.GetBalance(t, builder.L2Info.GetAddress("User14"))
+		balance2 := builderCaffNode.L2.GetBalance(t, builder.L2Info.GetAddress("User15"))
+		log.Info("waiting for balance", "account", "User14", "balance", balance1, "account", "User15", "balance", balance2)
+		return balance1.Cmp(transferAmount) > 0 && balance2.Cmp(transferAmount) > 0
+	})
+	Require(t, err)
+
+	time.Sleep(1 * time.Minute)
+	builderCaffNode.RestartCaffNode(t, false)
+
+	tx := builder.L2Info.PrepareTx("Faucet", "User14", 3e7, transferAmount, nil)
+
+	err = builder.L2.Client.SendTransaction(ctx, tx)
+	Require(t, err)
+
+	err = waitForWith(ctx, 10*time.Minute, 10*time.Second, func() bool {
+		balance1 := builderCaffNode.L2.GetBalance(t, builder.L2Info.GetAddress("User14"))
+		log.Info("waiting for balance", "account", "User14", "balance", balance1, "account")
+		// Now the balance should be greater than twice the transfer amount
+		return balance1.Cmp(transferAmount.Mul(transferAmount, big.NewInt(2))) > 0
+	})
+	Require(t, err)
+}
+
+// Check if restart works on EspressoCaffNode with  TEE type specified,
+// then make sure on restart we are checking the block, fromBlock and hotshotBlock signature
+func TestEspressoCaffNodeRestartWithTeeType(t *testing.T) {
+	ctx, _, _, _, cancel, valNodeCleanup, builder, cleanup, cleanEspresso := Setup(t)
+	defer cancel()
+	defer valNodeCleanup()
+	defer cleanup()
+	defer cleanEspresso()
+
+	// Set caff node config variables
+	builder.nodeConfig.EspressoCaffNode.WaitForConfirmations = true
+	builder.nodeConfig.EspressoCaffNode.RequiredBlockDepth = 6
+	builder.nodeConfig.EspressoCaffNode.WaitForFinalization = false
+	builder.nodeConfig.EspressoCaffNode.EspressoTeeType = "SGX"
+
+	// start the node
+	log.Info("Starting the caff node initially")
+	// Start the caff node with a snapshot signer
+	builderCaffNode, _, err := createCaffNode(ctx, t, builder, false, true)
+	Require(t, err)
+
+	err = checkTransferTxOnL2(t, ctx, builder.L2, "User14", builder.L2Info)
+	Require(t, err)
+	err = checkTransferTxOnL2(t, ctx, builder.L2, "User15", builder.L2Info)
+	Require(t, err)
+
+	err = waitForWith(ctx, 10*time.Minute, 10*time.Second, func() bool {
+		balance1 := builderCaffNode.L2.GetBalance(t, builder.L2Info.GetAddress("User14"))
+		balance2 := builderCaffNode.L2.GetBalance(t, builder.L2Info.GetAddress("User15"))
+		log.Info("waiting for balance", "account", "User14", "balance", balance1, "account", "User15", "balance", balance2)
+		return balance1.Cmp(transferAmount) > 0 && balance2.Cmp(transferAmount) > 0
+	})
+	Require(t, err)
+
+	// start the node
+	builder.nodeConfig.EspressoCaffNode.EspressoTeeType = "SGX"
+	time.Sleep(1 * time.Minute)
+
+	builderCaffNode.RestartCaffNode(t, true)
+
+	tx := builder.L2Info.PrepareTx("Faucet", "User14", 3e7, transferAmount, nil)
+
+	err = builder.L2.Client.SendTransaction(ctx, tx)
+	Require(t, err)
+
+	err = waitForWith(ctx, 10*time.Minute, 10*time.Second, func() bool {
+		balance1 := builderCaffNode.L2.GetBalance(t, builder.L2Info.GetAddress("User14"))
+		log.Info("waiting for balance", "account", "User14", "balance", balance1, "account")
+		// Now the balance should be greater than twice the transfer amount
+		return balance1.Cmp(transferAmount.Mul(transferAmount, big.NewInt(2))) > 0
+	})
 	Require(t, err)
 }
 
@@ -556,7 +665,7 @@ func TestEspressoCaffNodeDangerousConfig(t *testing.T) {
 	defer cleanup()
 
 	// start the node
-	_, cleanupCaffNode, err := createCaffNode(ctx, t, builder, true)
+	_, cleanupCaffNode, err := createCaffNode(ctx, t, builder, true, false)
 	if cleanupCaffNode != nil {
 		defer cleanupCaffNode()
 	}
@@ -612,7 +721,7 @@ func TestEspressoCaffNodeSGXVerifierShouldRetryWhenEncounterRPCError(t *testing.
 	err = checkTransferTxOnL2(t, ctx, builder.L2, "User15", builder.L2Info)
 	Require(t, err)
 
-	builder2, cleanupCaffNode, err := createCaffNode(ctx, t, builder, false)
+	builder2, cleanupCaffNode, err := createCaffNode(ctx, t, builder, false, false)
 	defer cleanupCaffNode()
 	Require(t, err)
 

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -282,6 +282,7 @@ func TestEspressoCaffNode(t *testing.T) {
 	Require(t, err)
 
 	// start the trusted node
+
 	trustedPort := 9000
 	trustedCleanup := mockTrustedNode(t, ctx, trustedPort)
 	defer trustedCleanup()

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -172,7 +172,7 @@ func AssertEventOrdering(t *testing.T, firstEventFunc func() error, secondEventF
 	}
 }
 
-func TestEspressoCaffNodeInitial(t *testing.T) {
+func TestEspressoCaffNode(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -191,8 +191,6 @@ func TestEspressoCaffNodeInitial(t *testing.T) {
 	err = waitForEspressoNode(ctx)
 	Require(t, err)
 
-	log.Info("Starting the caff node")
-
 	err = checkTransferTxOnL2(t, ctx, builder.L2, "User14", builder.L2Info)
 	Require(t, err)
 	err = checkTransferTxOnL2(t, ctx, builder.L2, "User15", builder.L2Info)
@@ -209,7 +207,6 @@ func TestEspressoCaffNodeInitial(t *testing.T) {
 		WrapL2ForDelayed(t, delayedTx, builder.L1Info, "Faucet", 100000),
 	})
 
-	log.Info("Sent delayed tx")
 	err = waitForWith(ctx, 240*time.Second, 10*time.Second, func() bool {
 		balance := builder.L2.GetBalance(t, addr)
 		log.Info("waiting for balance", "account", newAccount, "addr", addr, "balance", balance)
@@ -217,7 +214,6 @@ func TestEspressoCaffNodeInitial(t *testing.T) {
 	})
 	Require(t, err)
 
-	log.Info("Starting the caff node -2")
 	// don't make the caff node wait for finalization during the default test.
 	builder.nodeConfig.EspressoCaffNode.WaitForFinalization = false
 	// start the node
@@ -233,8 +229,6 @@ func TestEspressoCaffNodeInitial(t *testing.T) {
 		return balance1.Cmp(transferAmount) > 0 && balance2.Cmp(transferAmount) > 0
 	})
 	Require(t, err)
-
-	log.Info("Completed waiting for balance after wait for finalize as false")
 
 	err = waitForWith(ctx, 240*time.Second, 10*time.Second, func() bool {
 		balance := builderCaffNode.GetBalance(t, addr)
@@ -287,7 +281,6 @@ func TestEspressoCaffNodeInitial(t *testing.T) {
 	err = rpcClient.CallContext(ctx, nil, "eth_getBlockByNumber", "safe", false)
 	Require(t, err)
 
-	log.Info("Starting the trusted node")
 	// start the trusted node
 	trustedPort := 9000
 	trustedCleanup := mockTrustedNode(t, ctx, trustedPort)

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -591,7 +591,6 @@ func TestEspressoCaffNodeRestartWithTeeType(t *testing.T) {
 	Require(t, err)
 
 	// start the node
-	builder.nodeConfig.EspressoCaffNode.EspressoTeeType = "SGX"
 	time.Sleep(1 * time.Minute)
 
 	builderCaffNode.RestartCaffNode(t, true)

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -714,10 +714,10 @@ func (b *NodeBuilder) BuildEspressoCaffNode(t *testing.T, existing *NodeBuilder,
 
 	if withSnapshotSigner {
 		snapshotSigner := signature.DataSignerFromPrivateKey(existing.L1Info.GetInfoWithPrivKey("Sequencer").PrivateKey)
-		snapshotAddress := b.L1Info.GetInfoWithPrivKey("Sequencer").Address
+		snapshotSignerAddress := b.L1Info.GetInfoWithPrivKey("Sequencer").Address
 		b.L2.ConsensusNode, err = arbnode.CreateNodeFullExecutionClient(
 			b.ctx, b.L2.Stack, execNode, execNode, execNode, execNode, arbDb, NewFetcherFromConfig(b.nodeConfig), blockchain.Config(),
-			l1Client, deployInfo, nil, nil, nil, &snapshotAddress, snapshotSigner, fatalErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())
+			l1Client, deployInfo, nil, nil, nil, &snapshotSignerAddress, snapshotSigner, fatalErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())
 		Require(t, err)
 	} else {
 		b.L2.ConsensusNode, err = arbnode.CreateNodeFullExecutionClient(

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -714,10 +714,10 @@ func (b *NodeBuilder) BuildEspressoCaffNode(t *testing.T, existing *NodeBuilder,
 
 	if withSnapshotSigner {
 		snapshotSigner := signature.DataSignerFromPrivateKey(existing.L1Info.GetInfoWithPrivKey("Sequencer").PrivateKey)
-		snapshotSignerPublicKey := b.L1Info.GetInfoWithPrivKey("Sequencer").PrivateKey.PublicKey
+		snapshotAddress := b.L1Info.GetInfoWithPrivKey("Sequencer").Address
 		b.L2.ConsensusNode, err = arbnode.CreateNodeFullExecutionClient(
 			b.ctx, b.L2.Stack, execNode, execNode, execNode, execNode, arbDb, NewFetcherFromConfig(b.nodeConfig), blockchain.Config(),
-			l1Client, deployInfo, nil, nil, nil, &snapshotSignerPublicKey, snapshotSigner, fatalErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())
+			l1Client, deployInfo, nil, nil, nil, &snapshotAddress, snapshotSigner, fatalErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())
 		Require(t, err)
 	} else {
 		b.L2.ConsensusNode, err = arbnode.CreateNodeFullExecutionClient(
@@ -761,8 +761,8 @@ func (b *NodeBuilder) RestartCaffNode(t *testing.T, withSnapshotSigner bool) {
 	var currentNode *arbnode.Node
 	if withSnapshotSigner {
 		snapshotSigner := signature.DataSignerFromPrivateKey(b.L1Info.GetInfoWithPrivKey("Sequencer").PrivateKey)
-		signerPublicKey := b.L1Info.GetInfoWithPrivKey("Sequencer").PrivateKey.PublicKey
-		currentNode, err = arbnode.CreateNodeFullExecutionClient(b.ctx, stack, execNode, execNode, execNode, execNode, arbDb, NewFetcherFromConfig(b.nodeConfig), blockchain.Config(), b.L1.Client, b.addresses, nil, nil, nil, &signerPublicKey, snapshotSigner, feedErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())
+		signerAddress := b.L1Info.GetInfoWithPrivKey("Sequencer").Address
+		currentNode, err = arbnode.CreateNodeFullExecutionClient(b.ctx, stack, execNode, execNode, execNode, execNode, arbDb, NewFetcherFromConfig(b.nodeConfig), blockchain.Config(), b.L1.Client, b.addresses, nil, nil, nil, &signerAddress, snapshotSigner, feedErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())
 		Require(t, err)
 	} else {
 		currentNode, err = arbnode.CreateNodeFullExecutionClient(b.ctx, stack, execNode, execNode, execNode, execNode, arbDb, NewFetcherFromConfig(b.nodeConfig), blockchain.Config(), b.L1.Client, b.addresses, nil, nil, nil, nil, nil, feedErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -687,7 +687,7 @@ func (b *NodeBuilder) BuildL2(t *testing.T) func() {
 	return func() { b.L2.cleanup() }
 }
 
-func (b *NodeBuilder) BuildEspressoCaffNode(t *testing.T, existing *NodeBuilder) (func(), error) {
+func (b *NodeBuilder) BuildEspressoCaffNode(t *testing.T, existing *NodeBuilder, withSnapshotSigner bool) (func(), error) {
 	b.L2 = NewTestClient(b.ctx)
 	AddValNodeIfNeeded(t, b.ctx, b.nodeConfig, true, "", b.valnodeConfig.Wasm.RootPath)
 
@@ -709,10 +709,22 @@ func (b *NodeBuilder) BuildEspressoCaffNode(t *testing.T, existing *NodeBuilder)
 	fatalErrChan := make(chan error, 10)
 	locator, err := server_common.NewMachineLocator(b.valnodeConfig.Wasm.RootPath)
 	Require(t, err)
-	b.L2.ConsensusNode, err = arbnode.CreateNodeFullExecutionClient(
-		b.ctx, b.L2.Stack, execNode, execNode, execNode, execNode, arbDb, NewFetcherFromConfig(b.nodeConfig), blockchain.Config(),
-		l1Client, deployInfo, nil, nil, nil, nil, nil, fatalErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())
-	Require(t, err)
+
+	b.L1Info = existing.L1Info
+
+	if withSnapshotSigner {
+		snapshotSigner := signature.DataSignerFromPrivateKey(existing.L1Info.GetInfoWithPrivKey("Sequencer").PrivateKey)
+		snapshotSignerPublicKey := b.L1Info.GetInfoWithPrivKey("Sequencer").PrivateKey.PublicKey
+		b.L2.ConsensusNode, err = arbnode.CreateNodeFullExecutionClient(
+			b.ctx, b.L2.Stack, execNode, execNode, execNode, execNode, arbDb, NewFetcherFromConfig(b.nodeConfig), blockchain.Config(),
+			l1Client, deployInfo, nil, nil, nil, &snapshotSignerPublicKey, snapshotSigner, fatalErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())
+		Require(t, err)
+	} else {
+		b.L2.ConsensusNode, err = arbnode.CreateNodeFullExecutionClient(
+			b.ctx, b.L2.Stack, execNode, execNode, execNode, execNode, arbDb, NewFetcherFromConfig(b.nodeConfig), blockchain.Config(),
+			l1Client, deployInfo, nil, nil, nil, nil, nil, fatalErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())
+		Require(t, err)
+	}
 
 	err = b.L2.ConsensusNode.Start(b.ctx)
 	if err != nil {
@@ -725,11 +737,12 @@ func (b *NodeBuilder) BuildEspressoCaffNode(t *testing.T, existing *NodeBuilder)
 
 	b.L2.ExecNode = getExecNode(t, b.L2.ConsensusNode)
 	b.L2.cleanup = func() { b.L2.ConsensusNode.StopAndWait() }
+	b.addresses = existing.addresses
 	return func() { b.L2.cleanup() }, nil
 }
 
 // L2 -Only. RestartL2Node shutdowns the existing l2 node and start it again using the same data dir.
-func (b *NodeBuilder) RestartL2Node(t *testing.T) {
+func (b *NodeBuilder) RestartCaffNode(t *testing.T, withSnapshotSigner bool) {
 	if b.L2 == nil {
 		t.Fatalf("L2 was not created")
 	}
@@ -744,7 +757,53 @@ func (b *NodeBuilder) RestartL2Node(t *testing.T) {
 	feedErrChan := make(chan error, 10)
 	locator, err := server_common.NewMachineLocator(b.valnodeConfig.Wasm.RootPath)
 	Require(t, err)
-	currentNode, err := arbnode.CreateNodeFullExecutionClient(b.ctx, stack, execNode, execNode, execNode, execNode, arbDb, NewFetcherFromConfig(b.nodeConfig), blockchain.Config(), nil, nil, nil, nil, nil, nil, nil, feedErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())
+
+	var currentNode *arbnode.Node
+	if withSnapshotSigner {
+		snapshotSigner := signature.DataSignerFromPrivateKey(b.L1Info.GetInfoWithPrivKey("Sequencer").PrivateKey)
+		signerPublicKey := b.L1Info.GetInfoWithPrivKey("Sequencer").PrivateKey.PublicKey
+		currentNode, err = arbnode.CreateNodeFullExecutionClient(b.ctx, stack, execNode, execNode, execNode, execNode, arbDb, NewFetcherFromConfig(b.nodeConfig), blockchain.Config(), b.L1.Client, b.addresses, nil, nil, nil, &signerPublicKey, snapshotSigner, feedErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())
+		Require(t, err)
+	} else {
+		currentNode, err = arbnode.CreateNodeFullExecutionClient(b.ctx, stack, execNode, execNode, execNode, execNode, arbDb, NewFetcherFromConfig(b.nodeConfig), blockchain.Config(), b.L1.Client, b.addresses, nil, nil, nil, nil, nil, feedErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())
+		Require(t, err)
+	}
+
+	Require(t, currentNode.Start(b.ctx))
+	client := ClientForStack(t, stack)
+
+	StartWatchChanErr(t, b.ctx, feedErrChan, currentNode)
+
+	l2 := NewTestClient(b.ctx)
+	l2.ConsensusNode = currentNode
+	l2.Client = client
+	l2.ExecNode = execNode
+	l2.cleanup = func() { b.L2.ConsensusNode.StopAndWait() }
+	l2.Stack = stack
+
+	b.L2 = l2
+	b.L2Info = l2info
+}
+
+// L2 -Only. RestartL2Node shutdowns the existing l2 node and start it again using the same data dir.
+func (b *NodeBuilder) RestartL2Node(t *testing.T) {
+	if b.L2 == nil {
+		t.Fatalf("L2 was not created")
+	}
+	log.Info("L2 was created")
+	b.L2.cleanup()
+
+	l2info, stack, chainDb, arbDb, blockchain := createNonL1BlockChainWithStackConfig(t, b.L2Info, b.dataDir, b.chainConfig, b.arbOSInit, b.initMessage, b.l2StackConfig, b.execConfig, b.wasmCacheTag, b.useFreezer)
+
+	execConfigFetcher := func() *gethexec.Config { return b.execConfig }
+	execNode, err := gethexec.CreateExecutionNode(b.ctx, stack, chainDb, blockchain, nil, execConfigFetcher, 0)
+	Require(t, err)
+
+	feedErrChan := make(chan error, 10)
+	locator, err := server_common.NewMachineLocator(b.valnodeConfig.Wasm.RootPath)
+	Require(t, err)
+
+	currentNode, err := arbnode.CreateNodeFullExecutionClient(b.ctx, stack, execNode, execNode, execNode, execNode, arbDb, NewFetcherFromConfig(b.nodeConfig), blockchain.Config(), b.L1.Client, b.addresses, nil, nil, nil, nil, nil, feedErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())
 	Require(t, err)
 
 	Require(t, currentNode.Start(b.ctx))
@@ -1370,7 +1429,6 @@ func deployOnParentChain(
 	deployBold bool,
 	delayBufferThreshold uint64,
 ) (*chaininfo.RollupAddresses, *arbostypes.ParsedInitMessage) {
-	log.Info("Came inside deployParentChain")
 	parentChainInfo.GenerateAccount("RollupOwner")
 	parentChainInfo.GenerateAccount("Sequencer")
 	parentChainInfo.GenerateAccount("Validator")
@@ -1511,7 +1569,6 @@ func deployOnParentChain(
 	parentChainInfo.SetContract("Inbox", addresses.Inbox)
 	parentChainInfo.SetContract("UpgradeExecutor", addresses.UpgradeExecutor)
 	parentChainInfo.SetContract("EspressoTEEVerifierMock", espressoTEEVerifierAddress)
-	log.Info("RollupSequencerManager address", "address", rollupSequencerManagerAddress)
 	parentChainInfo.SetContract("RollupSequencerManager", rollupSequencerManagerAddress)
 	initMessage := getInitMessage(ctx, t, parentChainClient, addresses)
 	return addresses, initMessage

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -526,7 +526,7 @@ func buildOnParentChain(
 	Require(t, err)
 	chainTestClient.ConsensusNode, err = arbnode.CreateNodeFullExecutionClient(
 		ctx, chainTestClient.Stack, execNode, execNode, execNode, execNode, arbDb, NewFetcherFromConfig(nodeConfig), blockchain.Config(), parentChainTestClient.Client,
-		addresses, validatorTxOptsPtr, sequencerTxOptsPtr, dataSigner, nil, fatalErrChan, parentChainId, nil, locator.LatestWasmModuleRoot())
+		addresses, validatorTxOptsPtr, sequencerTxOptsPtr, dataSigner, nil, nil, fatalErrChan, parentChainId, nil, locator.LatestWasmModuleRoot())
 	Require(t, err)
 
 	err = chainTestClient.ConsensusNode.Start(ctx)
@@ -654,7 +654,7 @@ func (b *NodeBuilder) BuildL2(t *testing.T) func() {
 	Require(t, err)
 	b.L2.ConsensusNode, err = arbnode.CreateNodeFullExecutionClient(
 		b.ctx, b.L2.Stack, execNode, execNode, execNode, execNode, arbDb, NewFetcherFromConfig(b.nodeConfig), blockchain.Config(),
-		nil, nil, nil, nil, nil, nil, fatalErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())
+		nil, nil, nil, nil, nil, nil, nil, fatalErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())
 	Require(t, err)
 
 	// Give the node an init message
@@ -711,7 +711,7 @@ func (b *NodeBuilder) BuildEspressoCaffNode(t *testing.T, existing *NodeBuilder)
 	Require(t, err)
 	b.L2.ConsensusNode, err = arbnode.CreateNodeFullExecutionClient(
 		b.ctx, b.L2.Stack, execNode, execNode, execNode, execNode, arbDb, NewFetcherFromConfig(b.nodeConfig), blockchain.Config(),
-		l1Client, deployInfo, nil, nil, nil, nil, fatalErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())
+		l1Client, deployInfo, nil, nil, nil, nil, nil, fatalErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())
 	Require(t, err)
 
 	err = b.L2.ConsensusNode.Start(b.ctx)
@@ -744,7 +744,7 @@ func (b *NodeBuilder) RestartL2Node(t *testing.T) {
 	feedErrChan := make(chan error, 10)
 	locator, err := server_common.NewMachineLocator(b.valnodeConfig.Wasm.RootPath)
 	Require(t, err)
-	currentNode, err := arbnode.CreateNodeFullExecutionClient(b.ctx, stack, execNode, execNode, execNode, execNode, arbDb, NewFetcherFromConfig(b.nodeConfig), blockchain.Config(), nil, nil, nil, nil, nil, nil, feedErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())
+	currentNode, err := arbnode.CreateNodeFullExecutionClient(b.ctx, stack, execNode, execNode, execNode, execNode, arbDb, NewFetcherFromConfig(b.nodeConfig), blockchain.Config(), nil, nil, nil, nil, nil, nil, nil, feedErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())
 	Require(t, err)
 
 	Require(t, currentNode.Start(b.ctx))
@@ -1674,9 +1674,9 @@ func Create2ndNodeWithConfig(
 	locator, err := server_common.NewMachineLocator(valnodeConfig.Wasm.RootPath)
 	Require(t, err)
 	if useExecutionClientOnly {
-		currentNode, err = arbnode.CreateNodeExecutionClient(ctx, chainStack, currentExec, arbDb, NewFetcherFromConfig(nodeConfig), blockchain.Config(), parentChainClient, addresses, &validatorTxOpts, &sequencerTxOpts, dataSigner, nil, feedErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())
+		currentNode, err = arbnode.CreateNodeExecutionClient(ctx, chainStack, currentExec, arbDb, NewFetcherFromConfig(nodeConfig), blockchain.Config(), parentChainClient, addresses, &validatorTxOpts, &sequencerTxOpts, dataSigner, nil, nil, feedErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())
 	} else {
-		currentNode, err = arbnode.CreateNodeFullExecutionClient(ctx, chainStack, currentExec, currentExec, currentExec, currentExec, arbDb, NewFetcherFromConfig(nodeConfig), blockchain.Config(), parentChainClient, addresses, &validatorTxOpts, &sequencerTxOpts, dataSigner, nil, feedErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())
+		currentNode, err = arbnode.CreateNodeFullExecutionClient(ctx, chainStack, currentExec, currentExec, currentExec, currentExec, arbDb, NewFetcherFromConfig(nodeConfig), blockchain.Config(), parentChainClient, addresses, &validatorTxOpts, &sequencerTxOpts, dataSigner, nil, nil, feedErrChan, big.NewInt(1337), nil, locator.LatestWasmModuleRoot())
 	}
 
 	Require(t, err)


### PR DESCRIPTION
# Description

This is the initial PR for authenticated storage, I will have a follow up PR where I will make all the geth RPC calls authenticated to check for TEE signature. 

This part of the PR:
- Adds the signature over the block to the database
- Adds signature over the fromBlock and hotshot block
- Stores Delayed Messages in memory

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211374300506674
  - https://app.asana.com/0/0/1211374300506677