### PR TITLE
Skip dev node deployment

### DIFF
--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -230,6 +230,7 @@ func TestEspressoCaffNode(t *testing.T) {
 	})
 
 	err = waitForWith(ctx, 240*time.Second, 10*time.Second, func() bool {
+		AdvanceL1(t, ctx, builder.L1.Client, builder.L1Info, 100)
 		balance := builder.L2.GetBalance(t, addr)
 		log.Info("waiting for balance", "account", newAccount, "addr", addr, "balance", balance)
 		return balance.Cmp(transferAmount) >= 0
@@ -403,6 +404,7 @@ func TestEspressoCaffNodeDelayedMessagesConfirmations(t *testing.T) {
 	// Create the event function closures for the assert statement.
 	firstEvent := func() error {
 		err := waitForWith(ctx, 240*time.Second, 1*time.Second, func() bool {
+			AdvanceL1(t, ctx, builder.L1.Client, builder.L1Info, 10)
 			header, err := builder.L1.Client.HeaderByNumber(ctx, nil) // get the latest header to check tx block depth
 			Require(t, err)
 			return header.Number.Uint64() >= tx[0].BlockNumber.Uint64()+builder.nodeConfig.EspressoCaffNode.RequiredBlockDepth // check that the tx is at least RequiredBlockDepth blocks deep in the parent chains state.
@@ -462,6 +464,7 @@ func TestEspressoCaffNodeDelayedMessagesFinalized(t *testing.T) {
 		err := waitForWith(ctx, 240*time.Second, 1*time.Second, func() bool {
 			header, err := builder.L1.Client.HeaderByNumber(ctx, big.NewInt(rpc.FinalizedBlockNumber.Int64()))
 			Require(t, err)
+			AdvanceL1(t, ctx, builder.L1.Client, builder.L1Info, 30)
 			return header.Number.Int64() >= tx[0].BlockNumber.Int64()
 		})
 		return err

--- a/system_tests/espresso-e2e/docker-compose.yaml
+++ b/system_tests/espresso-e2e/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   espresso-dev-node:
-    image: ghcr.io/espressosystems/espresso-sequencer/espresso-dev-node:20250826
+    image: ghcr.io/espressosystems/espresso-sequencer/espresso-dev-node:release-fix-cors
     ports:
       - "$ESPRESSO_SEQUENCER_API_PORT:$ESPRESSO_SEQUENCER_API_PORT"
       - "$ESPRESSO_BUILDER_PORT:$ESPRESSO_BUILDER_PORT"

--- a/system_tests/espresso-e2e/docker-compose.yaml
+++ b/system_tests/espresso-e2e/docker-compose.yaml
@@ -16,6 +16,13 @@ services:
       - ESPRESSO_SEQUENCER_DATABASE_MAX_CONNECTIONS=25
       - ESPRESSO_DEV_NODE_EPOCH_HEIGHT
       - ESPRESSO_SEQUENCER_STORAGE_PATH=/data/espresso
+      # Currently we don't need the dev node to deploy Espresso contracts.
+      # We can skip them and save some time.
+      # These contract addresses are incorrect, but it doesn't matter.
+      - ESPRESSO_DEV_NODE_L1_DEPLOYMENT=skip
+      - ESPRESSO_SEQUENCER_LIGHT_CLIENT_PROXY_ADDRESS=0x0f1f89aaf1c6fdb7ff9d361e4388f5f3997f12a8
+      - ESPRESSO_SEQUENCER_STAKE_TABLE_ADDRESS=0x63e6dde6763c3466c7b45be880f7ee5dc2ca3e25
+      - ESPRESSO_SEQUENCER_STAKE_TABLE_PROXY_ADDRESS=0x9f5eac3d8e082f47631f1551f1343f23cd427162
       - RUST_LOG=WARN
       - RUST_LOG_FORMAT
       - ESPRESSO_DEV_NODE_VERSION=0.4

--- a/system_tests/espresso_e2e_test.go
+++ b/system_tests/espresso_e2e_test.go
@@ -158,7 +158,7 @@ func waitForWith(
 
 func waitForEspressoNode(ctx context.Context) error {
 	return waitForWith(ctx, 3*time.Minute, 1*time.Second, func() bool {
-		out, err := exec.Command("curl", "http://localhost:20000/api/dev-info", "-L").Output()
+		out, err := exec.Command("curl", "http://localhost:41000/v1/availability/block/10", "-L").Output()
 		if err != nil {
 			log.Warn("retry to check the espresso dev node", "err", err)
 			return false
@@ -437,6 +437,7 @@ func TestEspressoWithBlobs(t *testing.T) {
 	// Check if the tx is executed correctly
 	err = checkTransferTxOnL2(t, ctx, l2Node, "User10", l2Info)
 	Require(t, err)
+	AdvanceL1(t, ctx, builder.L1.Client, builder.L1Info, 100)
 
 	// Remember the number of messages
 	var msgCnt arbutil.MessageIndex

--- a/system_tests/espresso_e2e_test.go
+++ b/system_tests/espresso_e2e_test.go
@@ -11,10 +11,7 @@ import (
 	"testing"
 	"time"
 
-	lightclient "github.com/EspressoSystems/espresso-network/sdks/go/light-client"
-
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
@@ -170,14 +167,6 @@ func waitForEspressoNode(ctx context.Context) error {
 	})
 }
 
-func waitForHotShotLiveness(ctx context.Context, lightClientReader *lightclient.LightClientReader) error {
-	return waitForWith(ctx, 500*time.Second, 1*time.Second, func() bool {
-		log.Info("Waiting for HotShot Liveness")
-		_, err := lightClientReader.FetchMerkleRoot(1, nil)
-		return err == nil
-	})
-}
-
 func waitForL1Node(ctx context.Context) error {
 	err := waitFor(ctx, func() bool {
 		if e := exec.Command(
@@ -254,15 +243,6 @@ func TestEspressoE2E(t *testing.T) {
 		// Chosen based on intuition; no empirical data supports this value.
 		return h > 10
 	})
-	Require(t, err)
-
-	// make light client reader
-
-	lightClientReader, err := lightclient.NewLightClientReader(common.HexToAddress(lightClientAddress), builder.L1.Client)
-	Require(t, err)
-	// wait for hotshot liveness
-
-	err = waitForHotShotLiveness(ctx, lightClientReader)
 	Require(t, err)
 
 	// Check if the tx is executed correctly
@@ -452,15 +432,6 @@ func TestEspressoWithBlobs(t *testing.T) {
 		// Chosen based on intuition; no empirical data supports this value.
 		return h > 10
 	})
-	Require(t, err)
-
-	// make light client reader
-
-	lightClientReader, err := lightclient.NewLightClientReader(common.HexToAddress(lightClientAddress), builder.L1.Client)
-	Require(t, err)
-	// wait for hotshot liveness
-
-	err = waitForHotShotLiveness(ctx, lightClientReader)
 	Require(t, err)
 
 	// Check if the tx is executed correctly


### PR DESCRIPTION
Since nitro-integration has been not required to interact with Espresso contracts, we can simply skip their deployments and save us some time in CI