### PR TITLE
Separate wallet config from caff node config

### DIFF
--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -276,12 +276,19 @@ func mainImpl() int {
 		// This will be used by the hyperlane validator
 		os.Setenv("VALIDATOR_KEY", privHex)
 
-		caffNodetxOpts, dataSigner, err = util.OpenWallet("l1-espresso-caff-node", &nodeConfig.Node.EspressoCaffNode.ParentChainWallet, new(big.Int).SetUint64(nodeConfig.ParentChain.ID))
+		// Use top-level wallet config, with env variable as fallback
+		caffNodeWallet := nodeConfig.EspressoCaffNodeWallet
+		if envPrivateKey := os.Getenv("ESPRESSO_CAFF_NODE_WALLET_PRIVATE_KEY"); envPrivateKey != "" {
+			caffNodeWallet.PrivateKey = envPrivateKey
+			log.Info("Using Espresso Caff Node private key from environment variable")
+		}
+
+		caffNodetxOpts, dataSigner, err = util.OpenWallet("l1-espresso-caff-node", &caffNodeWallet, new(big.Int).SetUint64(nodeConfig.ParentChain.ID))
 		if err != nil {
 			flag.Usage()
-			log.Crit("error opening Batch poster parent chain wallet", "path", nodeConfig.Node.EspressoCaffNode.ParentChainWallet.Pathname, "account", nodeConfig.Node.EspressoCaffNode.ParentChainWallet.Account, "err", err)
+			log.Crit("error opening Espresso Caff Node parent chain wallet", "path", caffNodeWallet.Pathname, "account", caffNodeWallet.Account, "err", err)
 		}
-		if nodeConfig.Node.EspressoCaffNode.ParentChainWallet.OnlyCreateKey {
+		if caffNodeWallet.OnlyCreateKey {
 			return 0
 		}
 	}
@@ -835,6 +842,7 @@ type NodeConfig struct {
 	Rpc                    genericconf.RpcConfig           `koanf:"rpc"`
 	BlocksReExecutor       blocksreexecutor.Config         `koanf:"blocks-reexecutor"`
 	EnsureRollupDeployment bool                            `koanf:"ensure-rollup-deployment" reload:"hot"`
+	EspressoCaffNodeWallet genericconf.WalletConfig        `koanf:"espresso-caff-node-wallet"`
 }
 
 var NodeConfigDefault = NodeConfig{
@@ -861,6 +869,7 @@ var NodeConfigDefault = NodeConfig{
 	PprofCfg:               genericconf.PProfDefault,
 	BlocksReExecutor:       blocksreexecutor.DefaultConfig,
 	EnsureRollupDeployment: true,
+	EspressoCaffNodeWallet: genericconf.WalletConfigDefault,
 }
 
 func NodeConfigAddOptions(f *flag.FlagSet) {
@@ -888,6 +897,7 @@ func NodeConfigAddOptions(f *flag.FlagSet) {
 	genericconf.RpcConfigAddOptions("rpc", f)
 	blocksreexecutor.ConfigAddOptions("blocks-reexecutor", f)
 	f.Bool("ensure-rollup-deployment", NodeConfigDefault.EnsureRollupDeployment, "before starting the node, wait until the transaction that deployed rollup is finalized")
+	genericconf.WalletConfigAddOptions("espresso-caff-node-wallet", f, "")
 }
 
 func (c *NodeConfig) ResolveDirectoryNames() error {
@@ -896,6 +906,7 @@ func (c *NodeConfig) ResolveDirectoryNames() error {
 		return err
 	}
 	c.Chain.ResolveDirectoryNames(c.Persistent.Chain)
+	c.EspressoCaffNodeWallet.ResolveDirectoryNames(c.Persistent.Chain)
 
 	return nil
 }


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>

As we need to include `caffnode_config.json` as part of the PCR0 hash, we don't want to include wallet config or any secrets such as private key in there.

### This PR:

- Move `WalletConfig` to the top `NodeConfig` level that can be passed in via command line options or via env var


Recommended approach (Environment Variable):
```
export ESPRESSO_CAFF_NODE_WALLET_PRIVATE_KEY="05c2ed76b1afbd6cf3aedfbdc4ebaac547d7c179da3eb95a30eed5684a9fde87"
    nitro --conf.file /config/pcr0/caffnode_config.json
```
Or via command-line flag:
```
nitro --conf.file /config/pcr0/caffnode_config.json \
        --espresso-caff-node-wallet.private-key "05c2ed76b1afbd6cf3aedfbdc4ebaac547d7c179da3eb95a30eed5684a9fde87"
```