### PR TITLE
Verify snapshot on top of the openInitializeChainDb function

### DIFF
--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -603,6 +603,7 @@ func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeCo
 
 	// If snapshot mode is enabled, check if the snapshot hash matches the one in the config before opening the database in write mode
 	if config.Node.EspressoCaffNode.SnapshotChecksum != "" {
+		log.Info("Verifying the snaphot checksum")
 		err := arbutil.VerifySnapshot(config.Node.EspressoCaffNode.SnapshotChecksum, stack.ResolvePath("l2chaindata"), stack.ResolveAncient("l2chaindata", config.Persistent.Ancient))
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to verify snapshot: %w", err)

--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -600,6 +600,15 @@ func rebuildLocalWasm(ctx context.Context, config *gethexec.Config, l2BlockChain
 }
 
 func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeConfig, chainId *big.Int, cacheConfig *core.CacheConfig, targetConfig *gethexec.StylusTargetConfig, tracer *tracing.Hooks, persistentConfig *conf.PersistentConfig, l1Client *ethclient.Client, rollupAddrs chaininfo.RollupAddresses) (ethdb.Database, *core.BlockChain, error) {
+
+	// If snapshot mode is enabled, check if the snapshot hash matches the one in the config before opening the database in write mode
+	if config.Node.EspressoCaffNode.SnapshotChecksum != "" {
+		err := arbutil.VerifySnapshot(config.Node.EspressoCaffNode.SnapshotChecksum, stack.ResolvePath("l2chaindata"), stack.ResolveAncient("l2chaindata", config.Persistent.Ancient))
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to verify snapshot: %w", err)
+		}
+	}
+
 	if !config.Init.Force {
 		if readOnlyDb, err := stack.OpenDatabaseWithFreezerWithExtraOptions("l2chaindata", 0, 0, config.Persistent.Ancient, "l2chaindata/", true, persistentConfig.Pebble.ExtraOptions("l2chaindata")); err == nil {
 			if chainConfig := gethexec.TryReadStoredChainConfig(readOnlyDb); chainConfig != nil {
@@ -691,14 +700,6 @@ func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeCo
 	}
 
 	var initDataReader statetransfer.InitDataReader = nil
-
-	// If snapshot mode is enabled, check if the snapshot hash matches the one in the config before opening the database in write mode
-	if config.Node.EspressoCaffNode.SnapshotChecksum != "" {
-		err := arbutil.VerifySnapshot(config.Node.EspressoCaffNode.SnapshotChecksum, stack.ResolvePath("l2chaindata"), stack.ResolveAncient("l2chaindata", config.Persistent.Ancient))
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to verify snapshot: %w", err)
-		}
-	}
 
 	chainData, err := stack.OpenDatabaseWithFreezerWithExtraOptions("l2chaindata", config.Execution.Caching.DatabaseCache, config.Persistent.Handles, config.Persistent.Ancient, "l2chaindata/", false, persistentConfig.Pebble.ExtraOptions("l2chaindata"))
 	if err != nil {

--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -603,7 +603,7 @@ func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeCo
 
 	// If snapshot mode is enabled, check if the snapshot hash matches the one in the config before opening the database in write mode
 	if config.Node.EspressoCaffNode.SnapshotChecksum != "" {
-		log.Info("Verifying the snaphot checksum")
+		log.Info("Verifying the snapshot", "snapshot checksum", config.Node.EspressoCaffNode.SnapshotChecksum)
 		err := arbutil.VerifySnapshot(config.Node.EspressoCaffNode.SnapshotChecksum, stack.ResolvePath("l2chaindata"), stack.ResolveAncient("l2chaindata", config.Persistent.Ancient))
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to verify snapshot: %w", err)


### PR DESCRIPTION
# Description

This PR fixes a bug where we dont verify the snapshot when `!config.Init.Force` is false leading to `openInitializeChainDb` early return without verifying the snapshot