### PR TITLE
Fix empty batch

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -1890,6 +1890,15 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 		}
 	}
 
+	if b.building.firstDelayedMsg != nil && b.espressoStreamer != nil {
+		// #nosec G115
+		timeSinceMsg := time.Since(time.Unix(int64(b.building.firstDelayedMsg.Message.Header.Timestamp), 0))
+		if timeSinceMsg >= config.MaxEmptyBatchDelay {
+			forcePostBatch = true
+			b.building.haveUsefulMessage = true
+		}
+	}
+
 	for b.building.msgCount < msgCount {
 		msg, err := getNextMessage()
 		if err != nil {

--- a/ci_skip_tests
+++ b/ci_skip_tests
@@ -45,6 +45,7 @@ TestStylusOpcodeTraceEquivalence
 TestGettingState
 TestEmptyCliConfig
 TestBatchPosterDelayBufferDisabled
+TestLatestConsensusRelease
 
 # These tests are skipped because of invalid long paths of temporary directory
 # in CI environment. Currently we don't have methods to modify the


### PR DESCRIPTION
Cherrp-picks the empty batch fix

Note: A test is skipped in CI because this test is to check releases of upstream. I don't think this test is needed in our repo