### PR TITLE
Solve the `latestBaseFee` taking a Nil value

### DIFF
--- a/espressotee/espresso_tee_helpers.go
+++ b/espressotee/espresso_tee_helpers.go
@@ -91,6 +91,14 @@ func BaseFeeCheck(
 			continue
 		}
 
+		if latestBaseFee == nil {
+			log.Error(msg, "base fee is nil", "delay", retryDelay, "attempt", attempt+1)
+			if attempt < maxRetries-1 {
+				time.Sleep(retryDelay)
+			}
+			continue
+		}
+
 		if latestBaseFee.Uint64() > maxBaseFee {
 			log.Error(
 				msg,

--- a/espressotee/espresso_tee_helpers_test.go
+++ b/espressotee/espresso_tee_helpers_test.go
@@ -1,0 +1,136 @@
+package espressotee
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+)
+
+func TestBaseFeeCheck_NilBaseFee(t *testing.T) {
+	t.Run("nil base fee on all attempts", func(t *testing.T) {
+		attemptCount := 0
+		fn := func() (*big.Int, error) {
+			attemptCount++
+			// Always return nil
+			return nil, nil
+		}
+
+		err := BaseFeeCheck(
+			10000000, // maxBaseFee
+			3,        // maxRetries
+			10*time.Millisecond,
+			fn,
+			"test message",
+		)
+
+		// Should return error when base fee is always nil
+		if err == nil {
+			t.Error("Expected error when base fee is always nil, but got nil")
+		}
+
+		// Should have retried maxRetries times
+		if attemptCount != 3 {
+			t.Errorf("Expected 3 attempts, but got %d", attemptCount)
+		}
+	})
+
+	t.Run("nil base fee then valid base fee", func(t *testing.T) {
+		attemptCount := 0
+		fn := func() (*big.Int, error) {
+			attemptCount++
+			// Return nil first two times, then valid value
+			if attemptCount < 3 {
+				return nil, nil
+			}
+			// Return a valid low base fee
+			return big.NewInt(1000000), nil
+		}
+
+		err := BaseFeeCheck(
+			10000000, // maxBaseFee
+			5,        // maxRetries
+			10*time.Millisecond,
+			fn,
+			"test message",
+		)
+
+		// Should succeed after retries
+		if err != nil {
+			t.Errorf("Expected success after retries, but got error: %v", err)
+		}
+
+		// Should have retried until success
+		if attemptCount != 3 {
+			t.Errorf("Expected 3 attempts, but got %d", attemptCount)
+		}
+	})
+
+	t.Run("nil base fee with error", func(t *testing.T) {
+		attemptCount := 0
+		fn := func() (*big.Int, error) {
+			attemptCount++
+			// Return nil with error
+			return nil, fmt.Errorf("network error")
+		}
+
+		err := BaseFeeCheck(
+			10000000, // maxBaseFee
+			3,        // maxRetries
+			10*time.Millisecond,
+			fn,
+			"test message",
+		)
+
+		// Should eventually fail after retries
+		if err == nil {
+			t.Error("Expected error after all retries fail, but got nil")
+		}
+
+		// Should have retried maxRetries times
+		if attemptCount != 3 {
+			t.Errorf("Expected 3 attempts, but got %d", attemptCount)
+		}
+	})
+}
+
+func TestBaseFeeCheck_NilBaseFeeRetryLogic(t *testing.T) {
+	attemptCount := 0
+	maxRetries := 3
+	retryDelay := 10 * time.Millisecond
+
+	fn := func() (*big.Int, error) {
+		attemptCount++
+		// Return nil for first two attempts
+		if attemptCount < maxRetries {
+			return nil, nil
+		}
+		// Return valid base fee on last attempt
+		return big.NewInt(5000000), nil
+	}
+
+	startTime := time.Now()
+	err := BaseFeeCheck(
+		10000000, // maxBaseFee
+		maxRetries,
+		retryDelay,
+		fn,
+		"test nil retry",
+	)
+	duration := time.Since(startTime)
+
+	if err != nil {
+		t.Errorf("Expected success after retries, but got error: %v", err)
+	}
+
+	// Verify retry delay was respected (should have waited at least retryDelay * (maxRetries-1))
+	expectedMinDuration := retryDelay * time.Duration(maxRetries-1)
+	if duration < expectedMinDuration {
+		t.Errorf("Expected duration >= %v, but got %v", expectedMinDuration, duration)
+	}
+
+	// Verify we retried the expected number of times
+	if attemptCount != maxRetries {
+		t.Errorf("Expected %d attempts, but got %d", maxRetries, attemptCount)
+	}
+}

--- a/espressotee/espresso_tee_helpers_test.go
+++ b/espressotee/espresso_tee_helpers_test.go
@@ -1,136 +1,44 @@
 package espressotee
 
 import (
-	"fmt"
 	"math/big"
 	"testing"
 	"time"
 )
 
 func TestBaseFeeCheck_NilBaseFee(t *testing.T) {
-	t.Run("nil base fee on all attempts", func(t *testing.T) {
-		attemptCount := 0
+	t.Run("retries when base fee is nil", func(t *testing.T) {
+		attempts := 0
 		fn := func() (*big.Int, error) {
-			attemptCount++
-			// Always return nil
-			return nil, nil
-		}
-
-		err := BaseFeeCheck(
-			10000000, // maxBaseFee
-			3,        // maxRetries
-			10*time.Millisecond,
-			fn,
-			"test message",
-		)
-
-		// Should return error when base fee is always nil
-		if err == nil {
-			t.Error("Expected error when base fee is always nil, but got nil")
-		}
-
-		// Should have retried maxRetries times
-		if attemptCount != 3 {
-			t.Errorf("Expected 3 attempts, but got %d", attemptCount)
-		}
-	})
-
-	t.Run("nil base fee then valid base fee", func(t *testing.T) {
-		attemptCount := 0
-		fn := func() (*big.Int, error) {
-			attemptCount++
-			// Return nil first two times, then valid value
-			if attemptCount < 3 {
+			attempts++
+			if attempts < 2 {
 				return nil, nil
 			}
-			// Return a valid low base fee
-			return big.NewInt(1000000), nil
+			return big.NewInt(1000000), nil // Succeed on retry
 		}
 
-		err := BaseFeeCheck(
-			10000000, // maxBaseFee
-			5,        // maxRetries
-			10*time.Millisecond,
-			fn,
-			"test message",
-		)
-
-		// Should succeed after retries
+		err := BaseFeeCheck(10000000, 3, 10*time.Millisecond, fn, "test")
 		if err != nil {
-			t.Errorf("Expected success after retries, but got error: %v", err)
+			t.Errorf("Expected success after retry, got: %v", err)
 		}
-
-		// Should have retried until success
-		if attemptCount != 3 {
-			t.Errorf("Expected 3 attempts, but got %d", attemptCount)
+		if attempts != 2 {
+			t.Errorf("Expected 2 attempts, got %d", attempts)
 		}
 	})
 
-	t.Run("nil base fee with error", func(t *testing.T) {
-		attemptCount := 0
+	t.Run("fails when base fee always nil", func(t *testing.T) {
+		attempts := 0
 		fn := func() (*big.Int, error) {
-			attemptCount++
-			// Return nil with error
-			return nil, fmt.Errorf("network error")
+			attempts++
+			return nil, nil // Always nil
 		}
 
-		err := BaseFeeCheck(
-			10000000, // maxBaseFee
-			3,        // maxRetries
-			10*time.Millisecond,
-			fn,
-			"test message",
-		)
-
-		// Should eventually fail after retries
+		err := BaseFeeCheck(10000000, 3, 10*time.Millisecond, fn, "test")
 		if err == nil {
-			t.Error("Expected error after all retries fail, but got nil")
+			t.Error("Expected error when base fee always nil")
 		}
-
-		// Should have retried maxRetries times
-		if attemptCount != 3 {
-			t.Errorf("Expected 3 attempts, but got %d", attemptCount)
+		if attempts != 3 {
+			t.Errorf("Expected 3 attempts, got %d", attempts)
 		}
 	})
-}
-
-func TestBaseFeeCheck_NilBaseFeeRetryLogic(t *testing.T) {
-	attemptCount := 0
-	maxRetries := 3
-	retryDelay := 10 * time.Millisecond
-
-	fn := func() (*big.Int, error) {
-		attemptCount++
-		// Return nil for first two attempts
-		if attemptCount < maxRetries {
-			return nil, nil
-		}
-		// Return valid base fee on last attempt
-		return big.NewInt(5000000), nil
-	}
-
-	startTime := time.Now()
-	err := BaseFeeCheck(
-		10000000, // maxBaseFee
-		maxRetries,
-		retryDelay,
-		fn,
-		"test nil retry",
-	)
-	duration := time.Since(startTime)
-
-	if err != nil {
-		t.Errorf("Expected success after retries, but got error: %v", err)
-	}
-
-	// Verify retry delay was respected (should have waited at least retryDelay * (maxRetries-1))
-	expectedMinDuration := retryDelay * time.Duration(maxRetries-1)
-	if duration < expectedMinDuration {
-		t.Errorf("Expected duration >= %v, but got %v", expectedMinDuration, duration)
-	}
-
-	// Verify we retried the expected number of times
-	if attemptCount != maxRetries {
-		t.Errorf("Expected %d attempts, but got %d", maxRetries, attemptCount)
-	}
 }

--- a/espressotee/espresso_tee_helpers_test.go
+++ b/espressotee/espresso_tee_helpers_test.go
@@ -14,7 +14,7 @@ func TestBaseFeeCheck_NilBaseFee(t *testing.T) {
 			if attempts < 2 {
 				return nil, nil
 			}
-			return big.NewInt(1000000), nil // Succeed on retry
+			return big.NewInt(1000000), nil // Succeed on 3rd retry
 		}
 
 		err := BaseFeeCheck(10000000, 3, 10*time.Millisecond, fn, "test")


### PR DESCRIPTION
# This PR:
- Fixes the following error caught in production:
```
INFO  enclave         > panic: runtime error: invalid memory address or nil pointer dereference
 INFO  enclave         > [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x13a1997]
 INFO  enclave         >
 INFO  enclave         > goroutine 477 [running]:
 INFO  enclave         > math/big.(*Int).Uint64(...)
 INFO  enclave         >        /usr/local/go/src/math/big/int.go:433
 INFO  enclave         > github.com/offchainlabs/nitro/espressotee.BaseFeeCheck(0x1dcd65000, 0x5, 0xdf8475800, 0xc00738d5d0, {0x2cfe8c7, 0x40})
 INFO  enclave         >        /workspace/espressotee/espresso_tee_helpers.go:83 +0x1f7
```
- Includes some unit tests to verify the code fix.
