### PR TITLE
Use public CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   test:
     name: Go Tests
-    runs-on: ubuntu-24.04-8core
+    runs-on: ubuntu-latest
 
     # Creates a redis container for redis tests
     services:

--- a/.github/workflows/espresso-regression.yml
+++ b/.github/workflows/espresso-regression.yml
@@ -37,7 +37,7 @@ jobs:
 
   test:
     name: Espresso Regression test
-    runs-on: ubuntu-24.04-8core
+    runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && startsWith(github.event.workflow_run.head_branch, 'v'))
     steps:
 

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -16,7 +16,7 @@ jobs:
   # Only run on schedule AND main branch
   tests-scheduled:
     name: Scheduled tests
-    runs-on: ubuntu-8
+    runs-on: ubuntu-latest
 
     services:
       redis:
@@ -192,7 +192,7 @@ jobs:
   # Only run this job if files in bold/legacy/ are modified
   tests-pr:
     name: PR modified files tests
-    runs-on: ubuntu-8
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     
     permissions:

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build_and_run:
-    runs-on: ubuntu-8
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout

--- a/.github/workflows/shellcheck-ci.yml
+++ b/.github/workflows/shellcheck-ci.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   shellcheck:
     name: Run ShellCheck
-    runs-on: ubuntu-8
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Closes #[Asana ticket](https://app.asana.com/1/1208976916964769/project/1209393650288801/task/1211869942792424)

### This PR:
Changes our CI workflows to avoid using paid github runners by switching all jobs to run on `ubuntu-latest`
  
### This PR does not:
change any behavior with the integration itself, or it's build process
  
### Key places to review:
all files in `.github/workflows