### PR TITLE
rm light client reader from polling esp streamer

### DIFF
--- a/espresso/submitter/polling_espresso_submitter.go
+++ b/espresso/submitter/polling_espresso_submitter.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	espresso_client "github.com/EspressoSystems/espresso-network/sdks/go/client"
-	espresso_light_client "github.com/EspressoSystems/espresso-network/sdks/go/light-client"
 	tagged_base64 "github.com/EspressoSystems/espresso-network/sdks/go/tagged-base64"
 	espresso_types "github.com/EspressoSystems/espresso-network/sdks/go/types"
 	"github.com/ccoveille/go-safecast"
@@ -57,7 +56,6 @@ type PollingEspressoSubmitter struct {
 	db                 ethdb.Database
 	messageGetter      MessageGetter
 	espressoClient     espresso_client.EspressoClient
-	lightClientReader  espresso_light_client.LightClientReaderInterface
 	espressoKeyManager espresso_key_manager.EspressoKeyManagerInterface
 
 	chainID                               uint64
@@ -91,7 +89,6 @@ func NewPollingEspressoSubmitter(options ...EspressoSubmitterConfigOption) (Espr
 		db:                 config.Db,
 		messageGetter:      config.MessageGetter,
 		espressoClient:     config.EspressoClient,
-		lightClientReader:  config.LightClientReader,
 		espressoKeyManager: config.KeyManager,
 
 		chainID:                          config.ChainID,
@@ -524,7 +521,7 @@ func (s *PollingEspressoSubmitter) pollToResubmitEspressoTransactions(ctx contex
 // are not met, we will not submit the transaction to Espresso.
 //
 // The necessary conditions are:
-//   - The Espresso Client and Light Client Reader must be set
+//   - The Espresso Client must be set
 //   - The given `pos` parameter must be after our recorded finalized sequencer
 //     message count
 //
@@ -598,7 +595,7 @@ func (s *PollingEspressoSubmitter) Start(sw *stopwaiter.StopWaiter) error {
 			return err
 		}
 	} else {
-		log.Warn("light client reader or espresso client not set, skipping espresso verification")
+		log.Warn("espresso client not set, skipping espresso verification")
 	}
 
 	return nil


### PR DESCRIPTION
Turns out we were not using the `lightClientReader` in `PollingEspressoSubmitter` struct. 
This PR removes that field