### PR TITLE
Update codeowners (#919)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 # later match takes precedence, they will be requested for review when someone
 # opens a pull request.
 
-*      @ImJeremyHe @zacshowa @Sneh1999 @philippecamacho @jbearer @jjeangal
+*      @ImJeremyHe @zacshowa @Sneh1999 @philippecamacho @jbearer @jjeangal @varun-doshi


### PR DESCRIPTION
### Description

Backport of https://github.com/EspressoSystems/nitro-espresso-integration/pull/919 to integration-v3.9.2.