### PR TITLE
Solve the `latestBaseFee` taking a Nil value (#878)

### DIFF
--- a/espressotee/espresso_tee_helpers.go
+++ b/espressotee/espresso_tee_helpers.go
@@ -91,6 +91,14 @@ func BaseFeeCheck(
 			continue
 		}
 
+		if latestBaseFee == nil {
+			log.Error(msg, "base fee is nil", "delay", retryDelay, "attempt", attempt+1)
+			if attempt < maxRetries-1 {
+				time.Sleep(retryDelay)
+			}
+			continue
+		}
+
 		if latestBaseFee.Uint64() > maxBaseFee {
 			log.Error(
 				msg,

--- a/espressotee/espresso_tee_helpers_test.go
+++ b/espressotee/espresso_tee_helpers_test.go
@@ -1,0 +1,44 @@
+package espressotee
+
+import (
+	"math/big"
+	"testing"
+	"time"
+)
+
+func TestBaseFeeCheck_NilBaseFee(t *testing.T) {
+	t.Run("retries when base fee is nil", func(t *testing.T) {
+		attempts := 0
+		fn := func() (*big.Int, error) {
+			attempts++
+			if attempts < 2 {
+				return nil, nil
+			}
+			return big.NewInt(1000000), nil // Succeed on 3rd retry
+		}
+
+		err := BaseFeeCheck(10000000, 3, 10*time.Millisecond, fn, "test")
+		if err != nil {
+			t.Errorf("Expected success after retry, got: %v", err)
+		}
+		if attempts != 2 {
+			t.Errorf("Expected 2 attempts, got %d", attempts)
+		}
+	})
+
+	t.Run("fails when base fee always nil", func(t *testing.T) {
+		attempts := 0
+		fn := func() (*big.Int, error) {
+			attempts++
+			return nil, nil // Always nil
+		}
+
+		err := BaseFeeCheck(10000000, 3, 10*time.Millisecond, fn, "test")
+		if err == nil {
+			t.Error("Expected error when base fee always nil")
+		}
+		if attempts != 3 {
+			t.Errorf("Expected 3 attempts, got %d", attempts)
+		}
+	})
+}


### PR DESCRIPTION
## This PR:
Backports PR (#878) "Solve the `latestBaseFee` taking a Nil value" into celestia-v3.9.2.