### PR TITLE
Use TEE Caff Node compatible bindings in BatchPoster and Caff Node

### DIFF
--- a/espresso/key-manager/key_manager.go
+++ b/espresso/key-manager/key_manager.go
@@ -120,7 +120,7 @@ func (k *EspressoKeyManager) VerifyRegistered() (bool, error) {
 		panic("failed to get public key")
 	}
 	signerAddr := crypto.PubkeyToAddress(*pubKey)
-	ok, err := k.espressoTEEVerifierCaller.RegisteredSigners(signerAddr, uint8(k.teeType), k.registerSignerOpts)
+	ok, err := k.espressoTEEVerifierCaller.RegisteredServices(signerAddr, uint8(k.teeType), espressotee.BatchPoster, k.registerSignerOpts)
 	if err != nil {
 		return false, err
 	}
@@ -179,7 +179,7 @@ func (k *EspressoKeyManager) Register(getAttestationFunc func([]byte) ([]byte, e
 		return err
 	}
 
-	err = k.espressoTEEVerifierCaller.RegisterSigner(k.dataPoster, attestation, data, uint8(k.teeType), k.registerSignerOpts)
+	err = k.espressoTEEVerifierCaller.RegisterService(k.dataPoster, attestation, data, uint8(k.teeType), espressotee.BatchPoster, k.registerSignerOpts)
 	if err != nil {
 		return err
 	}

--- a/espressostreamer/espresso_streamer.go
+++ b/espressostreamer/espresso_streamer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -206,19 +207,14 @@ func (s *EspressoStreamer) verifyBatchPosterSignature(signature []byte, userData
 		return fmt.Errorf("failed to convert signature to public key: %w", err)
 	}
 	addr := crypto.PubkeyToAddress(*publicKey)
-	found := false
 	validAddresses := s.batcherAddressesFetcher(l1Height)
 	if len(validAddresses) == 0 {
 		// No valid addresses right now. Need to catch up
 		return ErrRetryParsingHotShotPayload
 	}
-	for _, allowed := range validAddresses {
-		if allowed == addr {
-			found = true
-			break
-		}
-	}
-	if !found {
+	// if the list of valid addresses doesn't contain the address from the signature, this signature is invalid,
+	// and we must return an error.
+	if !slices.Contains(validAddresses, addr) {
 		log.Warn("batch poster address", "addr", addr, "expected one of", validAddresses)
 		return fmt.Errorf("batch poster address does not match")
 	}
@@ -236,7 +232,9 @@ func (s *EspressoStreamer) GetCurrentEarliestHotShotBlockNumber() uint64 {
 
 /* Verify the attestation quote */
 func (s *EspressoStreamer) verifyLegacy(attestation []byte, signature [32]byte) error {
-	_, err := s.espressoSGXVerifier.Verify(nil, attestation, signature)
+	// as of 02/10/2025 there has never been an sgx TEE Caff Node that would want to use this function,
+	// Therefore we can hard code espressotee.BatchPoster
+	_, err := s.espressoSGXVerifier.Verify(nil, attestation, signature, espressotee.BatchPoster)
 	if err == nil {
 		return nil
 	}

--- a/espressostreamer/espresso_streamer_test.go
+++ b/espressostreamer/espresso_streamer_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/arbutil"
+	"github.com/offchainlabs/nitro/espressotee"
 	"github.com/offchainlabs/nitro/solgen/go/espressogen"
 )
 
@@ -304,7 +305,7 @@ type mockEspressoTEEVerifier struct {
 	mock.Mock
 }
 
-func (v *mockEspressoTEEVerifier) Verify(opts *bind.CallOpts, attestation []byte, signature [32]byte) (espressogen.EnclaveReport, error) {
+func (v *mockEspressoTEEVerifier) Verify(opts *bind.CallOpts, attestation []byte, signature [32]byte, serviceType espressotee.ServiceType) (espressogen.EnclaveReport, error) {
 	return espressogen.EnclaveReport{}, nil
 }
 

--- a/espressotee/espresso_verifier.go
+++ b/espressotee/espresso_verifier.go
@@ -18,16 +18,18 @@ import (
 )
 
 type EspressoTEEVerifierInterface interface {
-	RegisterSigner(
+	RegisterService(
 		dataPoster *dataposter.DataPoster,
 		attestation []byte,
 		data []byte,
 		teeType uint8,
+		serviceType ServiceType,
 		registerSignerOpts EspressoRegisterSignerOpts,
 	) error
-	RegisteredSigners(
+	RegisteredServices(
 		signer common.Address,
 		teeType uint8,
+		serviceType ServiceType,
 		registerSignerOpts EspressoRegisterSignerOpts,
 	) (bool, error)
 }
@@ -42,11 +44,12 @@ func NewEspressoTEEVerifier(contract *espressogen.IEspressoTEEVerifier, l1Client
 	return &EspressoTEEVerifier{contract: contract, l1Client: l1Client, address: address}
 }
 
-func (e *EspressoTEEVerifier) RegisterSigner(
+func (e *EspressoTEEVerifier) RegisterService(
 	dataPoster *dataposter.DataPoster,
 	attestation []byte,
 	data []byte,
 	teeType uint8,
+	serviceType ServiceType,
 	registerSignerOpts EspressoRegisterSignerOpts,
 ) error {
 	// First check base fee is low enough
@@ -68,8 +71,8 @@ func (e *EspressoTEEVerifier) RegisterSigner(
 		return err
 	}
 
-	// Pack the function arguments (attestation, data, teeType)
-	calldata, err := contractABI.Pack("registerSigner", attestation, data, teeType)
+	// Pack the function arguments (attestation, data, teeType, serviceType)
+	calldata, err := contractABI.Pack("registerService", attestation, data, teeType, serviceType)
 	if err != nil {
 		return err
 	}
@@ -126,12 +129,12 @@ func (e *EspressoTEEVerifier) RegisterSigner(
 	return nil
 }
 
-func (e *EspressoTEEVerifier) RegisteredSigners(address common.Address, teeType uint8, registerSignerOpts EspressoRegisterSignerOpts) (bool, error) {
+func (e *EspressoTEEVerifier) RegisteredServices(address common.Address, teeType uint8, serviceType ServiceType, registerSignerOpts EspressoRegisterSignerOpts) (bool, error) {
 	ok, err := ContractVerification(
 		registerSignerOpts.MaxRetries,
 		registerSignerOpts.RetryReadContractDelay,
 		func() (bool, error) {
-			return e.contract.RegisteredSigners(&bind.CallOpts{}, address, teeType)
+			return e.contract.RegisteredServices(&bind.CallOpts{}, address, teeType, uint8(serviceType))
 		},
 		"address not yet registered in contract",
 	)

--- a/espressotee/nitro_verifier.go
+++ b/espressotee/nitro_verifier.go
@@ -34,7 +34,7 @@ type EspressoNitroTEEVerifierInterface interface {
 		dataPoster *dataposter.DataPoster,
 		registerSignerOpts EspressoRegisterSignerOpts,
 	) ([]byte, []byte, error)
-	IsPCR0HashRegistered(pcr0Hash [32]byte) (bool, error)
+	IsPCR0HashRegistered(pcr0Hash [32]byte, serviceType ServiceType) (bool, error)
 }
 
 type EspressoNitroTEEVerifier struct {
@@ -47,8 +47,15 @@ func NewEspressoNitroTEEVerifier(contract *espressogen.IEspressoNitroTEEVerifier
 	return &EspressoNitroTEEVerifier{contract: contract, l1Client: l1Client, address: nitroAddr}
 }
 
-func (e *EspressoNitroTEEVerifier) IsPCR0HashRegistered(pcr0Hash [32]byte) (bool, error) {
-	return e.contract.RegisteredEnclaveHash(&bind.CallOpts{}, pcr0Hash)
+func (e *EspressoNitroTEEVerifier) IsPCR0HashRegistered(pcr0Hash [32]byte, serviceType ServiceType) (bool, error) {
+	switch serviceType {
+	case BatchPoster:
+		return e.contract.RegisteredBatchPosterEnclaveHashes(&bind.CallOpts{}, pcr0Hash)
+	case CaffNode:
+		return e.contract.RegisteredCaffNodeEnclaveHashes(&bind.CallOpts{}, pcr0Hash)
+	default:
+		return false, fmt.Errorf("Invalid service type for checking PCR0 hash registration")
+	}
 }
 
 /**
@@ -189,7 +196,7 @@ func (e *EspressoNitroTEEVerifier) VerifyAttestationAndCertificates(
 	log.Info("successfully got attestation", "pcr0 hash", pcr0Hash)
 
 	// Before verifying certificates on chain, check if the pcr0 hash is registered to save gas
-	verified, err := e.IsPCR0HashRegistered(pcr0Hash)
+	verified, err := e.IsPCR0HashRegistered(pcr0Hash, BatchPoster) // Currently we only cxall this function with the batcher, this might change in the future.
 	if err != nil {
 		log.Error("failed to check if pcr0 hash is verified", "pcr0 hash", pcr0Hash)
 		return nil, nil, err

--- a/espressotee/sgx_verifier.go
+++ b/espressotee/sgx_verifier.go
@@ -9,15 +9,15 @@ import (
 )
 
 type EspressoSGXVerifierInterface interface {
-	Verify(opts *bind.CallOpts, rawQuote []byte, reportDataHash [32]byte) (espressogen.EnclaveReport, error)
+	Verify(opts *bind.CallOpts, rawQuote []byte, reportDataHash [32]byte, serviceType ServiceType) (espressogen.EnclaveReport, error)
 }
 
 type EspressoSGXVerifier struct {
 	verifier *espressogen.IEspressoSGXTEEVerifier
 }
 
-func (v *EspressoSGXVerifier) Verify(opts *bind.CallOpts, rawQuote []byte, reportDataHash [32]byte) (espressogen.EnclaveReport, error) {
-	return v.verifier.Verify(opts, rawQuote, reportDataHash)
+func (v *EspressoSGXVerifier) Verify(opts *bind.CallOpts, rawQuote []byte, reportDataHash [32]byte, serviceType ServiceType) (espressogen.EnclaveReport, error) {
+	return v.verifier.Verify(opts, rawQuote, reportDataHash, uint8(serviceType))
 }
 
 func NewEspressoSGXVerifier(l1Client *ethclient.Client, addr common.Address) (*EspressoSGXVerifier, error) {

--- a/espressotee/types.go
+++ b/espressotee/types.go
@@ -1,0 +1,8 @@
+package espressotee
+
+type ServiceType uint8
+
+const (
+	BatchPoster ServiceType = iota
+	CaffNode
+)


### PR DESCRIPTION
Closes #[Asana Ticket](https://app.asana.com/0/home/1209393650288774/1211374300506650)

### TODO's:
Check that arbnode/batch_poster.go doesn't need additional changes.
Update caff node for new behavior with bindings.

### This PR:
Uses the new bindings from the in the integration repo for the batch poster
TODO: Use the new bindings in the Caff node for registration. 
### This PR does not:
Update the SequencerInbox contract to make E2E or integration tests pass.

### Key places to review:
All files in `espressotee`
`key_manager.go`
`espresso_streamer.go`

### How to test this PR:
```
make clean
make build
```
### Things tested
Currently the build is working.