### PR TITLE
Refactor batcher address monitor

### DIFF
--- a/.github/workflows/_go-tests.yml
+++ b/.github/workflows/_go-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-mode: [defaults-A, defaults-B, flaky, pathdb, challenge, stylus, l3challenge]
+        test-mode: [defaults-A, defaults-B, defaults-C, flaky, pathdb, challenge, stylus, l3challenge]
     services:
       redis:
         image: redis
@@ -66,7 +66,16 @@ jobs:
         run: >-
           ${{ github.workspace }}/.github/workflows/gotestsum.sh
           --tags cionly --timeout 60m --test_state_scheme hash
-          --junitfile test-results/junit-b.xml --skip '^Test[A-L]'
+          --junitfile test-results/junit-b.xml --run '^Test[M-S]'
+
+      - name: run tests without race detection and hash state scheme (C-batch)
+        if: matrix.test-mode == 'defaults-C'
+        id: run-tests-defaults-c
+        continue-on-error: true
+        run: >-
+          ${{ github.workspace }}/.github/workflows/gotestsum.sh
+          --tags cionly --timeout 60m --test_state_scheme hash
+          --junitfile test-results/junit-c.xml --skip '^Test[A-S]'
 
       - name: Process JUnit XML logs
         if: startsWith(matrix.test-mode, 'defaults') && always()

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -145,8 +145,9 @@ type BatchPoster struct {
 	bytes32ArrayType           abi.Type
 	blobsAttestationArguments  abi.Arguments
 	espressoStreamer           *espressostreamer.EspressoStreamer
-	espressoBatcherAddrMonitor *BatcherAddrMonitor
+	espressoBatcherAddrMonitor BatcherAddrMonitorInterface
 	espressoRestarting         bool
+	signerAddr                 common.Address
 }
 
 type l1BlockBound int
@@ -227,6 +228,8 @@ type BatchPosterConfig struct {
 	AddressMonitorStartL1 uint64   `koanf:"address-monitor-start-l1"`
 	InitBatcherAddresses  []string `koanf:"init-batcher-addresses"`
 	AddressMonitorStep    uint64   `koanf:"address-monitor-step"`
+
+	AddressValidRanges []AddressValidRangeConfig `koanf:"address-valid-ranges"`
 }
 
 func (c *BatchPosterConfig) Validate() error {
@@ -631,6 +634,11 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 
 			initAddresses = []common.Address{addr}
 		}
+		addr, err := recoverAddressFromSigner(opts.DataSigner)
+		if err != nil {
+			return nil, err
+		}
+		b.signerAddr = addr
 
 		// We dont need auth reads here because batch poster is not reliant on the
 		// database for determining which messages to post, it gets the messages
@@ -639,15 +647,20 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 		if err != nil {
 			return nil, err
 		}
-		monitor := NewBatcherAddrMonitor(
-			initAddresses,
-			&db,
-			opts.L1Reader,
-			opts.DeployInfo.SequencerInbox,
-			opts.DeployInfo.DeployedAt,
-			opts.Config().AddressMonitorStartL1,
-			opts.Config().AddressMonitorStep,
-		)
+		var monitor BatcherAddrMonitorInterface
+		if len(opts.Config().AddressValidRanges) == 0 {
+			monitor = NewBatcherAddrMonitor(
+				initAddresses,
+				&db,
+				opts.L1Reader,
+				opts.DeployInfo.SequencerInbox,
+				opts.DeployInfo.DeployedAt,
+				opts.Config().AddressMonitorStartL1,
+				opts.Config().AddressMonitorStep,
+			)
+		} else {
+			monitor = NewBatcherAddrSimpleMonitor(opts.Config().AddressValidRanges)
+		}
 
 		espressoStreamer := espressostreamer.NewEspressoStreamer(
 			opts.ChainID,
@@ -655,7 +668,9 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 			nil,
 			hotShotClient,
 			false,
-			monitor.GetValidAddresses,
+			func(l1Height uint64, addr common.Address) (bool, error) {
+				return monitor.IsValid(ctx, addr, l1Height)
+			},
 			opts.Config().EspressoTxnsPollingInterval,
 			opts.Config().Dangerous.MinimumHotshotBlockNum,
 		)
@@ -674,6 +689,9 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 			submitter.WithTxnsResubmissionInterval(cfg.EspressoTxnsResubmissionInterval),
 			submitter.WithResubmitEspressoTxDeadline(cfg.ResubmitEspressoTxDeadline),
 			submitter.WithMaxTransactionSize(cfg.EspressoTxSizeLimit),
+			submitter.WithCanSubmit(func(ctx context.Context) (bool, error) {
+				return b.espressoStreamer.CanBatcherAddressSend(ctx, b.signerAddr)
+			}),
 		)
 
 		// Get the espressoTEEVerifier address for the sequencer inbox contract

--- a/arbnode/espresso_batcher_addr_monitor.go
+++ b/arbnode/espresso_batcher_addr_monitor.go
@@ -1,14 +1,11 @@
 package arbnode
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"math/big"
-	"sort"
 
 	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -24,26 +21,21 @@ import (
 )
 
 var ownerFunctionCalledID common.Hash
-var seqInboxABI abi.ABI
+
+// 13 minutes worth of blocks on L1 (assuming 12s block time)
+const BUFFER_WINDOW = 64
 
 func init() {
 	parsedSeqInboxABI, err := bridgegen.SequencerInboxMetaData.GetAbi()
 	if err != nil {
 		panic(err)
 	}
-	seqInboxABI = *parsedSeqInboxABI
 	ownerFunctionCalledID = parsedSeqInboxABI.Events["OwnerFunctionCalled"].ID
 }
 
-// BatcherAddrUpdate represents a batch poster address status change, equivalent in effect to the `BatchPosterSet` event.
-// For compatibility, we do not directly search for `BatchPosterSet` events.
-// Instead, we search for `OwnerFunctionCalled(1)` events and parse the transaction input data to reconstruct the updates.
-type BatcherAddrUpdate struct {
-	// From this L1 height, the batcher address becomes functional or non-functional
-	L1Height     uint64         `koanf:"l1-height"`
-	ParentHeight uint64         `koanf:"parent-height"`
-	Addr         common.Address `koanf:"addr"`
-	IsBatcher    bool           `koanf:"is-batcher"`
+type BatcherAddrMonitorInterface interface {
+	Start(ctx context.Context) error
+	IsValid(ctx context.Context, batcherAddress common.Address, l1Height uint64) (bool, error)
 }
 
 type BatcherAddrMonitor struct {
@@ -51,20 +43,27 @@ type BatcherAddrMonitor struct {
 	// This is corresponding L1 height to the parent height.
 	// If the parent chain is Ethereum, this is equal to the parent height.
 	lastProcessedL1Height     uint64
-	lastEventL1Height         uint64
 	lastProcessedParentHeight uint64
 
-	// Cache for the latest valid addresses.
-	// Since batcher address changes are infrequent and callers typically
-	// process HotShot blocks sequentially, caching improves performance.
-	cached          bool
-	cachedAddresses []common.Address
-
-	updates []BatcherAddrUpdate
-	db      *authdb.AuthDB
-
-	// Init addresses are the addresses that were set as batcher when the rollup was deployed.
-	initAddresses []common.Address
+	// L1 heights where batcher addresses were updated
+	// This is append-only and sorted in ascending order
+	eventUpdatesAt []uint64
+	// validityCaches[0]: batcher addresses valid from eventUpdatesAt[0] to eventUpdatesAt[1]
+	// validityCaches[i]: batcher addresses valid from eventUpdatesAt[i] to eventUpdatesAt[i+1]
+	// validityCaches[last]: batcher addresses valid from eventUpdatesAt[last] to current height (inclusive)
+	// Cache all the validityCaches to avoid repeated lookups. Since the batcher addresses are relatively stable,
+	// this caching significantly improves performance for repeated validity checks.
+	validityCaches []map[common.Address]bool
+	// A batcher address becomes valid or invalid after it is included in a block that is finalized + bufferWindow old
+	// This makes sure our fast finality won't be hurt by L1 lag.
+	// This value should be part of consensus among all the caff nodes and batchers.
+	// It is not configurable and we currently hardcode it first.
+	bufferWindow uint64
+	db           *authdb.AuthDB
+	needsPersist bool
+	// Init addresses are the addresses serve as fallback valid addresses
+	initAddresses   []common.Address
+	fromParentBlock uint64
 
 	l1Reader *headerreader.HeaderReader
 
@@ -102,73 +101,49 @@ func NewBatcherAddrMonitor(
 		seqInboxInterface:         seqInboxInterface,
 		deployAt:                  deployAt,
 		lastProcessedParentHeight: fromParentBlock - 1,
+		fromParentBlock:           fromParentBlock,
 		step:                      step,
+		bufferWindow:              BUFFER_WINDOW,
 	}
 }
 
-func (b *BatcherAddrMonitor) AddBatchPosterSetEvents(events []BatcherAddrUpdate) error {
-	if len(events) == 0 {
-		return nil
+func (b *BatcherAddrMonitor) IsValid(ctx context.Context, batcherAddress common.Address, l1Height uint64) (bool, error) {
+	if len(b.eventUpdatesAt) == 0 {
+		b.addEventUpdates([]uint64{b.fromParentBlock})
+		for _, addr := range b.initAddresses {
+			b.validityCaches[0][addr] = true
+		}
 	}
-	log.Info("adding batcher addr events", "events", events)
-	b.updates = append(b.updates, events...)
-	// Sort events by l1Height to ensure correct processing order.
-	// Since BatcherAddr events are infrequent, the performance impact of sorting is negligible.
-	sort.Slice(b.updates, func(i, j int) bool {
-		return b.updates[i].L1Height < b.updates[j].L1Height
-	})
-	b.lastEventL1Height = b.updates[len(b.updates)-1].L1Height
-	b.cached = false
-	return b.Store()
-}
-
-func (b *BatcherAddrMonitor) GetValidAddresses(targetL1Height uint64) []common.Address {
-	if targetL1Height > b.lastProcessedL1Height {
-		// If the target L1 height is greater than the latest known L1 height,
-		// return an empty slice. The caller should wait until the monitor has
-		// observed at least this L1 height before calling this function.
-		return []common.Address{}
+	height := b.fromParentBlock - 1
+	if l1Height > b.bufferWindow {
+		height = l1Height - b.bufferWindow
+	}
+	if height > b.lastProcessedL1Height {
+		return false, fmt.Errorf("batcher address monitor is lagging behind, height: %d", l1Height)
 	}
 
-	if len(b.updates) == 0 || b.updates[0].L1Height > targetL1Height {
-		return b.initAddresses
-	}
-
-	// If the target L1 height is within the latest cached window, return the cached result.
-	// In a practical scenario, this is the most common case. Here means that during the time
-	// from `lastEventL1Height` to `l1Height`, the `events` are not changed. It is not needed to
-	// calculate valid batcher addresses.
-	latestCachedWindow := targetL1Height >= b.lastEventL1Height && targetL1Height <= b.lastProcessedL1Height
-	if b.cached && latestCachedWindow {
-		return b.cachedAddresses
-	}
-
-	result := map[common.Address]bool{}
-	for _, addr := range b.initAddresses {
-		result[addr] = true
-	}
-
-	for _, event := range b.updates {
-		if event.L1Height > targetL1Height {
+	index := 0
+	for i, updateHeight := range b.eventUpdatesAt {
+		if updateHeight > height {
 			break
 		}
-
-		result[event.Addr] = event.IsBatcher
+		index = i
 	}
 
-	var validAddrs []common.Address
-	for addr, isBatcher := range result {
-		if isBatcher {
-			validAddrs = append(validAddrs, addr)
-		}
+	cache := b.validityCaches[index]
+	if valid, exists := cache[batcherAddress]; exists {
+		return valid, nil
 	}
 
-	if latestCachedWindow {
-		b.cached = true
-		b.cachedAddresses = validAddrs
+	isBatcher, err := b.seqInboxInterface.IsBatchPoster(&bind.CallOpts{}, batcherAddress)
+	if err != nil {
+		return false, err
 	}
-	log.Info("valid addresses in batch monitor", "validAddresses", validAddrs)
-	return validAddrs
+	log.Debug("Batcher address validation", "address", batcherAddress, "isBatcher", isBatcher, "l1Height", l1Height)
+	cache[batcherAddress] = isBatcher
+	b.needsPersist = true
+
+	return isBatcher, nil
 }
 
 func (b *BatcherAddrMonitor) SetParentHeight(height uint64) {
@@ -183,7 +158,7 @@ func (b *BatcherAddrMonitor) GetLastProcessedParentHeight() uint64 {
 	return b.lastProcessedParentHeight
 }
 
-func (b *BatcherAddrMonitor) LookupAddressUpdates(ctx context.Context, fromBlock, toBlock uint64) ([]BatcherAddrUpdate, error) {
+func (b *BatcherAddrMonitor) LookupAddressUpdates(ctx context.Context, fromBlock, toBlock uint64) ([]uint64, error) {
 	from := big.NewInt(0).SetUint64(fromBlock)
 	to := big.NewInt(0).SetUint64(toBlock)
 	query := ethereum.FilterQuery{
@@ -200,86 +175,37 @@ func (b *BatcherAddrMonitor) LookupAddressUpdates(ctx context.Context, fromBlock
 	if err != nil {
 		return nil, err
 	}
-	return b.logsToBatcherAddrEvents(ctx, logs)
-}
-
-func (b *BatcherAddrMonitor) logsToBatcherAddrEvents(ctx context.Context, logs []types.Log) ([]BatcherAddrUpdate, error) {
-	if len(logs) == 0 {
-		return nil, nil
-	}
-	events := []BatcherAddrUpdate{}
-	for _, ethLog := range logs {
-		l1Height := ethLog.BlockNumber
+	var result []uint64
+	for _, log := range logs {
+		l1Height := log.BlockNumber
 		if b.l1Reader.IsParentChainArbitrum() {
-			header, err := b.l1Reader.Client().HeaderByNumber(ctx, big.NewInt(0).SetUint64(ethLog.BlockNumber))
+			header, err := b.l1Reader.Client().HeaderByNumber(ctx, big.NewInt(0).SetUint64(log.BlockNumber))
 			if err != nil {
 				return nil, err
 			}
 			l1Height = types.DeserializeHeaderExtraInformation(header).L1BlockNumber
 		}
-		txHash := ethLog.TxHash
-		tx, _, err := b.l1Reader.Client().TransactionByHash(ctx, txHash)
-		if err != nil {
-			return nil, err
-		}
-		// Parse data to get arguments from tx
-		data := tx.Data()
-		if len(data) < 4 {
-			return nil, fmt.Errorf("failed to parse a log: invalid data")
-		}
-		if !bytes.Equal(data[:4], seqInboxABI.Methods["setIsBatchPoster"].ID) {
-			if bytes.Equal(data[:4], []byte{0xbc, 0xa8, 0xc7, 0xb5}) {
-				// skip this case for now. `0xbca8c7b5` is `executeCall(address,bytes)`
-				continue
-			}
-			// Encountering an unknown method, caff node needs to update
-			// Note: if the method id is `0x27f28813`, it is the create rollup method.
-			// cast sig "createRollup(((uint64,uint64,address,uint256,bytes32,address,address,uint256,string,uint64,(uint256,uint256,uint256,uint256),address),address[],uint256,address,bool,uint256,address[],address))"
-			// that means the addr monitor is somehow fetching events from the genesis block, which is not expected.
-			return nil, fmt.Errorf("failed to parse a log: invalid method: %x, %d", data[:4], l1Height)
-		}
-		args, err := seqInboxABI.Methods["setIsBatchPoster"].Inputs.Unpack(data[4:])
-		if err != nil {
-			return nil, err
-		}
-		batchPoster, ok := args[0].(common.Address)
-		if !ok {
-			return nil, fmt.Errorf("failed to parse a log: invalid batch poster address")
-		}
-		isBatcher, ok := args[1].(bool)
-		if !ok {
-			return nil, fmt.Errorf("failed to parse a log: invalid isBatchPoster")
-		}
-
-		event := BatcherAddrUpdate{
-			Addr:         batchPoster,
-			IsBatcher:    isBatcher,
-			L1Height:     l1Height,
-			ParentHeight: ethLog.BlockNumber,
-		}
-		log.Info("adding event for batch poster updates", "event", event)
-		events = append(events, event)
+		result = append(result, l1Height)
 	}
-	return events, nil
+	return result, nil
 }
 
 func (b *BatcherAddrMonitor) Store() error {
 
 	newBatch := b.db.NewBatch()
 
-	eventsBytes, err := rlp.EncodeToBytes(b.updates)
+	err := authdb.WriteAddresses(newBatch, b.validityCaches)
+	if err != nil {
+		return fmt.Errorf("failed to write addresses: %w", err)
+	}
+
+	eventsBytes, err := rlp.EncodeToBytes(b.eventUpdatesAt)
 	if err != nil {
 		return fmt.Errorf("failed to encode events: %w", err)
 	}
-
-	err = authdb.WriteInitAddresses(newBatch, b.initAddresses)
-	if err != nil {
-		return fmt.Errorf("failed to put init addresses: %w", err)
-	}
-
 	err = authdb.WriteEvents(newBatch, eventsBytes)
 	if err != nil {
-		return fmt.Errorf("failed to put events: %w", err)
+		return fmt.Errorf("failed to write events: %w", err)
 	}
 
 	err = authdb.WriteLastProcessedHeight(newBatch, b.lastProcessedParentHeight)
@@ -291,47 +217,38 @@ func (b *BatcherAddrMonitor) Store() error {
 }
 
 func (b *BatcherAddrMonitor) Restore() error {
-
-	initAddresses, err := authdb.ReadInitAddresses(b.db)
-	if err != nil {
-		return fmt.Errorf("failed to get init addresses: %w, init addresses: %v", err, initAddresses)
-	}
-	if initAddresses != nil {
-		b.initAddresses = initAddresses
-	}
-
 	lastProcessedHeight, err := authdb.ReadLastProcessedHeight(b.db)
 	if err != nil {
 		return fmt.Errorf("failed to get last processed height: %w", err)
 	}
 
-	if lastProcessedHeight != 0 {
-		b.lastProcessedParentHeight = lastProcessedHeight
+	if lastProcessedHeight < b.fromParentBlock {
+		// It is running with a higher parent block than last processed height,
+		// prvious result becomes invalid
+		return nil
 	}
-
-	eventsBytes, err := authdb.ReadEvents(b.db)
+	updates, err := authdb.ReadEvents(b.db)
 	if err != nil {
 		return fmt.Errorf("failed to get events: %w", err)
 	}
 
-	if eventsBytes != nil {
-		var events []BatcherAddrUpdate
-		err = rlp.DecodeBytes(eventsBytes, &events)
-		if err != nil {
+	// Parse the RLP-encoded events into []uint64
+	var eventUpdates []uint64
+	if len(updates) > 0 {
+		if err := rlp.DecodeBytes(updates, &eventUpdates); err != nil {
 			return fmt.Errorf("failed to decode events: %w", err)
 		}
-		b.updates = events
-		b.cached = false
-		b.cachedAddresses = []common.Address{}
-		if len(events) > 0 {
-			b.lastEventL1Height = events[len(events)-1].L1Height
-		}
-	} else {
-		b.updates = []BatcherAddrUpdate{}
-		b.cached = false
-		b.cachedAddresses = []common.Address{}
-		b.lastEventL1Height = 0
 	}
+	b.eventUpdatesAt = eventUpdates
+
+	b.lastProcessedParentHeight = lastProcessedHeight
+
+	addresses, err := authdb.ReadAddresses(b.db)
+	if err != nil {
+		return fmt.Errorf("failed to get addresses: %w", err)
+	}
+	b.validityCaches = addresses
+
 	return nil
 }
 
@@ -341,22 +258,6 @@ func (b *BatcherAddrMonitor) backfill(ctx context.Context) error {
 		return fmt.Errorf("failed to get latest parent height: %w", err)
 	}
 	lastProcessedHeight := b.GetLastProcessedParentHeight()
-
-	if lastProcessedHeight <= b.deployAt {
-		// Verify init addresses are batchers
-		for _, addr := range b.initAddresses {
-			isBatcher, err := b.seqInboxInterface.IsBatchPoster(&bind.CallOpts{}, addr)
-			if err != nil {
-				return fmt.Errorf("failed to get batcher status: %w", err)
-			}
-			if !isBatcher {
-				return fmt.Errorf("init address %s is not a batcher", addr)
-			}
-		}
-
-		lastProcessedHeight = b.deployAt
-		b.lastProcessedParentHeight = lastProcessedHeight
-	}
 
 	blocksToRead := b.step
 	allowedRetry := 10
@@ -373,17 +274,14 @@ func (b *BatcherAddrMonitor) backfill(ctx context.Context) error {
 		}
 
 		log.Info("batcher addr monitor backfilling", "lastProcessedHeight", lastProcessedHeight, "latestParentHeight", latestParentHeight, "blocksToRead", blocksToRead)
-		events, err := b.LookupAddressUpdates(ctx, lastProcessedHeight+1, lastProcessedHeight+blocksToRead)
+		updates, err := b.LookupAddressUpdates(ctx, lastProcessedHeight+1, lastProcessedHeight+blocksToRead)
 		if err != nil {
 			retry++
 			log.Error("failed to lookup events", "err", err)
 			continue
 		}
-		err = b.AddBatchPosterSetEvents(events)
-		if err != nil {
-			retry++
-			log.Error("failed to add events", "err", err)
-			continue
+		if len(updates) > 0 {
+			b.addEventUpdates(updates)
 		}
 		lastProcessedHeight += blocksToRead
 		latestParentHeader, err = b.l1Reader.Client().HeaderByNumber(ctx, new(big.Int).SetInt64(int64(rpc.FinalizedBlockNumber)))
@@ -405,9 +303,9 @@ func (b *BatcherAddrMonitor) backfill(ctx context.Context) error {
 }
 
 func (b *BatcherAddrMonitor) Process(ctx context.Context) error {
-	latestHeader, err := b.l1Reader.LastHeader(ctx)
+	latestHeader, err := b.l1Reader.LatestFinalizedBlockHeader(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get latest block header: %w", err)
+		return fmt.Errorf("failed to get latest finalized block header: %w", err)
 	}
 	latestBlockNumber := latestHeader.Number.Uint64()
 	parentHeight := b.GetLastProcessedParentHeight()
@@ -418,22 +316,19 @@ func (b *BatcherAddrMonitor) Process(ctx context.Context) error {
 	}
 
 	newHeight := latestBlockNumber
-	events, err := b.LookupAddressUpdates(ctx, parentHeight+1, newHeight)
+	updates, err := b.LookupAddressUpdates(ctx, parentHeight+1, newHeight)
 	log.Debug("looking up events", "from", parentHeight+1, "to", newHeight)
 	if err != nil {
 		return err
 	}
-	err = b.AddBatchPosterSetEvents(events)
-	if err != nil {
-		return err
-	}
+	b.addEventUpdates(updates)
 	l1Height := newHeight
 	if b.l1Reader.IsParentChainArbitrum() {
 		l1Height = types.DeserializeHeaderExtraInformation(latestHeader).L1BlockNumber
 	}
 	b.SetL1Height(l1Height)
 	b.SetParentHeight(newHeight)
-	if len(events) == 0 {
+	if len(updates) == 0 {
 		// If no events are found, we still need to update the last processed height
 		batch := b.db.NewBatch()
 		err = authdb.WriteLastProcessedHeight(batch, newHeight)
@@ -441,12 +336,21 @@ func (b *BatcherAddrMonitor) Process(ctx context.Context) error {
 			return fmt.Errorf("failed to store last processed height: %w", err)
 		}
 		return batch.Write()
+	} else if b.needsPersist {
+		err := b.Store()
+		if err != nil {
+			return fmt.Errorf("failed to store in batcher address monitor: %w", err)
+		}
+		b.needsPersist = false
 	}
 	return nil
 }
 
-func (b *BatcherAddrMonitor) GetEvents() []BatcherAddrUpdate {
-	return b.updates
+func (b *BatcherAddrMonitor) addEventUpdates(updates []uint64) {
+	b.eventUpdatesAt = append(b.eventUpdatesAt, updates...)
+	for i := 0; i < len(updates); i++ {
+		b.validityCaches = append(b.validityCaches, make(map[common.Address]bool))
+	}
 }
 
 func (b *BatcherAddrMonitor) Start(ctx context.Context) error {

--- a/arbnode/espresso_batcher_addr_monitor_test.go
+++ b/arbnode/espresso_batcher_addr_monitor_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/offchainlabs/nitro/espresso/authdb"
 	"github.com/offchainlabs/nitro/util/headerreader"
@@ -22,56 +21,12 @@ func TestBatcherAddrMonitor(t *testing.T) {
 		initAddr1,
 		initAddr2,
 	}
-
 	// Test initial state
 	t.Run("initial state", func(t *testing.T) {
 		caffDb, err := authdb.NewAuthDB(rawdb.NewMemoryDatabase(), nil, true)
 		Require(t, err)
 
-		b := NewBatcherAddrMonitor(initAddresses, &caffDb, nil, common.Address{}, 0, 0, 100)
-		b.SetL1Height(100)
-		result1 := b.GetValidAddresses(100)
-		assert.Equal(t, initAddresses, result1)
-		// Batcher monitor has not seen this L1 height
-		result2 := b.GetValidAddresses(101)
-		assert.Equal(t, []common.Address{}, result2)
-	})
-
-	// Test AddEvent
-	t.Run("add events and get valid addresses", func(t *testing.T) {
-		caffDb, err := authdb.NewAuthDB(rawdb.NewMemoryDatabase(), nil, true)
-		Require(t, err)
-		Require(t, err)
-		b := NewBatcherAddrMonitor(initAddresses, &caffDb, nil, common.Address{}, 0, 0, 100)
-		b.SetL1Height(100)
-		addr3 := common.HexToAddress("0x3456789012345678901234567890123456789012")
-		err = b.AddBatchPosterSetEvents([]BatcherAddrUpdate{
-			{50, 50, initAddr1, false},
-			{60, 60, initAddr2, false},
-			{70, 70, addr3, true},
-		})
-		Require(t, err)
-
-		result1 := b.GetValidAddresses(40)
-		assert.Equal(t, initAddresses, result1)
-
-		result2 := b.GetValidAddresses(50)
-		assert.Equal(t, 1, len(result2))
-		assert.Equal(t, initAddr2, result2[0])
-
-		result3 := b.GetValidAddresses(60)
-		assert.Equal(t, 0, len(result3))
-
-		result4 := b.GetValidAddresses(70)
-		assert.Equal(t, 1, len(result4))
-		assert.Equal(t, addr3, result4[0])
-
-		result5 := b.GetValidAddresses(80)
-		assert.Equal(t, 1, len(result5))
-		assert.Equal(t, addr3, result5[0])
-
-		result6 := b.GetValidAddresses(101)
-		assert.Equal(t, 0, len(result6))
+		_ = NewBatcherAddrMonitor(initAddresses, &caffDb, nil, common.Address{}, 0, 0, 100)
 	})
 
 	t.Run("store and restore", func(t *testing.T) {
@@ -82,53 +37,77 @@ func TestBatcherAddrMonitor(t *testing.T) {
 		Require(t, err)
 		b := NewBatcherAddrMonitor(initAddresses, &caffDb, l1Reader, common.Address{}, 0, 0, 100)
 		b.lastProcessedParentHeight = 100
-		// only contain the init addresses
+		b.eventUpdatesAt = []uint64{100, 200}
 		err = b.Store()
 		Require(t, err)
 
-		// empty the init addresses
-		b.initAddresses = []common.Address{}
 		err = b.Restore()
 		Require(t, err)
-
-		assert.Equal(t, initAddresses, b.initAddresses)
 		assert.Equal(t, uint64(100), b.lastProcessedParentHeight)
-		assert.Equal(t, []BatcherAddrUpdate{}, b.updates)
+		assert.Equal(t, []uint64{100, 200}, b.eventUpdatesAt)
 
-		events := []BatcherAddrUpdate{
-			{50, 50, initAddr1, false},
-			{60, 60, initAddr2, false},
-		}
-		err = b.AddBatchPosterSetEvents(events)
-		Require(t, err)
+		b = NewBatcherAddrMonitor(initAddresses, &caffDb, l1Reader, common.Address{}, 0, 0, 100)
+		b.lastProcessedParentHeight = 100
+		b.eventUpdatesAt = []uint64{100, 200}
 		err = b.Store()
 		Require(t, err)
-
-		b.cached = true
-		b.cachedAddresses = initAddresses
-		b.initAddresses = []common.Address{}
-		b.updates = []BatcherAddrUpdate{}
-		b.lastProcessedParentHeight = 0
-
+		b.lastProcessedParentHeight = 10
+		b.eventUpdatesAt = []uint64{}
+		b.fromParentBlock = 101
 		err = b.Restore()
 		Require(t, err)
 
-		assert.Equal(t, initAddresses, b.initAddresses)
-		assert.Equal(t, events, b.updates)
-		assert.Equal(t, false, b.cached)
-		assert.Equal(t, []common.Address{}, b.cachedAddresses)
-		assert.Equal(t, uint64(100), b.lastProcessedParentHeight)
+		assert.Equal(t, uint64(10), b.lastProcessedParentHeight)
+		assert.Equal(t, []uint64{}, b.eventUpdatesAt)
+
 	})
-	t.Run("event rlp decode/encode", func(t *testing.T) {
-		events := []BatcherAddrUpdate{
-			{50, 50, initAddr1, false},
-			{60, 60, initAddr2, false},
+
+	t.Run("IsValid with no events", func(t *testing.T) {
+		ctx := context.Background()
+		caffDb, err := authdb.NewAuthDB(rawdb.NewMemoryDatabase(), nil, true)
+		Require(t, err)
+
+		b := NewBatcherAddrMonitor(initAddresses, &caffDb, nil, common.Address{}, 0, 0, 100)
+		// No events have been recorded yet; IsValid should return an error.
+		ok, err := b.IsValid(ctx, initAddr1, 100)
+		assert.False(t, ok)
+		assert.Error(t, err)
+	})
+
+	t.Run("IsValid uses cached results", func(t *testing.T) {
+		ctx := context.Background()
+		caffDb, err := authdb.NewAuthDB(rawdb.NewMemoryDatabase(), nil, true)
+		Require(t, err)
+
+		b := &BatcherAddrMonitor{
+			bufferWindow: 0,
+			// Two update points; we will target the first cache entry.
+			eventUpdatesAt: []uint64{100, 200},
+			validityCaches: []map[common.Address]bool{
+				{initAddr1: true, initAddr2: false},
+				{initAddr2: false},
+			},
+			// db is not used in IsValid, but keep it non-nil for completeness.
+			db:                        &caffDb,
+			lastProcessedParentHeight: 300,
+			lastProcessedL1Height:     300,
 		}
-		encoded, err := rlp.EncodeToBytes(events)
+
+		// height = l1Height - bufferWindow = 150, so index will resolve to 0
+		// and use the first cache map, where initAddr1 is true.
+		ok, err := b.IsValid(ctx, initAddr1, 150)
 		Require(t, err)
-		var decoded []BatcherAddrUpdate
-		err = rlp.DecodeBytes(encoded, &decoded)
+		assert.True(t, ok)
+
+		// For a height that falls into the second interval, it should use
+		// the second cache map, where initAddr2 is false.
+		ok, err = b.IsValid(ctx, initAddr2, 250)
 		Require(t, err)
-		assert.Equal(t, events, decoded)
+		assert.False(t, ok)
+
+		b.bufferWindow = 64
+		ok, err = b.IsValid(ctx, initAddr2, 250)
+		Require(t, err)
+		assert.False(t, ok)
 	})
 }

--- a/arbnode/espresso_batcher_addr_simple_monitor.go
+++ b/arbnode/espresso_batcher_addr_simple_monitor.go
@@ -1,0 +1,50 @@
+package arbnode
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type AddressValidRangeConfig struct {
+	Address string `koanf:"address"`
+	From    uint64 `koanf:"from"`
+	To      uint64 `koanf:"to"`
+}
+
+type AddressValidRange struct {
+	Address common.Address `koanf:"address"`
+	from    uint64         `koanf:"from"`
+	to      uint64         `koanf:"to"`
+}
+
+type BatcherAddrSimpleMonitor struct {
+	addressValidRanges []AddressValidRange
+}
+
+func NewBatcherAddrSimpleMonitor(addressValidRanges []AddressValidRangeConfig) *BatcherAddrSimpleMonitor {
+	converted := make([]AddressValidRange, 0, len(addressValidRanges))
+	for _, cfg := range addressValidRanges {
+		converted = append(converted, AddressValidRange{
+			Address: common.HexToAddress(cfg.Address),
+			from:    cfg.From,
+			to:      cfg.To,
+		})
+	}
+	return &BatcherAddrSimpleMonitor{
+		addressValidRanges: converted,
+	}
+}
+
+func (b *BatcherAddrSimpleMonitor) IsValid(ctx context.Context, batcherAddress common.Address, l1Height uint64) (bool, error) {
+	for _, addr := range b.addressValidRanges {
+		if addr.Address == batcherAddress {
+			return l1Height >= addr.from && l1Height <= addr.to, nil
+		}
+	}
+	return false, nil
+}
+
+func (b *BatcherAddrSimpleMonitor) Start(ctx context.Context) error {
+	return nil
+}

--- a/arbnode/espresso_batcher_addr_simple_monitor_test.go
+++ b/arbnode/espresso_batcher_addr_simple_monitor_test.go
@@ -1,0 +1,72 @@
+package arbnode
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestBatcherAddrSimpleMonitor_IsValid(t *testing.T) {
+	ctx := context.Background()
+
+	addr1Str := "0x1234567890123456789012345678901234567890"
+	addr2Str := "0x2345678901234567890123456789012345678901"
+
+	cfgs := []AddressValidRangeConfig{
+		{
+			Address: addr1Str,
+			From:    0,
+			To:      100,
+		},
+		{
+			Address: addr2Str,
+			From:    50,
+			To:      150,
+		},
+	}
+
+	monitor := NewBatcherAddrSimpleMonitor(cfgs)
+
+	addr1 := common.HexToAddress(addr1Str)
+	addr2 := common.HexToAddress(addr2Str)
+	addr3 := common.HexToAddress("0x3456789012345678901234567890123456789012")
+
+	t.Run("within first range", func(t *testing.T) {
+		ok, err := monitor.IsValid(ctx, addr1, 50)
+		assert.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("below first range", func(t *testing.T) {
+		ok, err := monitor.IsValid(ctx, addr1, 0)
+		assert.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("above first range", func(t *testing.T) {
+		ok, err := monitor.IsValid(ctx, addr1, 101)
+		assert.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("within second range", func(t *testing.T) {
+		ok, err := monitor.IsValid(ctx, addr2, 100)
+		assert.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("outside any range", func(t *testing.T) {
+		ok, err := monitor.IsValid(ctx, addr2, 151)
+		assert.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("unknown address", func(t *testing.T) {
+		ok, err := monitor.IsValid(ctx, addr3, 75)
+		assert.NoError(t, err)
+		assert.False(t, ok)
+	})
+}

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -291,7 +291,9 @@ func NewEspressoCaffNode(
 		sgxVerifier,
 		client,
 		recordPerformance,
-		batcherAddrMonitor.GetValidAddresses,
+		func(l1Height uint64, addr common.Address) (bool, error) {
+			return batcherAddrMonitor.IsValid(ctx, addr, l1Height)
+		},
 		configFetcher().RetryTime,
 		configFetcher().Dangerous.MinimumHotshotBlockNum,
 	)

--- a/arbnode/espresso_caff_node_test.go
+++ b/arbnode/espresso_caff_node_test.go
@@ -38,7 +38,11 @@ func (m *MockEspressoStreamer) StopAndWait() {
 var _ espressostreamer.EspressoStreamerInterface = (*MockEspressoStreamer)(nil)
 
 // SetBatcherAddressesFetcher implements espressostreamer.EspressoStreamerInterface.
-func (m *MockEspressoStreamer) SetBatcherAddressesFetcher(fetcher func(l1Height uint64) []common.Address) {
+func (m *MockEspressoStreamer) SetBatcherAddressesFetcher(fetcher func(l1Height uint64, address common.Address) (bool, error)) {
+	panic("unimplemented")
+}
+
+func (m *MockEspressoStreamer) CanBatcherAddressSend(ctx context.Context, address common.Address) (bool, error) {
 	panic("unimplemented")
 }
 

--- a/ci_skip_tests
+++ b/ci_skip_tests
@@ -47,6 +47,8 @@ TestGettingState
 TestBatchPosterDelayBufferDisabled
 TestEthSyncing
 TestOutOfGasInStorageCacheFlush
+TestPrimaryToSecondaryFailover
+TestRetryableExpiry
 
 # These tests are skipped because of invalid long paths of temporary directory
 # in CI environment. Currently we don't have methods to modify the

--- a/espresso/authdb/operations.go
+++ b/espresso/authdb/operations.go
@@ -1,7 +1,9 @@
 package authdb
 
 import (
+	"bytes"
 	"fmt"
+	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -75,43 +77,6 @@ func ReadFromBlock(db ethdb.KeyValueReader) (uint64, error) {
 	return DecodeUint64(numBytes)
 }
 
-// WriteInitAddresses writes the batcher address monitor's InitAddresses info
-func WriteInitAddresses(db ethdb.KeyValueWriter, addrs []common.Address) error {
-	if err := enforceAuthenticatedWriter(db); err != nil {
-		return err
-	}
-	if len(addrs) == 0 {
-		return nil
-	}
-	addrsBytes, err := rlp.EncodeToBytes(addrs)
-	if err != nil {
-		return fmt.Errorf("failed to encode addrs: %w", err)
-	}
-	return db.Put(initAddressesKey, addrsBytes)
-}
-
-// ReadInitAddresses reads the batcher address monitor's InitAddresses info
-func ReadInitAddresses(db ethdb.KeyValueReader) ([]common.Address, error) {
-	if err := enforceAuthenticatedReader(db); err != nil {
-		return nil, err
-	}
-	addrsBytes, err := db.Get(initAddressesKey)
-	if err != nil {
-		if rawdb.IsDbErrNotFound(err) {
-			// on batcher monitor first run, there may be no init addrs, thus not found is fine
-			return nil, nil // nolint:nilerr
-		}
-		return nil, fmt.Errorf("failed to get init addrs: %w", err)
-	}
-
-	var addrs []common.Address
-	err = rlp.DecodeBytes(addrsBytes, &addrs)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode addrs: %w", err)
-	}
-	return addrs, nil
-}
-
 // WriteEvents writes the batcher address monitor's Events info
 // We accept RLP-encoded events to avoid cyclic dependency since `BatcherAddrUpdate struct`
 // is defined in `arbnode` which will depend on this function
@@ -159,4 +124,76 @@ func ReadLastProcessedHeight(db ethdb.KeyValueReader) (uint64, error) {
 		return 0, fmt.Errorf("failed to get last processed height: %w", err)
 	}
 	return DecodeUint64(heightBytes)
+}
+
+type AddrFlag struct {
+	Addr common.Address
+	Flag bool
+}
+
+type AddrFlagList []AddrFlag
+
+func WriteAddresses(db ethdb.KeyValueWriter, addrs []map[common.Address]bool) error {
+	if err := enforceAuthenticatedWriter(db); err != nil {
+		return err
+	}
+
+	outer := make([]AddrFlagList, 0, len(addrs))
+
+	for _, m := range addrs {
+		list := make(AddrFlagList, 0, len(m))
+		for addr, flag := range m {
+			list = append(list, AddrFlag{
+				Addr: addr,
+				Flag: flag,
+			})
+		}
+
+		sort.Slice(list, func(i, j int) bool {
+			return bytes.Compare(
+				list[i].Addr.Bytes(),
+				list[j].Addr.Bytes(),
+			) < 0
+		})
+
+		outer = append(outer, list)
+	}
+
+	// Encode as RLP
+	encoded, err := rlp.EncodeToBytes(outer)
+	if err != nil {
+		return fmt.Errorf("failed to encode addresses: %w", err)
+	}
+
+	return db.Put(addressesKey, encoded)
+}
+
+func ReadAddresses(db ethdb.KeyValueReader) ([]map[common.Address]bool, error) {
+	// Read raw bytes
+	data, err := db.Get(addressesKey)
+	if err != nil {
+		if rawdb.IsDbErrNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	// Decode RLP -> [][]AddrFlag
+	var outer []AddrFlagList
+	if err := rlp.DecodeBytes(data, &outer); err != nil {
+		return nil, fmt.Errorf("failed to decode addresses: %w", err)
+	}
+
+	// Convert back to []map[Address]bool
+	result := make([]map[common.Address]bool, 0, len(outer))
+
+	for _, list := range outer {
+		m := make(map[common.Address]bool, len(list))
+		for _, af := range list {
+			m[af.Addr] = af.Flag
+		}
+		result = append(result, m)
+	}
+
+	return result, nil
 }

--- a/espresso/authdb/operations_test.go
+++ b/espresso/authdb/operations_test.go
@@ -26,9 +26,6 @@ func TestAuthCaffNodeOperations(t *testing.T) {
 	err = WriteFromBlock(plainDB, 456)
 	Assert(t, err != nil, "expected error when writing FromBlock to plain db, but got nil")
 
-	err = WriteInitAddresses(plainDB, []common.Address{{0x01}})
-	Assert(t, err != nil, "expected error when writing InitAddresses to plain db, but got nil")
-
 	err = WriteLastProcessedHeight(plainDB, 789)
 	Assert(t, err != nil, "expected error when writing LastProcessedHeight to plain db, but got nil")
 
@@ -42,11 +39,17 @@ func TestAuthCaffNodeOperations(t *testing.T) {
 	_, err = ReadFromBlock(plainDB)
 	Assert(t, err != nil, "expected error when reading FromBlock from plain db, but got nil")
 
-	_, err = ReadInitAddresses(plainDB)
-	Assert(t, err != nil, "expected error when reading InitAddresses from plain db, but got nil")
-
 	_, err = ReadLastProcessedHeight(plainDB)
 	Assert(t, err != nil, "expected error when reading LastProcessedHeight from plain db, but got nil")
+
+	// Test WriteAddresses with plain DB - should fail
+	plainAddrs := []map[common.Address]bool{
+		{
+			common.HexToAddress("0x1000000000000000000000000000000000000001"): true,
+		},
+	}
+	err = WriteAddresses(plainDB, plainAddrs)
+	Assert(t, err != nil, "expected error when writing addresses to plain db, but got nil")
 
 	// Test with plain batch - should fail
 	plainBatch := plainDB.NewBatch()
@@ -60,11 +63,12 @@ func TestAuthCaffNodeOperations(t *testing.T) {
 	err = WriteFromBlock(plainBatch, 456)
 	Assert(t, err != nil, "expected error when writing FromBlock to plain batch, but got nil")
 
-	err = WriteInitAddresses(plainBatch, []common.Address{{0x01}})
-	Assert(t, err != nil, "expected error when writing InitAddresses to plain batch, but got nil")
-
 	err = WriteLastProcessedHeight(plainBatch, 789)
 	Assert(t, err != nil, "expected error when writing LastProcessedHeight to plain batch, but got nil")
+
+	// Test WriteAddresses with plain batch - should fail
+	err = WriteAddresses(plainBatch, plainAddrs)
+	Assert(t, err != nil, "expected error when writing addresses to plain batch, but got nil")
 
 	hmac, err := espresso_tee_utils.HmacForTest()
 	Require(t, err)
@@ -91,8 +95,6 @@ func TestAuthCaffNodeOperations(t *testing.T) {
 
 	err = WriteFromBlock(batch, 456)
 	Require(t, err)
-	err = WriteInitAddresses(batch, []common.Address{{0x01}, {0x02}, {0x03}})
-	Require(t, err)
 	err = WriteLastProcessedHeight(batch, 789)
 	Require(t, err)
 	err = batch.Write()
@@ -104,15 +106,85 @@ func TestAuthCaffNodeOperations(t *testing.T) {
 		t.Fatalf("expected fromBlk 456, got %d", fromBlk)
 	}
 
-	initAddrs, err := ReadInitAddresses(&authdb)
-	Require(t, err)
-	if len(initAddrs) != 3 || initAddrs[0] != (common.Address{0x01}) || initAddrs[1] != (common.Address{0x02}) || initAddrs[2] != (common.Address{0x03}) {
-		t.Fatalf("unexpected initAddrs: %v", initAddrs)
-	}
-
 	lastBlk, err := ReadLastProcessedHeight(&authdb)
 	Require(t, err)
 	if lastBlk != 789 {
 		t.Fatalf("expected lastBlk 789, got %d", lastBlk)
+	}
+
+	// Test WriteAddresses / ReadAddresses with AuthDB and AuthBatch
+	a1 := common.HexToAddress("0x2000000000000000000000000000000000000001")
+	a2 := common.HexToAddress("0x2000000000000000000000000000000000000002")
+	a3 := common.HexToAddress("0x2000000000000000000000000000000000000003")
+
+	authAddrs := []map[common.Address]bool{
+		{
+			a1: true,
+			a2: false,
+		},
+		{
+			a3: true,
+		},
+	}
+
+	// Before writing, ReadAddresses on AuthDB should return nil, nil (no data)
+	addrRes, err := ReadAddresses(&authdb)
+	Require(t, err)
+	if addrRes != nil {
+		t.Fatalf("expected nil addresses before write, got %v", addrRes)
+	}
+
+	// Write using AuthDB
+	err = WriteAddresses(&authdb, authAddrs)
+	Require(t, err)
+
+	// Read back and compare
+	addrRes, err = ReadAddresses(&authdb)
+	Require(t, err)
+	if len(addrRes) != len(authAddrs) {
+		t.Fatalf("expected %d address lists, got %d", len(authAddrs), len(addrRes))
+	}
+	for i, expectedMap := range authAddrs {
+		gotMap := addrRes[i]
+		if len(gotMap) != len(expectedMap) {
+			t.Fatalf("index %d: expected %d addrs, got %d", i, len(expectedMap), len(gotMap))
+		}
+		for addr, flag := range expectedMap {
+			gotFlag, ok := gotMap[addr]
+			if !ok {
+				t.Fatalf("index %d: missing addr %s", i, addr.Hex())
+			}
+			if gotFlag != flag {
+				t.Fatalf("index %d: addr %s flag mismatch: expected %v, got %v", i, addr.Hex(), flag, gotFlag)
+			}
+		}
+	}
+
+	// Now test writing via AuthBatch
+	addrBatch := authdb.NewBatch()
+	err = WriteAddresses(addrBatch, authAddrs)
+	Require(t, err)
+	err = addrBatch.Write()
+	Require(t, err)
+
+	addrRes, err = ReadAddresses(&authdb)
+	Require(t, err)
+	if len(addrRes) != len(authAddrs) {
+		t.Fatalf("(batch) expected %d address lists, got %d", len(authAddrs), len(addrRes))
+	}
+	for i, expectedMap := range authAddrs {
+		gotMap := addrRes[i]
+		if len(gotMap) != len(expectedMap) {
+			t.Fatalf("(batch) index %d: expected %d addrs, got %d", i, len(expectedMap), len(gotMap))
+		}
+		for addr, flag := range expectedMap {
+			gotFlag, ok := gotMap[addr]
+			if !ok {
+				t.Fatalf("(batch) index %d: missing addr %s", i, addr.Hex())
+			}
+			if gotFlag != flag {
+				t.Fatalf("(batch) index %d: addr %s flag mismatch: expected %v, got %v", i, addr.Hex(), flag, gotFlag)
+			}
+		}
 	}
 }

--- a/espresso/authdb/schema.go
+++ b/espresso/authdb/schema.go
@@ -17,8 +17,8 @@ var (
 	// caff node specific
 	fromBlockKey           = []byte("fromBlk")
 	nextHotshotBlockNumKey = []byte("nextHsBlkNum")
-	initAddressesKey       = []byte("initAddrs")
-	eventsKey              = []byte("events")
+	addressesKey           = []byte("addresses")
+	eventsKey              = []byte("events2")
 	lastProcessedHeightKey = []byte("lastProcessedHeight")
 )
 

--- a/espresso/submitter/polling_espresso_submitter.go
+++ b/espresso/submitter/polling_espresso_submitter.go
@@ -60,6 +60,8 @@ type PollingEspressoSubmitter struct {
 	lightClientReader  espresso_light_client.LightClientReaderInterface
 	espressoKeyManager espresso_key_manager.EspressoKeyManagerInterface
 
+	canSubmit func(ctx context.Context) (bool, error)
+
 	chainID                               uint64
 	espressoTxnsPollingInterval           time.Duration
 	espressoTxnsSendingInterval           time.Duration
@@ -102,6 +104,7 @@ func NewPollingEspressoSubmitter(options ...EspressoSubmitterConfigOption) (Espr
 		resubmitEspressoTxDeadline:       config.ResubmitEspressoTxDeadline,
 
 		InitialFinalizedSequencerMessageCount: config.InitialFinalizedSequencerMessageCount,
+		canSubmit:                             config.CanSubmit,
 	}, nil
 }
 
@@ -481,6 +484,15 @@ func (s *PollingEspressoSubmitter) pollSubmittedTransactionForFinality(ctx conte
 func (s *PollingEspressoSubmitter) submitTransactionsToEspresso(ctx context.Context, ignored struct{}) time.Duration {
 	// When encountering an error during the initial attempt at submitting a transaction, double the amount of our polling interval and try again.
 	retryRate := s.espressoTxnsSendingInterval * 2
+
+	ok, err := s.canSubmit(ctx)
+	if err != nil {
+		return s.espressoTxnsSendingInterval
+	}
+
+	if !ok {
+		return retryRate
+	}
 	shouldSubmit := s.shouldSubmitEspressoTransaction(nil)
 	// Only submit the transaction if escape hatch is not enabled
 	if shouldSubmit {

--- a/espresso/submitter/submitter.go
+++ b/espresso/submitter/submitter.go
@@ -1,6 +1,7 @@
 package submitter
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"time"
@@ -57,6 +58,8 @@ type EspressoSubmitterConfig struct {
 	KeyManager        espresso_key_manager.EspressoKeyManagerInterface
 	MessageGetter     MessageGetter
 	Db                ethdb.Database
+
+	CanSubmit func(ctx context.Context) (bool, error)
 
 	// These are specific to the Multi Worker Queue Espresso Submitter
 	// and governs how many workers / buffering is used for the
@@ -131,6 +134,12 @@ func applyEspressoSubmitterConfigOptions(
 func WithMultipleOptions(options ...EspressoSubmitterConfigOption) EspressoSubmitterConfigOption {
 	return func(config *EspressoSubmitterConfig) {
 		applyEspressoSubmitterConfigOptions(config, options...)
+	}
+}
+
+func WithCanSubmit(canSubmit func(ctx context.Context) (bool, error)) EspressoSubmitterConfigOption {
+	return func(config *EspressoSubmitterConfig) {
+		config.CanSubmit = canSubmit
 	}
 }
 
@@ -397,6 +406,10 @@ func ValidateEspressoSubmitterConfig(config EspressoSubmitterConfig) error {
 
 	if config.EspressoTxnSendingInterval <= 0 {
 		return fmt.Errorf("espresso transactions submission interval must be greater than 0")
+	}
+
+	if config.CanSubmit == nil {
+		return fmt.Errorf("espresso can submit is not set")
 	}
 
 	return nil

--- a/espressostreamer/espresso_streamer.go
+++ b/espressostreamer/espresso_streamer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -47,7 +46,8 @@ type EspressoStreamerInterface interface {
 	RecordTimeDurationBetweenHotshotAndCurrentBlock(nextHotshotBlock uint64, blockProductionTime time.Time)
 	GetCurrentEarliestHotShotBlockNumber() uint64
 
-	SetBatcherAddressesFetcher(fetcher func(l1Height uint64) []common.Address)
+	SetBatcherAddressesFetcher(fetcher func(l1Height uint64, address common.Address) (bool, error))
+	CanBatcherAddressSend(ctx context.Context, address common.Address) (bool, error)
 	StopAndWait()
 }
 
@@ -71,8 +71,7 @@ type EspressoStreamer struct {
 
 	PerfRecorder *PerfRecorder
 
-	batcherAddressesFetcher func(l1Height uint64) []common.Address
-
+	batcherAddressesFetcher         func(l1Height uint64, address common.Address) (bool, error)
 	dangerousMinimumHotshotBlockNum uint64
 }
 
@@ -84,7 +83,7 @@ func NewEspressoStreamer(
 	espressoSGXVerifier espressotee.EspressoSGXVerifierInterface,
 	espressoClient espressoClient.EspressoClient,
 	recordPerformance bool,
-	batcherAddressesFetcher func(l1Height uint64) []common.Address,
+	batcherAddressesFetcher func(l1Height uint64, address common.Address) (bool, error),
 	retryTime time.Duration,
 	dangerousMinimumHotshotBlockNum uint64,
 ) *EspressoStreamer {
@@ -105,6 +104,32 @@ func NewEspressoStreamer(
 		currentMessagePos:               1,
 		dangerousMinimumHotshotBlockNum: dangerousMinimumHotshotBlockNum,
 	}
+}
+
+func (s *EspressoStreamer) CanBatcherAddressSend(ctx context.Context, address common.Address) (bool, error) {
+	if s.batcherAddressesFetcher == nil {
+		return false, errors.New("batcher addresses fetcher not set")
+	}
+	latest, err := s.espressoClient.FetchLatestBlockHeight(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to fetch espresso latest block height: %w", err)
+	}
+	// Even though we can query the latest block height, the node may not yet serve
+	// the header at that exact height. Using `latest-1` avoids spurious errors
+	// where this function would otherwise always fail. This is safe because
+	// Espresso block production is much faster than L1, and the L1 lag has
+	// already been accounted for in the batcher address monitor.
+	// TODO: Figure out why this doesn't work without `-1`.
+	// It might be just a dev node issue.
+	header, err := s.espressoClient.FetchHeaderByHeight(ctx, latest-1)
+	if err != nil {
+		return false, fmt.Errorf("failed to fetch espresso block header: %w", err)
+	}
+	l1Finalized := header.Header.GetL1Finalized()
+	if l1Finalized == nil {
+		return false, fmt.Errorf("l1 finalized not found")
+	}
+	return s.batcherAddressesFetcher(l1Finalized.Number, address)
 }
 
 // GetMessageCount
@@ -210,17 +235,15 @@ func (s *EspressoStreamer) verifyBatchPosterSignature(signature []byte, userData
 		return fmt.Errorf("failed to convert signature to public key: %w", err)
 	}
 	addr := crypto.PubkeyToAddress(*publicKey)
-	validAddresses := s.batcherAddressesFetcher(l1Height)
-	if len(validAddresses) == 0 {
-		log.Warn("no valid addresses found", "validAddresses", validAddresses)
-		// No valid addresses right now. Need to catch up
+	valid, err := s.batcherAddressesFetcher(l1Height, addr)
+	if err != nil {
+		log.Warn("failed to get valid addresses", "err", err)
 		return ErrRetryParsingHotShotPayload
 	}
-	// if the list of valid addresses doesn't contain the address from the signature, this signature is invalid,
-	// and we must return an error.
-	if !slices.Contains(validAddresses, addr) {
-		log.Warn("batch poster address", "addr", addr, "expected one of", validAddresses)
-		return fmt.Errorf("batch poster address does not match")
+	if !valid {
+		log.Error("address not valid", "addr", addr)
+		// Address not valid. Need to catch up
+		return fmt.Errorf("address not valid: %v", addr)
 	}
 	return nil
 }
@@ -339,7 +362,7 @@ func (s *EspressoStreamer) SetSGXVerifier(sgxVerifier espressotee.EspressoSGXVer
 	s.espressoSGXVerifier = sgxVerifier
 }
 
-func (s *EspressoStreamer) SetBatcherAddressesFetcher(fetcher func(l1Height uint64) []common.Address) {
+func (s *EspressoStreamer) SetBatcherAddressesFetcher(fetcher func(l1Height uint64, address common.Address) (bool, error)) {
 	s.batcherAddressesFetcher = fetcher
 }
 

--- a/espressostreamer/espresso_streamer_test.go
+++ b/espressostreamer/espresso_streamer_test.go
@@ -31,7 +31,7 @@ func TestEspressoStreamer(t *testing.T) {
 		mockEspressoClient := new(mockEspressoClient)
 		mockEspressoTEEVerifierClient := new(mockEspressoTEEVerifier)
 
-		streamer := NewEspressoStreamer(1, 3, mockEspressoTEEVerifierClient, mockEspressoClient, false, func(l1Height uint64) []common.Address { return []common.Address{} }, 1*time.Second, 0)
+		streamer := NewEspressoStreamer(1, 3, mockEspressoTEEVerifierClient, mockEspressoClient, false, func(l1Height uint64, addr common.Address) (bool, error) { return false, nil }, 1*time.Second, 0)
 
 		streamer.Reset(1, 3)
 
@@ -63,7 +63,7 @@ func TestEspressoStreamer(t *testing.T) {
 		mockEspressoClient := new(mockEspressoClient)
 		mockEspressoTEEVerifierClient := new(mockEspressoTEEVerifier)
 
-		streamer := NewEspressoStreamer(1, 3, mockEspressoTEEVerifierClient, mockEspressoClient, false, func(l1Height uint64) []common.Address { return []common.Address{} }, 1*time.Second, 0)
+		streamer := NewEspressoStreamer(1, 3, mockEspressoTEEVerifierClient, mockEspressoClient, false, func(l1Height uint64, addr common.Address) (bool, error) { return false, nil }, 1*time.Second, 0)
 
 		streamer.Reset(1, 3)
 
@@ -124,7 +124,7 @@ func TestEspressoStreamer(t *testing.T) {
 
 		mockEspressoClient.On("FetchTransactionsInBlock", ctx, uint64(6), namespace).Return(espressoClient.TransactionsInBlock{}, errors.New("test error"))
 
-		streamer := NewEspressoStreamer(namespace, 3, mockEspressoTEEVerifierClient, mockEspressoClient, false, func(l1Height uint64) []common.Address { return []common.Address{} }, 1*time.Second, 0)
+		streamer := NewEspressoStreamer(namespace, 3, mockEspressoTEEVerifierClient, mockEspressoClient, false, func(l1Height uint64, addr common.Address) (bool, error) { return false, nil }, 1*time.Second, 0)
 
 		testParseFn := func(tx types.Bytes, l1 uint64) ([]*MessageWithMetadataAndPos, error) {
 			return nil, nil
@@ -166,7 +166,7 @@ func TestEspressoStreamer(t *testing.T) {
 			},
 		}, nil)
 
-		streamer := NewEspressoStreamer(namespace, 3, mockEspressoTEEVerifierClient, mockEspressoClient, false, func(l1Height uint64) []common.Address { return []common.Address{} }, 1*time.Second, 0)
+		streamer := NewEspressoStreamer(namespace, 3, mockEspressoTEEVerifierClient, mockEspressoClient, false, func(l1Height uint64, addr common.Address) (bool, error) { return false, nil }, 1*time.Second, 0)
 
 		testParseFn := func(pos uint64, hotshotheight uint64) func(tx types.Bytes, l1Height uint64) ([]*MessageWithMetadataAndPos, error) {
 
@@ -252,7 +252,7 @@ func ExpectErr(t *testing.T, err error, expectedError error) {
 func TestEspressoEmptyTransaction(t *testing.T) {
 	mockEspressoClient := new(mockEspressoClient)
 	mockEspressoTEEVerifierClient := new(mockEspressoTEEVerifier)
-	streamer := NewEspressoStreamer(1, 1, mockEspressoTEEVerifierClient, mockEspressoClient, false, func(l1Height uint64) []common.Address { return []common.Address{} }, time.Millisecond, 0)
+	streamer := NewEspressoStreamer(1, 1, mockEspressoTEEVerifierClient, mockEspressoClient, false, func(l1Height uint64, addr common.Address) (bool, error) { return false, nil }, time.Millisecond, 0)
 	// This determines the contents of the message. For this test the contents of the message needs to be empty (not 0's) to properly test the behavior
 	msgFetcher := func(arbutil.MessageIndex) ([]byte, error) {
 		return []byte{}, nil

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -400,6 +400,7 @@ func TestEspressoCaffNodeDelayedMessagesConfirmations(t *testing.T) {
 	// Check the caff node RPC for tx. assert that it is not there.
 	_, _, err = builderCaffNode.Client.TransactionByHash(ctx, tx[0].TxHash)
 	ExpectErr(t, err, ethereum.NotFound)
+	AdvanceL1(t, ctx, builder.L1.Client, builder.L1Info, 100)
 
 	// Create the event function closures for the assert statement.
 	firstEvent := func() error {
@@ -746,7 +747,7 @@ func TestEspressoCaffNodeSGXVerifierShouldRetryWhenEncounterRPCError(t *testing.
 
 	espressoStreamer.SetSGXVerifier(NewMockSgxTeeVerifier())
 	// Set this will cause the caff node to use the sgx verifier
-	espressoStreamer.SetBatcherAddressesFetcher(func(l1Height uint64) []common.Address { return []common.Address{{}} })
+	espressoStreamer.SetBatcherAddressesFetcher(func(l1Height uint64, addr common.Address) (bool, error) { return false, nil })
 
 	err = waitForWith(ctx, 10*time.Minute, 10*time.Second, func() bool {
 		balance1 := builder2.L2.GetBalance(t, builder.L2Info.GetAddress("User16"))

--- a/system_tests/espresso_batcher_monitor_test.go
+++ b/system_tests/espresso_batcher_monitor_test.go
@@ -54,18 +54,15 @@ func TestEspressoBatcherMonitor(t *testing.T) {
 	Require(t, err)
 	log.Info("tx receipt", "receipt", receipt.BlockNumber)
 
-	AdvanceL1(t, ctx, builder.L1.Client, builder.L1Info, 35)
+	AdvanceL1(t, ctx, builder.L1.Client, builder.L1Info, 100)
 	time.Sleep(time.Second * 25)
 
-	events := monitor.GetEvents()
-	if len(events) != 1 {
-		t.Fatal("expected 1 valid address, got", events)
-	}
-	if events[0].Addr != batchPosterAddr {
-		t.Fatal("expected valid address to be", batchPosterAddr, "got", events[0].Addr)
-	}
-	if events[0].IsBatcher != true {
-		t.Fatal("expected valid address to be batcher, got", events[0].IsBatcher)
+	l1Height, err := builder.L1.Client.BlockNumber(ctx)
+	Require(t, err)
+	valid, err := monitor.IsValid(ctx, batchPosterAddr, l1Height)
+	Require(t, err)
+	if !valid {
+		t.Fatal("expect valid")
 	}
 
 	newAddr := common.Address{}
@@ -76,18 +73,14 @@ func TestEspressoBatcherMonitor(t *testing.T) {
 	Require(t, err)
 	_, err = EnsureTxSucceededWithTimeout(ctx, builder.L1.Client, tx2, time.Second*10)
 	Require(t, err)
-	AdvanceL1(t, ctx, builder.L1.Client, builder.L1Info, 30)
+	AdvanceL1(t, ctx, builder.L1.Client, builder.L1Info, 100)
 	time.Sleep(time.Second * 5)
 
-	events2 := monitor.GetEvents()
-	if len(events2) != 2 {
-		t.Fatal("expected 2 valid addresses, got", events2)
+	l1Height, err = builder.L1.Client.BlockNumber(ctx)
+	Require(t, err)
+	valid, err = monitor.IsValid(ctx, newAddr, l1Height)
+	Require(t, err)
+	if valid {
+		t.Fatal("expect invalid")
 	}
-	if events2[1].Addr != newAddr {
-		t.Fatal("expected valid address to be", newAddr, "got", events2[1].Addr)
-	}
-	if events2[1].IsBatcher != false {
-		t.Fatal("expected valid address to not be batcher, got", events2[1].IsBatcher)
-	}
-
 }


### PR DESCRIPTION
Since it is difficult to track batcher address changes using `OwnerCalled(1)`, the monitor now validates addresses directly from L1 and caches the results. Consequently, the **initialAddresses** field has been removed.

We also introduce an important constant, bufferWindow. A batcher address is considered valid or invalid only after it has been included in a block that is finalized plus the bufferWindow. This ensures that the espresso streamer can safely consume the latest HotShot blocks without worrying about the signer being invalid at the L1 finalized block. We can discuss the appropriate value for this constant.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211961624137409