### PR TITLE
Add accessor_chains to authdb

### DIFF
--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -350,20 +350,7 @@ func (n *EspressoCaffNode) createBlock(ctx context.Context) (returnValue bool) {
 		}
 	}
 
-	// Store block and its auth tag
-	err = n.db.AuthWriteBlock(batch, block)
-	if err != nil {
-		log.Error("failed to store block and its auth tag", "err", err)
-		return false
-	}
-
-	// Store header and its auth tag
-	err = n.db.AuthWriteHeader(batch, block.Header())
-	if err != nil {
-		log.Error("failed to store header and its auth tag", "err", err)
-		return false
-	}
-
+	// the `AuthDB.Put()` adds the auth tags alongside the content of block header, body, and receipts
 	err = n.executionEngine.AppendBlock(block, statedb, receipts, blockCalcTime)
 	if err != nil {
 		log.Error("Failed to append block", "err", err)

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -357,6 +357,13 @@ func (n *EspressoCaffNode) createBlock(ctx context.Context) (returnValue bool) {
 		return false
 	}
 
+	// Store header and its auth tag
+	err = n.db.AuthWriteHeader(batch, block.Header())
+	if err != nil {
+		log.Error("failed to store header and its auth tag", "err", err)
+		return false
+	}
+
 	err = n.executionEngine.AppendBlock(block, statedb, receipts, blockCalcTime)
 	if err != nil {
 		log.Error("Failed to append block", "err", err)

--- a/espresso/authdb/accessors_chain.go
+++ b/espresso/authdb/accessors_chain.go
@@ -2,6 +2,7 @@ package authdb
 
 import (
 	"crypto/hmac"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -9,102 +10,127 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
-func (d *AuthDB) readHeader(hash common.Hash, number uint64) *types.Header {
-	headerKey := _headerKey(number, hash)
-	// Get the header bytes
+func (d *AuthDB) authReadHeader(hash common.Hash, number uint64) ([]byte, error) {
+	headerKey := headerKey(number, hash)
 	headerBytes, err := d.db.Get(headerKey)
 	if err != nil {
 		log.Error("Failed to get header bytes", "hash", hash, "err", err)
-		return nil
+		return nil, err
 	}
 
-	// Contract block from headerBytes
 	header := new(types.Header)
 	err = rlp.DecodeBytes(headerBytes, header)
 	if err != nil {
 		log.Error("Failed to decode header", "hash", hash, "err", err)
-		return nil
+		return nil, err
+	}
+
+	expectedTag, err := d.db.Get(headerAuthTagKey(number, hash))
+	if err != nil {
+		log.Error("Failed to get header auth tag", "hash", hash, "err", err)
+		return nil, err
 	}
 
 	d.mac.Write(headerKey)
 	d.mac.Write(headerBytes)
-	taggedBlockHash := d.mac.Sum(nil)
+	tag := d.mac.Sum(nil)
 	d.mac.Reset()
 
-	if !hmac.Equal(taggedBlockHash, header.Hash().Bytes()) {
-		log.Error("Block hash mismatch", "hash", hash, "number", number)
-		return nil
+	if !hmac.Equal(tag, expectedTag) {
+		log.Error("failed to authenticate header", "hash", hash, "number", number)
+		return nil, fmt.Errorf("failed to authenticate header, hash: %v, number: %d", hash, number)
 	}
 
-	if header.Number.Uint64() != number {
-		log.Error("Block number mismatch", "hash", hash, "number", number)
-		return nil
-	}
-
-	return header
+	return headerBytes, nil
 }
 
-func (d *AuthDB) readBody(hash common.Hash, number uint64) *types.Body {
-	block := d.readBlock(hash, number)
-	if block == nil {
-		return nil
-	}
-
-	return block.Body()
-}
-
-func (d *AuthDB) readReceipts(hash common.Hash, number uint64) *types.Receipts {
-	block := d.readBlock(hash, number)
-	if block == nil {
-		return nil
-	}
-	// TODO
-	return nil
-}
-
-func (d *AuthDB) readBlock(hash common.Hash, number uint64) *types.Block {
-	blockKey := blockKey(number, hash)
-	// Get the block bytes
-	blockBytes, err := d.db.Get(blockKey)
+func (d *AuthDB) authReadBody(hash common.Hash, number uint64) ([]byte, error) {
+	bodyKey := blockBodyKey(number, hash)
+	bodyBytes, err := d.db.Get(bodyKey)
 	if err != nil {
-		log.Error("Failed to get block bytes", "number", number, "hash", hash, "err", err)
-		return nil
+		log.Error("Failed to get body bytes", "hash", hash, "err", err)
+		return nil, err
 	}
 
-	if len(blockBytes) == 0 {
-		log.Warn("Empty block bytes", "number", number, "hash", hash)
-		return nil
-	}
-
-	// Contract block from blockBytes
-	block := new(types.Block)
-	err = rlp.DecodeBytes(blockBytes, block)
+	body := new(types.Body)
+	err = rlp.DecodeBytes(bodyBytes, body)
 	if err != nil {
-		log.Error("Failed to decode block", "number", number, "hash", hash, "err", err)
-		return nil
+		log.Error("Failed to decode body", "hash", hash, "err", err)
+		return nil, err
 	}
 
-	d.mac.Write(blockKey)
-	d.mac.Write(blockBytes)
-	taggedBlockHash := d.mac.Sum(nil)
+	expectedTag, err := d.db.Get(bodyAuthTagKey(number, hash))
+	if err != nil {
+		log.Error("Failed to get body auth tag", "hash", hash, "err", err)
+		return nil, err
+	}
+
+	d.mac.Write(bodyKey)
+	d.mac.Write(bodyBytes)
+	tag := d.mac.Sum(nil)
 	d.mac.Reset()
 
-	if !hmac.Equal(taggedBlockHash, block.Hash().Bytes()) {
-		log.Error("Block hash mismatch", "number", number, "hash", hash, "blockHash", hash)
-		return nil
+	if !hmac.Equal(tag, expectedTag) {
+		log.Error("failed to authenticate body", "hash", hash, "number", number)
+		return nil, fmt.Errorf("failed to authenticate body, hash: %v, number: %d", hash, number)
 	}
 
-	if block.Header().Number.Uint64() != number {
-		log.Error("Block number mismatch", "number", number, "hash", hash, "number", number)
-		return nil
-	}
-	return block
+	return bodyBytes, nil
 }
 
-func (d *AuthDB) readHeaderHash(hash common.Hash, number uint64) common.Hash {
-	header := d.readHeader(hash, number)
-	if header == nil {
-		return common.Hash{}
+func (d *AuthDB) authReadReceipts(hash common.Hash, number uint64) ([]byte, error) {
+	receiptsKey := blockBodyKey(number, hash)
+	receiptsBytes, err := d.db.Get(receiptsKey)
+	if err != nil {
+		log.Error("Failed to get receipts bytes", "hash", hash, "err", err)
+		return nil, err
 	}
-	return header.Hash()
+
+	receipts := new(types.Receipts)
+	err = rlp.DecodeBytes(receiptsBytes, receipts)
+	if err != nil {
+		log.Error("Failed to decode receipts", "hash", hash, "err", err)
+		return nil, err
+	}
+
+	expectedTag, err := d.db.Get(receiptsAuthTagKey(number, hash))
+	if err != nil {
+		log.Error("Failed to get receipts auth tag", "hash", hash, "err", err)
+		return nil, err
+	}
+
+	d.mac.Write(receiptsKey)
+	d.mac.Write(receiptsBytes)
+	tag := d.mac.Sum(nil)
+	d.mac.Reset()
+
+	if !hmac.Equal(tag, expectedTag) {
+		log.Error("failed to authenticate receipts", "hash", hash, "number", number)
+		return nil, fmt.Errorf("failed to authenticate receipts, hash: %v, number: %d", hash, number)
+	}
+
+	return receiptsBytes, nil
 }
+
+// func (d *AuthDB) authReadBlock(hash common.Hash, number uint64) ([]byte, error) {
+// 	bodyBytes, err := d.authReadBody(hash, number)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	body := new(types.Body)
+// 	if err := rlp.DecodeBytes(bodyBytes, body); err != nil {
+// 		return nil, fmt.Errorf("failed to decode body: %w", err)
+// 	}
+
+// 	headerBytes, err := d.authReadHeader(hash, number)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	header := new(types.Header)
+// 	if err := rlp.DecodeBytes(headerBytes, header); err != nil {
+// 		return nil, fmt.Errorf("failed to decode header: %w", err)
+// 	}
+
+// 	block := types.NewBlockWithHeader(header).WithBody(*body)
+// 	return rlp., nil
+// }

--- a/espresso/authdb/accessors_chain.go
+++ b/espresso/authdb/accessors_chain.go
@@ -1,0 +1,110 @@
+package authdb
+
+import (
+	"crypto/hmac"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+func (d *AuthDB) readHeader(hash common.Hash, number uint64) *types.Header {
+	headerKey := _headerKey(number, hash)
+	// Get the header bytes
+	headerBytes, err := d.db.Get(headerKey)
+	if err != nil {
+		log.Error("Failed to get header bytes", "hash", hash, "err", err)
+		return nil
+	}
+
+	// Contract block from headerBytes
+	header := new(types.Header)
+	err = rlp.DecodeBytes(headerBytes, header)
+	if err != nil {
+		log.Error("Failed to decode header", "hash", hash, "err", err)
+		return nil
+	}
+
+	d.mac.Write(headerKey)
+	d.mac.Write(headerBytes)
+	taggedBlockHash := d.mac.Sum(nil)
+	d.mac.Reset()
+
+	if !hmac.Equal(taggedBlockHash, header.Hash().Bytes()) {
+		log.Error("Block hash mismatch", "hash", hash, "number", number)
+		return nil
+	}
+
+	if header.Number.Uint64() != number {
+		log.Error("Block number mismatch", "hash", hash, "number", number)
+		return nil
+	}
+
+	return header
+}
+
+func (d *AuthDB) readBody(hash common.Hash, number uint64) *types.Body {
+	block := d.readBlock(hash, number)
+	if block == nil {
+		return nil
+	}
+
+	return block.Body()
+}
+
+func (d *AuthDB) readReceipts(hash common.Hash, number uint64) *types.Receipts {
+	block := d.readBlock(hash, number)
+	if block == nil {
+		return nil
+	}
+	// TODO
+	return nil
+}
+
+func (d *AuthDB) readBlock(hash common.Hash, number uint64) *types.Block {
+	blockKey := blockKey(number, hash)
+	// Get the block bytes
+	blockBytes, err := d.db.Get(blockKey)
+	if err != nil {
+		log.Error("Failed to get block bytes", "number", number, "hash", hash, "err", err)
+		return nil
+	}
+
+	if len(blockBytes) == 0 {
+		log.Warn("Empty block bytes", "number", number, "hash", hash)
+		return nil
+	}
+
+	// Contract block from blockBytes
+	block := new(types.Block)
+	err = rlp.DecodeBytes(blockBytes, block)
+	if err != nil {
+		log.Error("Failed to decode block", "number", number, "hash", hash, "err", err)
+		return nil
+	}
+
+	d.mac.Write(blockKey)
+	d.mac.Write(blockBytes)
+	taggedBlockHash := d.mac.Sum(nil)
+	d.mac.Reset()
+
+	if !hmac.Equal(taggedBlockHash, block.Hash().Bytes()) {
+		log.Error("Block hash mismatch", "number", number, "hash", hash, "blockHash", hash)
+		return nil
+	}
+
+	if block.Header().Number.Uint64() != number {
+		log.Error("Block number mismatch", "number", number, "hash", hash, "number", number)
+		return nil
+	}
+	return block
+}
+
+func (d *AuthDB) readHeaderHash(hash common.Hash, number uint64) common.Hash {
+	header := d.readHeader(hash, number)
+	if header == nil {
+		return common.Hash{}
+	}
+	return header.Hash()
+}

--- a/espresso/authdb/authdb.go
+++ b/espresso/authdb/authdb.go
@@ -3,6 +3,7 @@ package authdb
 import (
 	"bytes"
 	"crypto/hmac"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"hash"
@@ -54,6 +55,33 @@ func (d *AuthDB) AuthWriteBlock(batch ethdb.Batch, block *types.Block) error {
 	d.mac.Reset()
 	if err := batch.Put(blockAuthTagKey(num, hash), tag); err != nil {
 		return fmt.Errorf("fail to put block auth tag with number=%d, hash=%s: %w", num, hash, err)
+	}
+
+	return nil
+}
+
+func (d *AuthDB) AuthWriteHeader(batch ethdb.Batch, header *types.Header) error {
+	num := header.Number.Uint64()
+	hash := header.Hash()
+	headerBytes, err := rlp.EncodeToBytes(header)
+	if err != nil {
+		return fmt.Errorf("failed to encode block: %w", err)
+	}
+
+	headerKey := _headerKey(num, hash)
+	if err := batch.Put(headerKey, headerBytes); err != nil {
+		return fmt.Errorf("fail to put header with number=%d, hash=%s: %w", num, hash, err)
+	}
+	if d.mac == nil {
+		return nil
+	}
+
+	d.mac.Write(headerKey)
+	d.mac.Write(headerBytes)
+	tag := d.mac.Sum(nil)
+	d.mac.Reset()
+	if err := batch.Put(headerAuthTagKey(num, hash), tag); err != nil {
+		return fmt.Errorf("fail to put header auth tag with number=%d, hash=%s: %w", num, hash, err)
 	}
 
 	return nil
@@ -452,15 +480,53 @@ func (d *AuthDB) Get(key []byte) ([]byte, error) {
 	// switch-case copied over from rawdb.database.go::InspectDatabase()
 	switch {
 	case bytes.HasPrefix(key, headerPrefix) && len(key) == (len(headerPrefix)+8+common.HashLength):
-		// headers.Add(size)
+		number, err := DecodeUint64(key[len(headerPrefix) : len(headerPrefix)+8])
+		if err != nil {
+			log.Error("failed to decode block number from key", "err", err)
+			return nil, err
+		}
+		hash := common.BytesToHash(key[len(headerPrefix)+8 : len(headerPrefix)+8+common.HashLength])
+		headerBytes, err := rlp.EncodeToBytes(d.readHeader(hash, number))
+		if err != nil {
+			log.Error("failed to encode header into bytes", "err", err)
+			return nil, err
+		}
+		return headerBytes, nil
 	case bytes.HasPrefix(key, blockBodyPrefix) && len(key) == (len(blockBodyPrefix)+8+common.HashLength):
-		// bodies.Add(size)
+		number, err := DecodeUint64(key[len(blockBodyPrefix) : len(blockBodyPrefix)+8])
+		if err != nil {
+			log.Error("failed to decode block number from key", "err", err)
+			return nil, err
+		}
+		hash := common.BytesToHash(key[len(blockBodyPrefix)+8 : len(blockBodyPrefix)+8+common.HashLength])
+		body := d.readBody(hash, number)
+		if body == nil {
+			return nil, nil
+		}
+		bodyBytes, err := rlp.EncodeToBytes(body)
+		if err != nil {
+			log.Error("failed to encode body into bytes", "err", err)
+			return nil, err
+		}
+		return bodyBytes, nil
 	case bytes.HasPrefix(key, blockReceiptsPrefix) && len(key) == (len(blockReceiptsPrefix)+8+common.HashLength):
 		// receipts.Add(size)
 	case bytes.HasPrefix(key, headerPrefix) && bytes.HasSuffix(key, headerTDSuffix):
-		// tds.Add(size)
+		log.Error("headerTDSuffix is deprecated")
+		return nil, fmt.Errorf("headerTDSuffix is deprecated")
 	case bytes.HasPrefix(key, headerPrefix) && bytes.HasSuffix(key, headerHashSuffix):
-		// numHashPairings.Add(size)
+		number := binary.BigEndian.Uint64(key[len(headerPrefix) : len(headerPrefix)+8])
+		hashBytes, err := d.db.Get(headerHashKey(number))
+		if err != nil {
+			log.Error("failed to get header hash", "err", err)
+			return nil, err
+		}
+		hash := common.BytesToHash(hashBytes)
+		headerHash := d.readHeaderHash(hash, number)
+		if headerHash == (common.Hash{}) {
+			return nil, fmt.Errorf("header hash not found")
+		}
+		return hash.Bytes(), nil
 	case bytes.HasPrefix(key, headerNumberPrefix) && len(key) == (len(headerNumberPrefix)+common.HashLength):
 		// hashNumPairings.Add(size)
 	// note: IsLegacyTrieNode is not a read op, skipping

--- a/espresso/authdb/authdb.go
+++ b/espresso/authdb/authdb.go
@@ -3,17 +3,14 @@ package authdb
 import (
 	"bytes"
 	"crypto/hmac"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"hash"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
-
 	"github.com/offchainlabs/nitro/util/dbutil"
 )
 
@@ -32,60 +29,68 @@ func NewAuthDB(db ethdb.Database, mac hash.Hash) (AuthDB, error) {
 	return AuthDB{db: db, mac: mac}, nil
 }
 
-func (d *AuthDB) AuthWriteBlock(batch ethdb.Batch, block *types.Block) error {
-	num := block.NumberU64()
-	hash := block.Hash()
-	blockBytes, err := rlp.EncodeToBytes(block)
-	if err != nil {
-		return fmt.Errorf("failed to encode block: %w", err)
-	}
-	// `rawdb.WriteBlock()` will store Body and Header separately under different prefixes
-	// We store the (encoded) block content in one-piece here under a new db key.
-	blockKey := blockKey(num, hash)
-	if err := batch.Put(blockKey, blockBytes); err != nil {
-		return fmt.Errorf("fail to put block with number=%d, hash=%s: %w", num, hash, err)
-	}
-	if d.mac == nil {
-		return nil
-	}
+// // Different from rawdb.WriteBlock which write header and body separately,
+// // we write the full RLP-encoded block under a different key
+// func (d *AuthDB) AuthWriteBlock(batch ethdb.Batch, block *types.Block) error {
+// 	num := block.NumberU64()
+// 	hash := block.Hash()
+// 	blockBytes, err := rlp.EncodeToBytes(block)
+// 	if err != nil {
+// 		return fmt.Errorf("failed to encode block: %w", err)
+// 	}
+// 	// `rawdb.WriteBlock()` will store Body and Header separately under different prefixes
+// 	// We store the (encoded) block content in one-piece here under a new db key.
+// 	blockKey := blockKey(num, hash)
+// 	if err := batch.Put(blockKey, blockBytes); err != nil {
+// 		return fmt.Errorf("fail to put block with number=%d, hash=%s: %w", num, hash, err)
+// 	}
+// 	if d.mac == nil {
+// 		return nil
+// 	}
 
-	d.mac.Write(blockKey)
-	d.mac.Write(blockBytes)
-	tag := d.mac.Sum(nil)
-	d.mac.Reset()
-	if err := batch.Put(blockAuthTagKey(num, hash), tag); err != nil {
-		return fmt.Errorf("fail to put block auth tag with number=%d, hash=%s: %w", num, hash, err)
-	}
+// 	d.mac.Write(blockKey)
+// 	d.mac.Write(blockBytes)
+// 	tag := d.mac.Sum(nil)
+// 	d.mac.Reset()
+// 	if err := batch.Put(blockAuthTagKey(num, hash), tag); err != nil {
+// 		return fmt.Errorf("fail to put block auth tag with number=%d, hash=%s: %w", num, hash, err)
+// 	}
 
-	return nil
-}
+// 	return nil
+// }
 
-func (d *AuthDB) AuthWriteHeader(batch ethdb.Batch, header *types.Header) error {
-	num := header.Number.Uint64()
-	hash := header.Hash()
-	headerBytes, err := rlp.EncodeToBytes(header)
-	if err != nil {
-		return fmt.Errorf("failed to encode block: %w", err)
-	}
+// // Same as rawdb.WriteHeader except with additional auth tag
+// func (d *AuthDB) AuthWriteHeader(batch ethdb.Batch, header *types.Header) error {
+// 	// header writing logic is almost identical to rawdb.WriterHeader except using batch
+// 	var (
+// 		hash   = header.Hash()
+// 		number = header.Number.Uint64()
+// 	)
+// 	// Write the hash -> number mapping
+// 	rawdb.WriteHeaderNumber(batch, hash, number)
+// 	// Write the encoded header
+// 	data, err := rlp.EncodeToBytes(header)
+// 	if err != nil {
+// 		log.Crit("Failed to RLP encode header", "err", err)
+// 	}
+// 	key := headerKey(number, hash)
+// 	if err := d.db.Put(key, data); err != nil {
+// 		log.Crit("Failed to store header", "err", err)
+// 	}
 
-	headerKey := _headerKey(num, hash)
-	if err := batch.Put(headerKey, headerBytes); err != nil {
-		return fmt.Errorf("fail to put header with number=%d, hash=%s: %w", num, hash, err)
-	}
-	if d.mac == nil {
-		return nil
-	}
+// 	if d.mac == nil {
+// 		return nil
+// 	}
 
-	d.mac.Write(headerKey)
-	d.mac.Write(headerBytes)
-	tag := d.mac.Sum(nil)
-	d.mac.Reset()
-	if err := batch.Put(headerAuthTagKey(num, hash), tag); err != nil {
-		return fmt.Errorf("fail to put header auth tag with number=%d, hash=%s: %w", num, hash, err)
-	}
-
-	return nil
-}
+// 	d.mac.Write(key)
+// 	d.mac.Write(data)
+// 	tag := d.mac.Sum(nil)
+// 	d.mac.Reset()
+// 	if err := batch.Put(headerAuthTagKey(number, hash), tag); err != nil {
+// 		return fmt.Errorf("fail to put header auth tag with number=%d, hash=%s: %w", number, hash, err)
+// 	}
+// 	return nil
+// }
 
 func (d *AuthDB) AuthWriteNextHotshotBlockNum(batch ethdb.Batch, num uint64) error {
 	// Add the next hotshot block number to the auth db
@@ -461,6 +466,62 @@ func (d *AuthDB) WasmTargets() []ethdb.WasmTarget {
 }
 
 func (d *AuthDB) Put(key []byte, value []byte) error {
+	if d.mac == nil {
+		return d.db.Put(key, value)
+	}
+
+	// We add auth tags to header, body and tx receipts
+	switch {
+	case bytes.HasPrefix(key, headerPrefix) && len(key) == (len(headerPrefix)+8+common.HashLength):
+		number, hash, err := parseUint64AndHash(key, len(headerPrefix))
+		if err != nil {
+			return err
+		}
+
+		d.mac.Write(key)
+		d.mac.Write(value)
+		tag := d.mac.Sum(nil)
+		d.mac.Reset()
+		err = d.db.Put(headerAuthTagKey(number, hash), tag)
+		if err != nil {
+			log.Crit("failed to write header auth tag", "err", err)
+			return nil
+		}
+
+	case bytes.HasPrefix(key, blockBodyPrefix) && len(key) == (len(blockBodyPrefix)+8+common.HashLength):
+		number, hash, err := parseUint64AndHash(key, len(blockBodyPrefix))
+		if err != nil {
+			return err
+		}
+
+		d.mac.Write(key)
+		d.mac.Write(value)
+		tag := d.mac.Sum(nil)
+		d.mac.Reset()
+		err = d.db.Put(bodyAuthTagKey(number, hash), tag)
+		if err != nil {
+			log.Crit("failed to write body auth tag", "err", err)
+			return nil
+		}
+
+	case bytes.HasPrefix(key, blockReceiptsPrefix) && len(key) == (len(blockReceiptsPrefix)+8+common.HashLength):
+		number, hash, err := parseUint64AndHash(key, len(blockReceiptsPrefix))
+		if err != nil {
+			return err
+		}
+
+		d.mac.Write(key)
+		d.mac.Write(value)
+		tag := d.mac.Sum(nil)
+		d.mac.Reset()
+		err = d.db.Put(receiptsAuthTagKey(number, hash), tag)
+		if err != nil {
+			log.Crit("failed to write receipts auth tag", "err", err)
+			return nil
+		}
+	default:
+		// pass through the rest
+	}
 	return d.db.Put(key, value)
 }
 
@@ -480,55 +541,52 @@ func (d *AuthDB) Get(key []byte) ([]byte, error) {
 	// switch-case copied over from rawdb.database.go::InspectDatabase()
 	switch {
 	case bytes.HasPrefix(key, headerPrefix) && len(key) == (len(headerPrefix)+8+common.HashLength):
-		number, err := DecodeUint64(key[len(headerPrefix) : len(headerPrefix)+8])
+		number, hash, err := parseUint64AndHash(key, len(headerPrefix))
 		if err != nil {
-			log.Error("failed to decode block number from key", "err", err)
 			return nil, err
 		}
-		hash := common.BytesToHash(key[len(headerPrefix)+8 : len(headerPrefix)+8+common.HashLength])
-		headerBytes, err := rlp.EncodeToBytes(d.readHeader(hash, number))
-		if err != nil {
-			log.Error("failed to encode header into bytes", "err", err)
-			return nil, err
-		}
-		return headerBytes, nil
+		return d.authReadHeader(hash, number)
 	case bytes.HasPrefix(key, blockBodyPrefix) && len(key) == (len(blockBodyPrefix)+8+common.HashLength):
-		number, err := DecodeUint64(key[len(blockBodyPrefix) : len(blockBodyPrefix)+8])
+		number, hash, err := parseUint64AndHash(key, len(headerPrefix))
 		if err != nil {
-			log.Error("failed to decode block number from key", "err", err)
 			return nil, err
 		}
-		hash := common.BytesToHash(key[len(blockBodyPrefix)+8 : len(blockBodyPrefix)+8+common.HashLength])
-		body := d.readBody(hash, number)
-		if body == nil {
-			return nil, nil
-		}
-		bodyBytes, err := rlp.EncodeToBytes(body)
-		if err != nil {
-			log.Error("failed to encode body into bytes", "err", err)
-			return nil, err
-		}
-		return bodyBytes, nil
+		return d.authReadBody(hash, number)
 	case bytes.HasPrefix(key, blockReceiptsPrefix) && len(key) == (len(blockReceiptsPrefix)+8+common.HashLength):
-		// receipts.Add(size)
+		number, hash, err := parseUint64AndHash(key, len(headerPrefix))
+		if err != nil {
+			return nil, err
+		}
+		return d.authReadReceipts(hash, number)
 	case bytes.HasPrefix(key, headerPrefix) && bytes.HasSuffix(key, headerTDSuffix):
 		log.Error("headerTDSuffix is deprecated")
 		return nil, fmt.Errorf("headerTDSuffix is deprecated")
 	case bytes.HasPrefix(key, headerPrefix) && bytes.HasSuffix(key, headerHashSuffix):
-		number := binary.BigEndian.Uint64(key[len(headerPrefix) : len(headerPrefix)+8])
+		number, err := DecodeUint64(key[len(headerPrefix) : len(headerPrefix)+8])
+		if err != nil {
+			log.Error("failed to decode header number", "err", err)
+			return nil, err
+		}
 		hashBytes, err := d.db.Get(headerHashKey(number))
 		if err != nil {
 			log.Error("failed to get header hash", "err", err)
 			return nil, err
 		}
 		hash := common.BytesToHash(hashBytes)
-		headerHash := d.readHeaderHash(hash, number)
-		if headerHash == (common.Hash{}) {
-			return nil, fmt.Errorf("header hash not found")
-		}
-		return hash.Bytes(), nil
+		return d.authReadHeader(hash, number)
 	case bytes.HasPrefix(key, headerNumberPrefix) && len(key) == (len(headerNumberPrefix)+common.HashLength):
-		// hashNumPairings.Add(size)
+		hash := common.BytesToHash(key[len(headerNumberPrefix) : len(headerNumberPrefix)+common.HashLength])
+		numberBytes, err := d.db.Get(headerNumberKey(hash))
+		if err != nil {
+			log.Error("failed to get header number", "err", err)
+			return nil, err
+		}
+		number, err := DecodeUint64(numberBytes)
+		if err != nil {
+			log.Error("failed to decode header number", "err", err)
+			return nil, err
+		}
+		return d.authReadHeader(hash, number)
 	// note: IsLegacyTrieNode is not a read op, skipping
 	// case IsLegacyTrieNode(key, it.Value()):
 	case bytes.HasPrefix(key, stateIDPrefix) && len(key) == len(stateIDPrefix)+common.HashLength:

--- a/espresso/authdb/authdb.go
+++ b/espresso/authdb/authdb.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
+
 	"github.com/offchainlabs/nitro/util/dbutil"
 )
 

--- a/espresso/authdb/geth_schema.go
+++ b/espresso/authdb/geth_schema.go
@@ -15,6 +15,8 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 // Package rawdb contains a collection of low level database accessors.
+//
+//nolint:unused,gosec
 package authdb
 
 import (

--- a/espresso/authdb/schema.go
+++ b/espresso/authdb/schema.go
@@ -13,6 +13,8 @@ import (
 var (
 	blockPrefix                   = []byte("blk-")
 	blockAuthTagPrefix            = []byte("blkTag-")
+	_headerPrefix                 = []byte("header-")
+	headerAuthTagPrefix           = []byte("headerTag-")
 	fromBlockKey                  = []byte("fromBlk")
 	fromBlockAuthTagKey           = []byte("fromBlkTag")
 	nextHotshotBlockNumKey        = []byte("nextHsBlkNum")
@@ -31,6 +33,15 @@ func blockKey(blockNum uint64, blockHash common.Hash) []byte {
 
 func blockAuthTagKey(blockNum uint64, blockHash common.Hash) []byte {
 	return append(append(blockAuthTagPrefix, EncodeUint64(blockNum)...), blockHash.Bytes()...)
+}
+
+// The `headerKey` name collides with rawdb.headerKey, so we need to use a different name.
+func _headerKey(blockNum uint64, blockHash common.Hash) []byte {
+	return append(append(_headerPrefix, EncodeUint64(blockNum)...), blockHash.Bytes()...)
+}
+
+func headerAuthTagKey(blockNum uint64, blockHash common.Hash) []byte {
+	return append(append(headerAuthTagPrefix, EncodeUint64(blockNum)...), blockHash.Bytes()...)
 }
 
 func EncodeUint64(number uint64) []byte {

--- a/espresso/authdb/schema.go
+++ b/espresso/authdb/schema.go
@@ -6,15 +6,18 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // The fields below define which low level database schema prefixes our AuthDB will intercept in Get
 
 var (
-	blockPrefix                   = []byte("blk-")
-	blockAuthTagPrefix            = []byte("blkTag-")
-	_headerPrefix                 = []byte("header-")
-	headerAuthTagPrefix           = []byte("headerTag-")
+	// authenticated Geth
+	headerAuthTagPrefix   = []byte("headerTag-")
+	bodyAuthTagPrefix     = []byte("bodyTag-")
+	receiptsAuthTagPrefix = []byte("receiptsTag-")
+
+	// caff node specific
 	fromBlockKey                  = []byte("fromBlk")
 	fromBlockAuthTagKey           = []byte("fromBlkTag")
 	nextHotshotBlockNumKey        = []byte("nextHsBlkNum")
@@ -27,21 +30,16 @@ var (
 	lastProcessedHeightAuthTagKey = []byte("lastProcessedHeightTag")
 )
 
-func blockKey(blockNum uint64, blockHash common.Hash) []byte {
-	return append(append(blockPrefix, EncodeUint64(blockNum)...), blockHash.Bytes()...)
-}
-
-func blockAuthTagKey(blockNum uint64, blockHash common.Hash) []byte {
-	return append(append(blockAuthTagPrefix, EncodeUint64(blockNum)...), blockHash.Bytes()...)
-}
-
-// The `headerKey` name collides with rawdb.headerKey, so we need to use a different name.
-func _headerKey(blockNum uint64, blockHash common.Hash) []byte {
-	return append(append(_headerPrefix, EncodeUint64(blockNum)...), blockHash.Bytes()...)
+func bodyAuthTagKey(blockNum uint64, blockHash common.Hash) []byte {
+	return append(append(bodyAuthTagPrefix, EncodeUint64(blockNum)...), blockHash.Bytes()...)
 }
 
 func headerAuthTagKey(blockNum uint64, blockHash common.Hash) []byte {
 	return append(append(headerAuthTagPrefix, EncodeUint64(blockNum)...), blockHash.Bytes()...)
+}
+
+func receiptsAuthTagKey(blockNum uint64, blockHash common.Hash) []byte {
+	return append(append(receiptsAuthTagPrefix, EncodeUint64(blockNum)...), blockHash.Bytes()...)
 }
 
 func EncodeUint64(number uint64) []byte {
@@ -57,4 +55,23 @@ func DecodeUint64(enc []byte) (uint64, error) {
 	var number uint64
 	err := binary.Read(bytes.NewReader(enc), binary.BigEndian, &number)
 	return number, err
+}
+
+// helper func to parse db-key with pattern:
+// prefix + num (uint64 big endian) + hash
+func parseUint64AndHash(key []byte, prefixLen int) (uint64, common.Hash, error) {
+	var hash common.Hash
+	expectedKeyLen := prefixLen + 8 + common.HashLength
+	if len(key) != expectedKeyLen {
+		return 0, hash, fmt.Errorf("expected key len: %d, got: %d", expectedKeyLen, len(key))
+	}
+
+	number, err := DecodeUint64(key[prefixLen : prefixLen+8])
+	if err != nil {
+		log.Error("failed to parse block number from db key", "err", err)
+		return 0, hash, err
+	}
+
+	hash = common.BytesToHash(key[prefixLen+8 : prefixLen+8+common.HashLength])
+	return number, hash, nil
 }


### PR DESCRIPTION
### This PR:
- Adds auth to header, body , receipts and hash
- We dont explicitly add block and header  again to the database, instead we intercept the `Put` call to insert additional tags for them
- Add linter directive to avoid linter errors 
