### PR TITLE
Build tee bindings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ clean:
 	rm -f arbitrator/wasm-libraries/forward/*.wat
 	rm -rf arbitrator/stylus/tests/*/target/ arbitrator/stylus/tests/*/*.wasm
 	rm -rf brotli/buildfiles
-	@rm -rf contracts/build contracts/cache solgen/go/ espresso-tee-contracts/go/
+	@rm -rf contracts/build contracts/cache solgen/go/ espresso-tee-contracts/espressogen/
 	@rm -rf contracts-legacy/build contracts-legacy/cache
 	@rm -rf contracts-local/out contracts-local/forge-cache
 	@rm -f .make/*
@@ -613,9 +613,9 @@ contracts/test/prover/proofs/%.json: $(arbitrator_cases)/%.wasm $(prover_bin)
 	go run ./solgen/gen.go
 	@touch $@
 
-.make/espresso-gen: $(DEP_PREDICATE) espresso-tee-contracts/gen.go .make/solidity $(ORDER_ONLY_PREDICATE) .make
+.make/espresso-gen: $(DEP_PREDICATE) espresso-tee-contracts/bindings/gen.go .make/solidity $(ORDER_ONLY_PREDICATE) .make
 	mkdir -p espresso-tee-contracts/go/
-	go run -modfile ./espresso-tee-contracts/go.mod ./espresso-tee-contracts/gen.go
+	go run -modfile ./espresso-tee-contracts/bindings/go.mod ./espresso-tee-contracts/bindings/gen.go
 	@touch $@
 
 .make/solidity: $(DEP_PREDICATE) safe-smart-account/contracts/*/*.sol safe-smart-account/contracts/*.sol contracts/src/*/*.sol contracts-legacy/src/*/*.sol contracts-local/src/*/*.sol contracts-local/gas-dimensions/src/*.sol .make/yarndeps $(ORDER_ONLY_PREDICATE) .make

--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ clean:
 	rm -f arbitrator/wasm-libraries/forward/*.wat
 	rm -rf arbitrator/stylus/tests/*/target/ arbitrator/stylus/tests/*/*.wasm
 	rm -rf brotli/buildfiles
-	@rm -rf contracts/build contracts/cache solgen/go/
+	@rm -rf contracts/build contracts/cache solgen/go/ espresso-tee-contracts/bindings/go/
 	@rm -rf contracts-legacy/build contracts-legacy/cache
 	@rm -rf contracts-local/out contracts-local/forge-cache
 	@rm -f .make/*
@@ -608,9 +608,14 @@ contracts/test/prover/proofs/%.json: $(arbitrator_cases)/%.wasm $(prover_bin)
 	cargo test --manifest-path arbitrator/Cargo.toml --release
 	@touch $@
 
-.make/solgen: $(DEP_PREDICATE) solgen/gen.go .make/solidity $(ORDER_ONLY_PREDICATE) .make
+.make/solgen: $(DEP_PREDICATE) solgen/gen.go .make/solidity .make/espresso-gen  $(ORDER_ONLY_PREDICATE) .make
 	mkdir -p solgen/go/
 	go run ./solgen/gen.go
+	@touch $@
+
+.make/espresso-gen: $(DEP_PREDICATE) espresso-tee-contracts/bindings/gen.go .make/solidity $(ORDER_ONLY_PREDICATE) .make
+	mkdir -p espresso-tee-contracts/go/
+	go run -modfile ./espresso-tee-contracts/go.mod ./espresso-tee-contracts/bindings/gen.go
 	@touch $@
 
 .make/solidity: $(DEP_PREDICATE) safe-smart-account/contracts/*/*.sol safe-smart-account/contracts/*.sol contracts/src/*/*.sol contracts-legacy/src/*/*.sol contracts-local/src/*/*.sol contracts-local/gas-dimensions/src/*.sol .make/yarndeps $(ORDER_ONLY_PREDICATE) .make

--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ clean:
 	rm -f arbitrator/wasm-libraries/forward/*.wat
 	rm -rf arbitrator/stylus/tests/*/target/ arbitrator/stylus/tests/*/*.wasm
 	rm -rf brotli/buildfiles
-	@rm -rf contracts/build contracts/cache solgen/go/ espresso-tee-contracts/bindings/go/
+	@rm -rf contracts/build contracts/cache solgen/go/ espresso-tee-contracts/go/
 	@rm -rf contracts-legacy/build contracts-legacy/cache
 	@rm -rf contracts-local/out contracts-local/forge-cache
 	@rm -f .make/*
@@ -613,9 +613,9 @@ contracts/test/prover/proofs/%.json: $(arbitrator_cases)/%.wasm $(prover_bin)
 	go run ./solgen/gen.go
 	@touch $@
 
-.make/espresso-gen: $(DEP_PREDICATE) espresso-tee-contracts/bindings/gen.go .make/solidity $(ORDER_ONLY_PREDICATE) .make
+.make/espresso-gen: $(DEP_PREDICATE) espresso-tee-contracts/gen.go .make/solidity $(ORDER_ONLY_PREDICATE) .make
 	mkdir -p espresso-tee-contracts/go/
-	go run -modfile ./espresso-tee-contracts/go.mod ./espresso-tee-contracts/bindings/gen.go
+	go run -modfile ./espresso-tee-contracts/go.mod ./espresso-tee-contracts/gen.go
 	@touch $@
 
 .make/solidity: $(DEP_PREDICATE) safe-smart-account/contracts/*/*.sol safe-smart-account/contracts/*.sol contracts/src/*/*.sol contracts-legacy/src/*/*.sol contracts-local/src/*/*.sol contracts-local/gas-dimensions/src/*.sol .make/yarndeps $(ORDER_ONLY_PREDICATE) .make

--- a/Makefile
+++ b/Makefile
@@ -614,7 +614,7 @@ contracts/test/prover/proofs/%.json: $(arbitrator_cases)/%.wasm $(prover_bin)
 	@touch $@
 
 .make/espresso-gen: $(DEP_PREDICATE) espresso-tee-contracts/bindings/gen.go .make/solidity $(ORDER_ONLY_PREDICATE) .make
-	mkdir -p espresso-tee-contracts/go/
+	mkdir -p espresso-tee-contracts/espressogen/
 	go run -modfile ./espresso-tee-contracts/bindings/go.mod ./espresso-tee-contracts/bindings/gen.go
 	@touch $@
 

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -19,7 +19,6 @@ import (
 	hotshotClient "github.com/EspressoSystems/espresso-network/sdks/go/client"
 	lightclient "github.com/EspressoSystems/espresso-network/sdks/go/light-client"
 	"github.com/andybalholm/brotli"
-	"github.com/espressosystems/espresso-tee-contracts/espressogen"
 	"github.com/spf13/pflag"
 
 	"github.com/ethereum/go-ethereum"
@@ -47,6 +46,7 @@ import (
 	"github.com/offchainlabs/nitro/cmd/chaininfo"
 	"github.com/offchainlabs/nitro/cmd/genericconf"
 	"github.com/offchainlabs/nitro/daprovider"
+	"github.com/offchainlabs/nitro/espresso-tee-contracts/espressogen"
 	espresso_key_manager "github.com/offchainlabs/nitro/espresso/key-manager"
 	"github.com/offchainlabs/nitro/espresso/submitter"
 	"github.com/offchainlabs/nitro/espressostreamer"

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -19,6 +19,7 @@ import (
 	hotshotClient "github.com/EspressoSystems/espresso-network/sdks/go/client"
 	lightclient "github.com/EspressoSystems/espresso-network/sdks/go/light-client"
 	"github.com/andybalholm/brotli"
+	"github.com/espressosystems/espresso-tee-contracts/espressogen"
 	"github.com/spf13/pflag"
 
 	"github.com/ethereum/go-ethereum"
@@ -51,7 +52,6 @@ import (
 	"github.com/offchainlabs/nitro/espressostreamer"
 	"github.com/offchainlabs/nitro/espressotee"
 	"github.com/offchainlabs/nitro/execution"
-	"github.com/offchainlabs/nitro/solgen/go/espressogen"
 	"github.com/offchainlabs/nitro/util"
 	"github.com/offchainlabs/nitro/util/arbmath"
 	"github.com/offchainlabs/nitro/util/blobs"

--- a/arbnode/espresso_batch_poster_helpers.go
+++ b/arbnode/espresso_batch_poster_helpers.go
@@ -10,8 +10,8 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/offchainlabs/nitro/arbutil"
+	"github.com/offchainlabs/nitro/espresso-tee-contracts/espressogen"
 	"github.com/offchainlabs/nitro/espressotee"
-	"github.com/offchainlabs/nitro/solgen/go/espressogen"
 )
 
 // Reads state from external sources and resets the espresso streamer to start producing

--- a/espressotee/espresso_verifier.go
+++ b/espressotee/espresso_verifier.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/offchainlabs/nitro/arbnode/dataposter"
-	"github.com/offchainlabs/nitro/solgen/go/espressogen"
+	"github.com/offchainlabs/nitro/espresso-tee-contracts/espressogen"
 )
 
 type EspressoTEEVerifierInterface interface {

--- a/espressotee/nitro_verifier.go
+++ b/espressotee/nitro_verifier.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/offchainlabs/nitro/arbnode/dataposter"
-	"github.com/offchainlabs/nitro/solgen/go/espressogen"
+	"github.com/offchainlabs/nitro/espresso-tee-contracts/espressogen"
 )
 
 type EspressoNitroTEEVerifierInterface interface {

--- a/espressotee/sgx_verifier.go
+++ b/espressotee/sgx_verifier.go
@@ -5,7 +5,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 
-	"github.com/offchainlabs/nitro/solgen/go/espressogen"
+	"github.com/offchainlabs/nitro/espresso-tee-contracts/espressogen"
 )
 
 type EspressoSGXVerifierInterface interface {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ replace github.com/ethereum/go-ethereum => ./go-ethereum
 
 replace github.com/offchainlabs/bold => ./bold
 
+replace github.com/espressosystems/espresso-tee-contracts/espressogen => ./espresso-tee-contracts
+
 require (
 	cloud.google.com/go/storage v1.43.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,6 @@ replace github.com/ethereum/go-ethereum => ./go-ethereum
 
 replace github.com/offchainlabs/bold => ./bold
 
-replace github.com/espressosystems/espresso-tee-contracts/espressogen => ./espresso-tee-contracts
-
 require (
 	cloud.google.com/go/storage v1.43.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
@@ -178,7 +176,7 @@ require (
 	github.com/google/go-github/v62 v62.0.0
 	github.com/google/pprof v0.0.0-20231023181126-ff6d637d2a7b // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
-	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/gorilla/websocket v1.5.0
 	github.com/graph-gophers/graphql-go v1.3.0 // indirect
 	github.com/h2non/filetype v1.0.6 // indirect
 	github.com/hashicorp/go-bexpr v0.1.10 // indirect


### PR DESCRIPTION
Closes #[Asana Ticket](https://app.asana.com/0/home/1209393650288774/1211374300506640)

### This PR:
Adds to the build process of the nitro node to build the espresso-tee-contracts bindings.

### This PR does not:
Change the existing project to use these new bindings in existing places.  

### Key places to review:
`Makefile`
`go.mod`
project structure of the espresso-tee-contracts project on the main branch.

### How to test this PR:
Run `make clean`, see that the generated bindings do not exist in the `espresso-tee-contracts` directory.
Run `make contracts`, observe that the espressogen bindings are created.

