### PR TITLE
[Backport integration-v3.5.6] abstract espresso configs as type 

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -135,13 +135,12 @@ type BatchPoster struct {
 	nextRevertCheckBlock int64       // the last parent block scanned for reverting batches
 	postedFirstBatch     bool        // indicates if batch poster has posted the first batch
 
-	accessList func(SequencerInboxAccs, AfterDelayedMessagesRead uint64) types.AccessList
-	// Types for packing the blob hashes into the data used to generate the batchers attestation quote.
-	bytesType        abi.Type
-	bytes32ArrayType abi.Type
+	accessList   func(SequencerInboxAccs, AfterDelayedMessagesRead uint64) types.AccessList
 
-	blobsAttestationArguments abi.Arguments
-
+	espressoConfig             *EspressoConfig
+	bytesType                  abi.Type
+	bytes32ArrayType           abi.Type
+	blobsAttestationArguments  abi.Arguments
 	espressoStreamer           *espressostreamer.EspressoStreamer
 	espressoBatcherAddrMonitor *BatcherAddrMonitor
 	espressoRestarting         bool
@@ -162,7 +161,6 @@ const (
 type BatchPosterDangerousConfig struct {
 	AllowPostingFirstBatchWhenSequencerMessageCountMismatch bool   `koanf:"allow-posting-first-batch-when-sequencer-message-count-mismatch"`
 	FixedGasLimit                                           uint64 `koanf:"fixed-gas-limit"`
-	MinimumHotshotBlockNum                                  uint64 `koanf:"minimum-hotshot-block-num"`
 }
 
 type BatchPosterConfig struct {
@@ -204,27 +202,6 @@ type BatchPosterConfig struct {
 
 	gasRefunder  common.Address
 	l1BlockBound l1BlockBound
-	// Espresso specific flags
-	EspressoTeeType                  string                                    `koanf:"espresso-tee-type"`
-	EspressoRegisterServiceConfig    espressotee.EspressoRegisterServiceConfig `koanf:"espresso-register-service-config"`
-	HotShotUrl                       string                                    `koanf:"hotshot-url"`
-	EspressoTxnsPollingInterval      time.Duration                             `koanf:"espresso-txns-polling-interval"`
-	EspressoTxnsSendingInterval      time.Duration                             `koanf:"espresso-txns-sending-interval"`
-	EspressoTxnsResubmissionInterval time.Duration                             `koanf:"espresso-txns-resubmission-interval"`
-	ResubmitEspressoTxDeadline       time.Duration                             `koanf:"resubmit-espresso-tx-deadline"`
-	EspressoTxSizeLimit              int64                                     `koanf:"espresso-tx-size-limit"`
-	UserDataAttestationFile          string                                    `koanf:"user-data-attestation-file"`
-	QuoteFile                        string                                    `koanf:"quote-file"`
-	AttestationServiceURL            string                                    `koanf:"attestation-service-url"`
-
-	// Fetch messages from HotShot block
-	HotShotBlock             uint64 `koanf:"hotshot-block"`
-	EspressoEventPollingStep uint64 `koanf:"espresso-event-polling-step"`
-	HotShotFirstPostingBlock uint64 `koanf:"hotshot-first-posting-block"`
-	AddressMonitorStartL1    uint64 `koanf:"address-monitor-start-l1"`
-	// Please make sure that these addresses are already valid at the `AddressMonitorStartL1`
-	InitBatcherAddresses []string `koanf:"init-batcher-addresses"`
-	AddressMonitorStep   uint64   `koanf:"address-monitor-step"`
 }
 
 func (c *BatchPosterConfig) Validate() error {
@@ -251,7 +228,10 @@ func (c *BatchPosterConfig) Validate() error {
 	return nil
 }
 
+type EspressoConfigFetcher func() *EspressoConfig
 type BatchPosterConfigFetcher func() *BatchPosterConfig
+type EspressoBatchConfigFetcher func() *EspressoBatchPosterConfig
+type EspressoStreamerConfigFetcher func() *espressostreamer.EspressoStreamerConfig
 
 func DangerousBatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Bool(prefix+".allow-posting-first-batch-when-sequencer-message-count-mismatch", DefaultBatchPosterConfig.Dangerous.AllowPostingFirstBatchWhenSequencerMessageCountMismatch, "allow posting the first batch even if sequence number doesn't match chain (useful after force-inclusion)")
@@ -278,26 +258,11 @@ func BatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.String(prefix+".l1-block-bound", DefaultBatchPosterConfig.L1BlockBound, "only post messages to batches when they're within the max future block/timestamp as of this L1 block tag (\"safe\", \"finalized\", \"latest\", or \"ignore\" to ignore this check)")
 	f.Duration(prefix+".l1-block-bound-bypass", DefaultBatchPosterConfig.L1BlockBoundBypass, "post batches even if not within the layer 1 future bounds if we're within this margin of the max delay")
 	f.Bool(prefix+".use-access-lists", DefaultBatchPosterConfig.UseAccessLists, "post batches with access lists to reduce gas usage (disabled for L3s)")
-	f.String(prefix+".espresso-tee-type", DefaultBatchPosterConfig.EspressoTeeType, "the Trusted Execution Environment (TEE) that Batch poster is running in")
-	f.String(prefix+".hotshot-url", DefaultBatchPosterConfig.HotShotUrl, "specifies the hotshot url if we are batching in espresso mode")
-	f.Uint64(prefix+".hotshot-block", DefaultBatchPosterConfig.HotShotBlock, "specifies the hotshot block number to start the espresso streamer on")
-	f.Uint64(prefix+".hotshot-first-posting-block", DefaultBatchPosterConfig.HotShotFirstPostingBlock, "specifies the l1 block number when this rollup started posting to hotshot")
-	f.Uint64(prefix+".espresso-event-polling-step", DefaultBatchPosterConfig.EspressoEventPollingStep, "specifies the number of blocks at a time to query when searching for logs emitted by batch posting.")
 	f.Uint64(prefix+".gas-estimate-base-fee-multiple-bips", uint64(DefaultBatchPosterConfig.GasEstimateBaseFeeMultipleBips), "for gas estimation, use this multiple of the basefee (measured in basis points) as the max fee per gas")
 	f.Duration(prefix+".reorg-resistance-margin", DefaultBatchPosterConfig.ReorgResistanceMargin, "do not post batch if its within this duration from layer 1 minimum bounds. Requires l1-block-bound option not be set to \"ignore\"")
 	f.Bool(prefix+".check-batch-correctness", DefaultBatchPosterConfig.CheckBatchCorrectness, "setting this to true will run the batch against an inbox multiplexer and verifies that it produces the correct set of messages")
 	f.Duration(prefix+".max-empty-batch-delay", DefaultBatchPosterConfig.MaxEmptyBatchDelay, "maximum empty batch posting delay, batch poster will only be able to post an empty batch if this time period building a batch has passed")
 	f.Uint64(prefix+".delay-buffer-threshold-margin", DefaultBatchPosterConfig.DelayBufferThresholdMargin, "the number of blocks to post the batch before reaching the delay buffer threshold")
-	f.Duration(prefix+".espresso-txns-polling-interval", DefaultBatchPosterConfig.EspressoTxnsPollingInterval, "interval between polling for transactions to be included in the block")
-	f.Duration(prefix+".espresso-txns-sending-interval", DefaultBatchPosterConfig.EspressoTxnsSendingInterval, "interval between sending transactions to Espresso Network")
-	f.Duration(prefix+".espresso-txns-resubmission-interval", DefaultBatchPosterConfig.EspressoTxnsResubmissionInterval, "interval between checking if the node should resubmitting transactions to Espresso Network")
-	f.Duration(prefix+".resubmit-espresso-tx-deadline", DefaultBatchPosterConfig.ResubmitEspressoTxDeadline, "time threshold after which a transaction will be automatically resubmitted if no response is received")
-	f.String(prefix+".user-data-attestation-file", DefaultBatchPosterConfig.UserDataAttestationFile, "path to SGX user data attestation file")
-	f.String(prefix+".quote-file", DefaultBatchPosterConfig.QuoteFile, "path to SGX quote file")
-	f.String(prefix+".attestation-service-url", DefaultBatchPosterConfig.AttestationServiceURL, "URL of the attestation service to use for obtaining zk proof over  attestation")
-	f.Int64(prefix+".espresso-tx-size-limit", DefaultBatchPosterConfig.EspressoTxSizeLimit, "specifies the maximum size of a transaction to be sent to the Espresso Network")
-	f.Uint64(prefix+".address-monitor-step", DefaultBatchPosterConfig.AddressMonitorStep, "specifies the number of blocks at a time to query when searching for logs emitted for updating valid batcher addresses.")
-	f.Uint64(prefix+".address-monitor-start-l1", DefaultBatchPosterConfig.AddressMonitorStartL1, "specifies the l1 block number when this rollup started posting to monitor addresses")
 	espressotee.AddEspressoRegisterServiceConfigOptions(prefix+".espresso-register-service-config", f)
 	redislock.AddConfigOptions(prefix+".redis-lock", f)
 	dataposter.DataPosterConfigAddOptions(prefix+".data-poster", f, dataposter.DefaultDataPosterConfig)
@@ -310,48 +275,31 @@ var DefaultBatchPosterConfig = BatchPosterConfig{
 	DisableDapFallbackStoreDataOnChain: false,
 	// This default is overridden for L3 chains in applyChainParameters in cmd/nitro/nitro.go
 	MaxSize: 100000,
-	// Try to fill 3 blobs per batch
+	// The Max4844BatchSize should be calculated from the values from L1 chain configs
+	// using the eip4844 utility package from go-ethereum.
+	// The default value of 0 causes the batch poster to use the value from go-ethereum.
 	Max4844BatchSize:                 blobs.BlobEncodableData*(params.MaxBlobGasPerBlock/params.BlobTxBlobGasPerBlob)/2 - 2000,
-	PollInterval:                     time.Second * 10,
-	PollIntervalAfterBatchPost:       time.Second * 10,
-	ErrorDelay:                       time.Second * 10,
-	MaxDelay:                         time.Hour,
-	WaitForMaxDelay:                  false,
-	CompressionLevel:                 brotli.BestCompression,
-	DASRetentionPeriod:               daprovider.DefaultDASRetentionPeriod,
-	GasRefunderAddress:               "",
-	ExtraBatchGas:                    50_000,
-	Post4844Blobs:                    false,
-	IgnoreBlobPrice:                  false,
-	DataPoster:                       dataposter.DefaultDataPosterConfig,
-	ParentChainWallet:                DefaultBatchPosterL1WalletConfig,
-	L1BlockBound:                     "",
-	L1BlockBoundBypass:               time.Hour,
-	UseAccessLists:                   true,
-	RedisLock:                        redislock.DefaultCfg,
-	GasEstimateBaseFeeMultipleBips:   arbmath.OneInUBips * 3 / 2,
-	ReorgResistanceMargin:            10 * time.Minute,
-	CheckBatchCorrectness:            true,
-	MaxEmptyBatchDelay:               3 * 24 * time.Hour,
-	DelayBufferThresholdMargin:       25, // 5 minutes considering 12-second blocks
-	EspressoTxnsPollingInterval:      time.Second,
-	EspressoTxnsSendingInterval:      125 * time.Millisecond,
-	EspressoTxnsResubmissionInterval: 2 * time.Second,
-	ResubmitEspressoTxDeadline:       10 * time.Minute,
-	HotShotUrl:                       "",
-	EspressoTeeType:                  "NITRO",
-	EspressoRegisterServiceConfig:    espressotee.DefaultEspressoRegisterServiceConfig,
-	// EspressoTxSizeLimit is 1 MB, to have some buffer we set it to 900 KB
-	EspressoTxSizeLimit:      900 * 1024,
-	UserDataAttestationFile:  "",
-	QuoteFile:                "",
-	AttestationServiceURL:    "",
-	HotShotBlock:             1,
-	HotShotFirstPostingBlock: 1,
-	InitBatcherAddresses:     []string{},
-	EspressoEventPollingStep: 100,
-	AddressMonitorStep:       100,
-	AddressMonitorStartL1:    1,
+	PollInterval:                   time.Second * 10,
+	ErrorDelay:                     time.Second * 10,
+	MaxDelay:                       time.Hour,
+	WaitForMaxDelay:                false,
+	CompressionLevel:               brotli.BestCompression,
+	DASRetentionPeriod:             daprovider.DefaultDASRetentionPeriod,
+	GasRefunderAddress:             "",
+	ExtraBatchGas:                  50_000,
+	Post4844Blobs:                  false,
+	IgnoreBlobPrice:                false,
+	DataPoster:                     dataposter.DefaultDataPosterConfig,
+	ParentChainWallet:              DefaultBatchPosterL1WalletConfig,
+	L1BlockBound:                   "",
+	L1BlockBoundBypass:             time.Hour,
+	UseAccessLists:                 true,
+	RedisLock:                      redislock.DefaultCfg,
+	GasEstimateBaseFeeMultipleBips: arbmath.OneInUBips * 3 / 2,
+	ReorgResistanceMargin:          10 * time.Minute,
+	CheckBatchCorrectness:          true,
+	MaxEmptyBatchDelay:             3 * 24 * time.Hour,
+	DelayBufferThresholdMargin:     25, // 5 minutes considering 12-second blocks
 }
 
 var DefaultBatchPosterL1WalletConfig = genericconf.WalletConfig{
@@ -363,41 +311,29 @@ var DefaultBatchPosterL1WalletConfig = genericconf.WalletConfig{
 }
 
 var TestBatchPosterConfig = BatchPosterConfig{
-	Enable:                           true,
-	MaxSize:                          100000,
-	Max4844BatchSize:                 DefaultBatchPosterConfig.Max4844BatchSize,
-	PollInterval:                     time.Millisecond * 10,
+	Enable:                             true,
+	DisableDapFallbackStoreDataOnChain: true,
+	MaxSize:                            100000,
+	Max4844BatchSize:                   DefaultBatchPosterConfig.Max4844BatchSize,
+	PollInterval:                       time.Millisecond * 10,
 	PollIntervalAfterBatchPost:       time.Millisecond * 10,
-	ErrorDelay:                       time.Millisecond * 10,
-	MaxDelay:                         0,
-	WaitForMaxDelay:                  false,
-	CompressionLevel:                 2,
-	DASRetentionPeriod:               daprovider.DefaultDASRetentionPeriod,
-	GasRefunderAddress:               "",
-	ExtraBatchGas:                    10_000,
-	Post4844Blobs:                    false,
-	IgnoreBlobPrice:                  false,
-	DataPoster:                       dataposter.TestDataPosterConfig,
-	ParentChainWallet:                DefaultBatchPosterL1WalletConfig,
-	L1BlockBound:                     "",
-	L1BlockBoundBypass:               time.Hour,
-	UseAccessLists:                   true,
-	GasEstimateBaseFeeMultipleBips:   arbmath.OneInUBips * 3 / 2,
-	CheckBatchCorrectness:            true,
-	DelayBufferThresholdMargin:       0,
-	EspressoTxnsPollingInterval:      time.Second,
-	EspressoTxnsSendingInterval:      time.Second,
-	EspressoTxnsResubmissionInterval: 2 * time.Second,
-	ResubmitEspressoTxDeadline:       10 * time.Second,
-	HotShotUrl:                       "",
-	EspressoTeeType:                  "TESTS",
-	EspressoRegisterServiceConfig:    espressotee.DefaultEspressoRegisterServiceConfig,
-	EspressoTxSizeLimit:              200 * 1024,
-
-	HotShotBlock:             1,
-	HotShotFirstPostingBlock: 1,
-	InitBatcherAddresses:     []string{},
-	EspressoEventPollingStep: 100,
+	ErrorDelay:                         time.Millisecond * 10,
+	MaxDelay:                           0,
+	WaitForMaxDelay:                    false,
+	CompressionLevel:                   2,
+	DASRetentionPeriod:                 daprovider.DefaultDASRetentionPeriod,
+	GasRefunderAddress:                 "",
+	ExtraBatchGas:                      10_000,
+	Post4844Blobs:                      false,
+	IgnoreBlobPrice:                    false,
+	DataPoster:                         dataposter.TestDataPosterConfig,
+	ParentChainWallet:                  DefaultBatchPosterL1WalletConfig,
+	L1BlockBound:                       "",
+	L1BlockBoundBypass:                 time.Hour,
+	UseAccessLists:                     true,
+	GasEstimateBaseFeeMultipleBips:     arbmath.OneInUBips * 3 / 2,
+	CheckBatchCorrectness:              true,
+	DelayBufferThresholdMargin:         0,
 }
 
 type BatchPosterOpts struct {
@@ -416,6 +352,8 @@ type BatchPosterOpts struct {
 	DAPReaders    []daprovider.Reader
 
 	DataSigner signature.DataSignerFunc
+
+	EspressoConfigFetcher EspressoConfigFetcher
 }
 
 func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, error) {
@@ -478,6 +416,7 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 		dapWriter:                 opts.DAPWriter,
 		redisLock:                 redisLock,
 		dapReaders:                opts.DAPReaders,
+		espressoConfig:            opts.EspressoConfigFetcher(),
 		bytesType:                 bytesType,
 		bytes32ArrayType:          bytes32ArrayType,
 		blobsAttestationArguments: blobsAttestationArguments,
@@ -526,7 +465,7 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 
 	submitterOptions = append(submitterOptions, WithTransactionStreamer(opts.Streamer))
 
-	hotshotUrl := opts.Config().HotShotUrl
+	hotshotUrl := opts.EspressoConfigFetcher().BatchPoster.HotShotUrl
 	// If the hotshot URL is non-empty, create the Espresso client.
 	if hotshotUrl != "" {
 		hotShotClient := hotshotClient.NewClient(hotshotUrl)
@@ -568,7 +507,7 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 
 		submitterOptions = append(submitterOptions, submitter.WithInitialFinalizedSequencerMessageCount(sequencerMessageCount))
 
-		initStringAddresses := opts.Config().InitBatcherAddresses
+		initStringAddresses := opts.EspressoConfigFetcher().BatchPoster.InitBatcherAddresses
 		// Convert the init addresses to common.Address
 		initAddresses := []common.Address{}
 		for _, addr := range initStringAddresses {
@@ -590,25 +529,30 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 		if err != nil {
 			return nil, err
 		}
-		monitor := NewBatcherAddrMonitor(
-			initAddresses,
-			&db,
-			opts.L1Reader,
-			opts.DeployInfo.SequencerInbox,
-			opts.DeployInfo.DeployedAt,
-			opts.Config().AddressMonitorStartL1,
-			opts.Config().AddressMonitorStep,
-		)
+		var monitor BatcherAddrMonitorInterface
+		if len(opts.EspressoConfigFetcher().BatchPoster.AddressValidRanges) == 0 {
+			monitor = NewBatcherAddrMonitor(
+				initAddresses,
+				&db,
+				opts.L1Reader,
+				opts.DeployInfo.SequencerInbox,
+				opts.DeployInfo.DeployedAt,
+				opts.EspressoConfigFetcher().Streamer.AddressMonitorStartL1,
+				opts.EspressoConfigFetcher().Streamer.AddressMonitorStep,
+			)
+		} else {
+			monitor = NewBatcherAddrSimpleMonitor(opts.EspressoConfigFetcher().BatchPoster.AddressValidRanges)
+		}
 
 		espressoStreamer := espressostreamer.NewEspressoStreamer(
 			opts.ChainID,
-			opts.Config().HotShotBlock,
+			opts.EspressoConfigFetcher().Streamer.HotShotBlock,
 			nil,
 			hotShotClient,
 			false,
 			monitor.GetValidAddresses,
-			opts.Config().EspressoTxnsPollingInterval,
-			opts.Config().Dangerous.MinimumHotshotBlockNum,
+			opts.EspressoConfigFetcher().Streamer.TxnsPollingInterval,
+			opts.EspressoConfigFetcher().Streamer.Dangerous.MinimumHotshotBlockNum,
 		)
 
 		b.espressoBatcherAddrMonitor = monitor
@@ -616,15 +560,16 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 	}
 
 	if b.espressoStreamer != nil {
-		cfg := opts.Config()
+		txPollingInterval := opts.EspressoConfigFetcher().Streamer.TxnsPollingInterval
+		cfg := opts.EspressoConfigFetcher().BatchPoster
 
 		submitterOptions = append(
 			submitterOptions,
-			submitter.WithTxnsPollingInterval(cfg.EspressoTxnsPollingInterval),
-			submitter.WithTxnsSendingInterval(cfg.EspressoTxnsSendingInterval),
-			submitter.WithTxnsResubmissionInterval(cfg.EspressoTxnsResubmissionInterval),
+			submitter.WithTxnsPollingInterval(txPollingInterval),
+			submitter.WithTxnsSendingInterval(cfg.TxnsSendingInterval),
+			submitter.WithTxnsResubmissionInterval(cfg.TxnsResubmissionInterval),
 			submitter.WithResubmitEspressoTxDeadline(cfg.ResubmitEspressoTxDeadline),
-			submitter.WithMaxTransactionSize(cfg.EspressoTxSizeLimit),
+			submitter.WithMaxTransactionSize(cfg.TxSizeLimit),
 		)
 
 		// Get the espressoTEEVerifier address for the sequencer inbox contract
@@ -640,9 +585,9 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 			return nil, err
 		}
 		verifier := espressotee.NewEspressoTEEVerifier(espresssoTEEVerifierAddress.Hex(), opts.L1Reader.Client(), espresssoTEEVerifierAddress)
-		teeType, err := espressotee.FromString(cfg.EspressoTeeType)
+		teeType, err := espressotee.FromString(cfg.TeeType)
 		if err != nil {
-			return nil, fmt.Errorf("unsupported tee type in config: %s", cfg.EspressoTeeType)
+			return nil, fmt.Errorf("unsupported tee type in config: %s", cfg.TeeType)
 		}
 
 		var nitroVerifier espressotee.EspressoNitroTEEVerifierInterface
@@ -661,7 +606,7 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 			submitterOptions,
 			// TODO: pass the persistent private key to the key manager in future
 			submitter.WithKeyManager(
-				espresso_key_manager.NewEspressoKeyManager(verifier, nitroVerifier, b.dataPoster, opts.DataSigner, teeType, espressotee.BatchPoster, cfg.EspressoRegisterServiceConfig, nil, opts.Config().UserDataAttestationFile, opts.Config().QuoteFile, opts.Config().AttestationServiceURL),
+				espresso_key_manager.NewEspressoKeyManager(verifier, nitroVerifier, b.dataPoster, opts.DataSigner, teeType, espressotee.BatchPoster, cfg.RegisterServiceConfig, nil, opts.EspressoConfigFetcher().BatchPoster.UserDataAttestationFile, opts.EspressoConfigFetcher().BatchPoster.QuoteFile, opts.EspressoConfigFetcher().BatchPoster.AttestationServiceURL),
 			),
 		)
 

--- a/arbnode/espresso_batch_poster_config.go
+++ b/arbnode/espresso_batch_poster_config.go
@@ -1,0 +1,78 @@
+package arbnode
+
+import (
+	"time"
+
+	"github.com/spf13/pflag"
+
+	"github.com/offchainlabs/nitro/espressotee"
+)
+
+type EspressoBatchPosterConfig struct {
+	TeeType                    string                                    `koanf:"tee-type"`
+	RegisterServiceConfig      espressotee.EspressoRegisterServiceConfig `koanf:"register-service-config"`
+	HotShotUrl                 string                                    `koanf:"hotshot-url"`
+	TxnsSendingInterval        time.Duration                             `koanf:"txns-sending-interval"`
+	TxnsResubmissionInterval   time.Duration                             `koanf:"txns-resubmission-interval"`
+	ResubmitEspressoTxDeadline time.Duration                             `koanf:"resubmit-espresso-tx-deadline"`
+	TxSizeLimit                int64                                     `koanf:"tx-size-limit"`
+	UserDataAttestationFile    string                                    `koanf:"user-data-attestation-file"`
+	QuoteFile                  string                                    `koanf:"quote-file"`
+	AttestationServiceURL      string                                    `koanf:"attestation-service-url"`
+
+	EventPollingStep         uint64 `koanf:"event-polling-step"`
+	HotShotFirstPostingBlock uint64 `koanf:"hotshot-first-posting-block"`
+	// Please make sure that these addresses are already valid at the `AddressMonitorStartL1`
+	InitBatcherAddresses []string `koanf:"init-batcher-addresses"`
+
+	AddressValidRanges []AddressValidRangeConfig `koanf:"address-valid-ranges"`
+}
+
+func EspressoBatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
+	f.String(prefix+".tee-type", DefaultEspressoBatchPosterConfig.TeeType, "the Trusted Execution Environment (TEE) that Batch poster is running in")
+	f.String(prefix+".hotshot-url", DefaultEspressoBatchPosterConfig.HotShotUrl, "specifies the hotshot url if we are batching in espresso mode")
+	f.Uint64(prefix+".hotshot-first-posting-block", DefaultEspressoBatchPosterConfig.HotShotFirstPostingBlock, "specifies the l1 block number when this rollup started posting to hotshot")
+	f.Uint64(prefix+".event-polling-step", DefaultEspressoBatchPosterConfig.EventPollingStep, "specifies the number of blocks at a time to query when searching for logs emitted by batch posting.")
+	f.Duration(prefix+".txns-sending-interval", DefaultEspressoBatchPosterConfig.TxnsSendingInterval, "interval between sending transactions to Espresso Network")
+	f.Duration(prefix+".txns-resubmission-interval", DefaultEspressoBatchPosterConfig.TxnsResubmissionInterval, "interval between checking if the node should resubmitting transactions to Espresso Network")
+	f.Duration(prefix+".resubmit-espresso-tx-deadline", DefaultEspressoBatchPosterConfig.ResubmitEspressoTxDeadline, "time threshold after which a transaction will be automatically resubmitted if no response is received")
+	f.String(prefix+".user-data-attestation-file", DefaultEspressoBatchPosterConfig.UserDataAttestationFile, "path to SGX user data attestation file")
+	f.String(prefix+".quote-file", DefaultEspressoBatchPosterConfig.QuoteFile, "path to SGX quote file")
+	f.String(prefix+".attestation-service-url", DefaultEspressoBatchPosterConfig.AttestationServiceURL, "URL of the attestation service to use for obtaining zk proof over  attestation")
+	f.Int64(prefix+".tx-size-limit", DefaultEspressoBatchPosterConfig.TxSizeLimit, "specifies the maximum size of a transaction to be sent to the Espresso Network")
+	f.StringSlice(prefix+".init-batcher-addresses", DefaultEspressoBatchPosterConfig.InitBatcherAddresses, "specifies the init batcher addresses")
+}
+
+var DefaultEspressoBatchPosterConfig = EspressoBatchPosterConfig{
+	// We should send to espresso at a speed faster than the speed nitro is producing messages
+	TxnsSendingInterval:        125 * time.Millisecond,
+	TxnsResubmissionInterval:   2 * time.Second,
+	ResubmitEspressoTxDeadline: 10 * time.Minute,
+	HotShotUrl:                 "",
+	TeeType:                    "NITRO",
+	RegisterServiceConfig:      espressotee.DefaultEspressoRegisterServiceConfig,
+	// EspressoTxSizeLimit is 1 MB, to have some buffer we set it to 900 KB
+	TxSizeLimit:              900 * 1024,
+	UserDataAttestationFile:  "",
+	QuoteFile:                "",
+	AttestationServiceURL:    "",
+	HotShotFirstPostingBlock: 1,
+	InitBatcherAddresses:     []string{},
+	EventPollingStep:         100,
+	AddressValidRanges:       []AddressValidRangeConfig{},
+}
+
+var TestEspressoBatchPosterConfig = EspressoBatchPosterConfig{
+	TxnsSendingInterval:        time.Second,
+	TxnsResubmissionInterval:   2 * time.Second,
+	ResubmitEspressoTxDeadline: 10 * time.Second,
+	HotShotUrl:                 "",
+	TeeType:                    "TESTS",
+	RegisterServiceConfig:      espressotee.DefaultEspressoRegisterServiceConfig,
+	TxSizeLimit:                200 * 1024,
+
+	HotShotFirstPostingBlock: 1,
+	InitBatcherAddresses:     []string{},
+	EventPollingStep:         100,
+	AddressValidRanges:       []AddressValidRangeConfig{},
+}

--- a/arbnode/espresso_batch_poster_helpers.go
+++ b/arbnode/espresso_batch_poster_helpers.go
@@ -16,7 +16,7 @@ func (b *BatchPoster) resetStreamerToParentChainOrConfigHotshotBlock(messageCoun
 	hotshotBlock := b.fetchHotshotBlockFromLastCheckpoint(ctx)
 	if hotshotBlock == 0 {
 		// if there hasn't been a batch posted, or we encountered an error, start reading from the configured hotshot block number.
-		hotshotBlock = b.config().HotShotBlock
+		hotshotBlock = b.espressoConfig.Streamer.HotShotBlock
 	}
 	b.espressoStreamer.Reset(uint64(messageCount), hotshotBlock)
 }
@@ -28,7 +28,7 @@ func (b *BatchPoster) resetStreamerToParentChainOrConfigHotshotBlock(messageCoun
 // returns the Hotshot height of the last event in the iterator returned from FilterTEESignatureVerified()
 // representing the most recently emitted hotshotblock height. Any errors encountered will result in 0 being returned.
 func (b *BatchPoster) fetchHotshotBlockFromLastCheckpoint(ctx context.Context) uint64 {
-	pollingStep := b.config().EspressoEventPollingStep
+	pollingStep := b.espressoConfig.BatchPoster.EventPollingStep
 	header, err := b.l1Reader.LastHeader(ctx)
 	if err != nil {
 		log.Error("Failed to fetch last header from parent chain", "err", err)
@@ -38,10 +38,10 @@ func (b *BatchPoster) fetchHotshotBlockFromLastCheckpoint(ctx context.Context) u
 	var lastHotshotHeight uint64 = 0
 	// Prevent unsigned integer underflow: in Go, subtracting a larger value
 	// from a smaller uint64 will wrap around to a very large number.
-	for i := header.Number.Uint64(); i >= b.config().HotShotFirstPostingBlock; i -= min(i, pollingStep) {
+	for i := header.Number.Uint64(); i >= b.espressoConfig.BatchPoster.HotShotFirstPostingBlock; i -= min(i, pollingStep) {
 		start := i - min(i, pollingStep)
-		if start < b.config().HotShotFirstPostingBlock {
-			start = b.config().HotShotFirstPostingBlock
+		if start < b.espressoConfig.BatchPoster.HotShotFirstPostingBlock {
+			start = b.espressoConfig.BatchPoster.HotShotFirstPostingBlock
 		}
 		filterOpts := bind.FilterOpts{
 			Start:   start,

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -44,29 +44,26 @@ type EspressoCaffNodeInitArgs struct {
 }
 
 type EspressoCaffNodeConfig struct {
-	Enable                        bool                                      `koanf:"enable"`
-	HotShotUrl                    string                                    `koanf:"hotshot-url"`
-	NextHotshotBlock              uint64                                    `koanf:"next-hotshot-block"`
-	FromBlock                     uint64                                    `koanf:"from-block"`
-	Namespace                     uint64                                    `koanf:"namespace"`
-	RetryTime                     time.Duration                             `koanf:"retry-time"`
-	HotshotPollingInterval        time.Duration                             `koanf:"hotshot-polling-interval"`
-	HotshotPollingTimeout         time.Duration                             `koanf:"hotshot-polling-timeout"`
-	EspressoSGXVerifierAddr       string                                    `koanf:"espresso-sgx-verifier-addr"`
-	BatchPosterAddr               string                                    `koanf:"batch-poster-addr"`
-	RecordPerformance             bool                                      `koanf:"record-performance"`
-	WaitForFinalization           bool                                      `koanf:"wait-for-finalization"`
-	WaitForConfirmations          bool                                      `koanf:"wait-for-confirmations"`
-	RequiredBlockDepth            uint64                                    `koanf:"required-block-depth"`
-	BlocksToRead                  uint64                                    `koanf:"blocks-to-read"`
-	Dangerous                     DangerousCaffNodeConfig                   `koanf:"dangerous"`
-	EspressoRegisterServiceConfig espressotee.EspressoRegisterServiceConfig `koanf:"espresso-register-service-config"`
-	EspressoTeeType               string                                    `koanf:"espresso-tee-type"`
+	Enable                 bool                                      `koanf:"enable"`
+	HotShotUrl             string                                    `koanf:"hotshot-url"`
+	Namespace              uint64                                    `koanf:"namespace"`
+	HotshotPollingInterval time.Duration                             `koanf:"hotshot-polling-interval"`
+	HotshotPollingTimeout  time.Duration                             `koanf:"hotshot-polling-timeout"`
+	SGXVerifierAddr        string                                    `koanf:"sgx-verifier-addr"`
+	BatchPosterAddr        string                                    `koanf:"batch-poster-addr"`
+	RecordPerformance      bool                                      `koanf:"record-performance"`
+	WaitForFinalization    bool                                      `koanf:"wait-for-finalization"`
+	WaitForConfirmations   bool                                      `koanf:"wait-for-confirmations"`
+	RequiredBlockDepth     uint64                                    `koanf:"required-block-depth"`
+	BlocksToRead           uint64                                    `koanf:"blocks-to-read"`
+	Dangerous              DangerousCaffNodeConfig                   `koanf:"dangerous"`
+	RegisterServiceConfig  espressotee.EspressoRegisterServiceConfig `koanf:"register-service-config"`
+	TeeType                string                                    `koanf:"tee-type"`
 
 	// SGX specific config, leave empty if not using SGX
 	UserDataAttestationFile string `koanf:"user-data-attestation-file"`
 	QuoteFile               string `koanf:"quote-file"`
-	EspressoTEEVerifierAddr string `koanf:"espresso-tee-verifier-addr"`
+	TEEVerifierAddr         string `koanf:"tee-verifier-addr"`
 
 	// AWS Nitro Attestation Service URL
 	AttestationServiceURL string `koanf:"attestation-service-url"`
@@ -81,7 +78,6 @@ type EspressoCaffNodeConfig struct {
 
 	KeyPairAttestationsPath string `koanf:"key-pair-attestations-path"`
 	SnapshotChecksum        string `koanf:"snapshot-checksum"`
-	AddressMonitorStep      uint64 `koanf:"address-monitor-step"`
 	GenerateSnapshot        bool   `koanf:"generate-snapshot"`
 	AuthDBBatchSize         int    `koanf:"auth-db-batch-size"`
 }
@@ -94,77 +90,70 @@ func (c *EspressoCaffNodeConfig) ResolveDirectoryNames(chain string) {
 }
 
 type DangerousCaffNodeConfig struct {
-	IgnoreDatabaseHotshotBlock bool   `koanf:"ignore-database-hotshot-block"`
-	IgnoreDatabaseFromBlock    bool   `koanf:"ignore-database-from-block"`
-	MinimumHotshotBlockNum     uint64 `koanf:"minimum-hotshot-block-num"`
+	IgnoreDatabaseHotshotBlock bool `koanf:"ignore-database-hotshot-block"`
+	IgnoreDatabaseFromBlock    bool `koanf:"ignore-database-from-block"`
 }
 
 var DefaultDangerousCaffNodeConfig = DangerousCaffNodeConfig{
 	IgnoreDatabaseHotshotBlock: false,
 	IgnoreDatabaseFromBlock:    false,
-	MinimumHotshotBlockNum:     0,
 }
 
 var DefaultEspressoCaffNodeConfig = EspressoCaffNodeConfig{
-	Enable:                  false,
-	HotShotUrl:              "",
-	NextHotshotBlock:        1,
-	Namespace:               0,
-	RetryTime:               time.Second * 2,
-	HotshotPollingInterval:  time.Millisecond * 100,
-	HotshotPollingTimeout:   time.Minute * 2,
-	EspressoSGXVerifierAddr: "",
-	BatchPosterAddr:         "",
-	RecordPerformance:       false,
+	Enable:                 false,
+	HotShotUrl:             "",
+	Namespace:              0,
+	HotshotPollingInterval: time.Millisecond * 100,
+	HotshotPollingTimeout:  time.Minute * 2,
+	SGXVerifierAddr:        "",
+	BatchPosterAddr:        "",
+	RecordPerformance:      false,
 	// Setting these values to the default
 	// values set by Arbitrum
-	WaitForFinalization:           false,
-	WaitForConfirmations:          true,
-	RequiredBlockDepth:            20,
-	BlocksToRead:                  10000,
-	Dangerous:                     DefaultDangerousCaffNodeConfig,
-	FromBlock:                     1,
-	KeyPairAttestationsPath:       "caff_node_key_pair_attestations",
-	EspressoTeeType:               "",
-	EspressoRegisterServiceConfig: espressotee.DefaultEspressoRegisterServiceConfig,
-	UserDataAttestationFile:       "",
-	QuoteFile:                     "",
-	AttestationServiceURL:         "",
-	EspressoTEEVerifierAddr:       "",
-	DataPoster:                    dataposter.DefaultDataPosterConfig,
-	SnapshotChecksum:              "",
-	ParentChainWallet:             DefaultBatchPosterL1WalletConfig,
-	AddressMonitorStep:            100,
-	GenerateSnapshot:              false,
-	AuthDBBatchSize:               10000,
+	WaitForFinalization:     false,
+	WaitForConfirmations:    true,
+	RequiredBlockDepth:      20,
+	BlocksToRead:            10000,
+	Dangerous:               DefaultDangerousCaffNodeConfig,
+	KeyPairAttestationsPath: "caff_node_key_pair_attestations",
+	TeeType:                 "",
+	RegisterServiceConfig:   espressotee.DefaultEspressoRegisterServiceConfig,
+	UserDataAttestationFile: "",
+	QuoteFile:               "",
+	AttestationServiceURL:   "",
+	TEEVerifierAddr:         "",
+	DataPoster:              dataposter.DefaultDataPosterConfig,
+	SnapshotChecksum:        "",
+	ParentChainWallet:       DefaultBatchPosterL1WalletConfig,
+	GenerateSnapshot:        false,
+	AuthDBBatchSize:         10000,
+	StateChecker:            DefaultStateCheckerConfig,
+	ForceInclusionChecker:   DefaultEspressoForceInclusionCheckerConfig,
 }
 
 func EspressoCaffNodeConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".enable", DefaultEspressoCaffNodeConfig.Enable, "enable espresso Caff node")
 	f.String(prefix+".hotshot-url", DefaultEspressoCaffNodeConfig.HotShotUrl, "Hotshot url")
-	f.Uint64(prefix+".next-hotshot-block", DefaultEspressoCaffNodeConfig.NextHotshotBlock, "the Hotshot block number from which the Caff node will read")
 	f.Uint64(prefix+".namespace", DefaultEspressoCaffNodeConfig.Namespace, "the namespace of the chain in Espresso Network, usually the chain id")
-	f.Duration(prefix+".retry-time", DefaultEspressoCaffNodeConfig.RetryTime, "retry time after a failure")
 	f.Duration(prefix+".hotshot-polling-interval", DefaultEspressoCaffNodeConfig.HotshotPollingInterval, "time after a success")
 	f.Duration(prefix+".hotshot-polling-timeout", DefaultEspressoCaffNodeConfig.HotshotPollingTimeout, "timeout for hotshot polling")
-	f.String(prefix+".espresso-sgx-verifier-addr", DefaultEspressoCaffNodeConfig.EspressoSGXVerifierAddr, "espresso legacy SGX verifier address that is used to verify the signature of the Hotshot transactions")
+	f.String(prefix+".sgx-verifier-addr", DefaultEspressoCaffNodeConfig.SGXVerifierAddr, "espresso legacy SGX verifier address that is used to verify the signature of the Hotshot transactions")
 	f.String(prefix+".batch-poster-addr", DefaultEspressoCaffNodeConfig.BatchPosterAddr, "batch poster address that is used to verify the signature of the Hotshot transactions")
 	f.Bool(prefix+".record-performance", DefaultEspressoCaffNodeConfig.RecordPerformance, "record performance of the Caff node")
 	f.Bool(prefix+".wait-for-finalization", DefaultEspressoCaffNodeConfig.WaitForFinalization, "Configures the Caff node to only produce blocks from delayed messages if they are finalized on the parent chain")
 	f.Bool(prefix+".wait-for-confirmations", DefaultEspressoCaffNodeConfig.WaitForConfirmations, "Configures the Caff node to only produce blocks from delayed messages if they have atleast requiredBlockDepth confirmations on the parent chain")
 	f.Uint64(prefix+".required-block-depth", DefaultEspressoCaffNodeConfig.RequiredBlockDepth, "Configures the required block depth/number of confirmations on the parent chain that a delayed message is required to have before this Caff node will add it to it's state")
 	f.Uint64(prefix+".blocks-to-read", DefaultEspressoCaffNodeConfig.BlocksToRead, "Configures the number of blocks to read from the parent chain for delayed messages")
-	f.Uint64(prefix+".from-block", DefaultEspressoCaffNodeConfig.FromBlock, "Configures the block number to start reading delayed messages from")
 	f.String(prefix+".key-pair-attestations-path", DefaultEspressoCaffNodeConfig.KeyPairAttestationsPath, "Path to attestation documents with KMSKeyID, EncryptedPrivateKey attestations")
 	f.String(prefix+".snapshot-checksum", DefaultEspressoCaffNodeConfig.SnapshotChecksum, "Configures the snapshot checksum")
-	f.String(prefix+".espresso-tee-type", DefaultEspressoCaffNodeConfig.EspressoTeeType, "The Trusted Execution Environment (TEE) that Caff node is running in")
+	f.String(prefix+".tee-type", DefaultEspressoCaffNodeConfig.TeeType, "The Trusted Execution Environment (TEE) that Caff node is running in")
 	f.String(prefix+".user-data-attestation-file", DefaultEspressoCaffNodeConfig.UserDataAttestationFile, "path to SGX user data attestation file")
 	f.String(prefix+".quote-file", DefaultEspressoCaffNodeConfig.QuoteFile, "path to SGX quote file")
-	f.String(prefix+".attestation-service-url", DefaultBatchPosterConfig.AttestationServiceURL, "URL of the attestation service to use for obtaining zk proof over  attestation")
+	f.String(prefix+".attestation-service-url", DefaultEspressoBatchPosterConfig.AttestationServiceURL, "URL of the attestation service to use for obtaining zk proof over  attestation")
 	genericconf.WalletConfigAddOptions(prefix+".parent-chain-wallet", f, DefaultBatchPosterConfig.ParentChainWallet.Pathname)
-	f.String(prefix+".espresso-tee-verifier-addr", DefaultEspressoCaffNodeConfig.EspressoTEEVerifierAddr, "Address of the EspressoTEEVerifier contract utilize for handling cross chain NFT verification")
+	f.String(prefix+".tee-verifier-addr", DefaultEspressoCaffNodeConfig.TEEVerifierAddr, "Address of the EspressoTEEVerifier contract utilize for handling cross chain NFT verification")
 	DangerousCaffNodeConfigAddOptions(prefix+".dangerous", f)
-	espressotee.AddEspressoRegisterServiceConfigOptions(prefix+".espresso-register-service-config", f)
+	espressotee.AddEspressoRegisterServiceConfigOptions(prefix+".register-service-config", f)
 	f.Bool(prefix+".generate-snapshot", DefaultEspressoCaffNodeConfig.GenerateSnapshot, "Configures whether to generate a snapshot")
 	f.Int(prefix+".auth-db-batch-size", DefaultEspressoCaffNodeConfig.AuthDBBatchSize, "Batch size to use when initializing auth tags in the AuthDB")
 	dataposter.DataPosterConfigAddOptions(prefix+".data-poster", f, dataposter.DefaultDataPosterConfig)
@@ -202,6 +191,8 @@ type EspressoCaffNode struct {
 	keyManager         *espresso_key_manager.EspressoKeyManager
 	dataPoster         *dataposter.DataPoster
 	caffNodePrivateKey *ecdsa.PrivateKey
+
+	streamerConfigFetcher EspressoStreamerConfigFetcher
 }
 
 func NewEspressoCaffNode(
@@ -218,6 +209,7 @@ func NewEspressoCaffNode(
 	stack *node.Node,
 	dataPosterDB ethdb.Database,
 	caffNodeInitArgs *EspressoCaffNodeInitArgs,
+	streamerConfigFetcher EspressoStreamerConfigFetcher,
 ) (*EspressoCaffNode, error) {
 	if !configFetcher().Enable {
 		return nil, nil
@@ -226,13 +218,13 @@ func NewEspressoCaffNode(
 	if l1Reader == nil {
 		return nil, fmt.Errorf("l1 reader is nil")
 	}
-	teeType, err := espressotee.FromString(configFetcher().EspressoTeeType)
+	teeType, err := espressotee.FromString(configFetcher().TeeType)
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing TEE type, %w", err)
 	}
 
 	var db authdb.AuthDB
-	if configFetcher().EspressoTeeType != "" {
+	if configFetcher().TeeType != "" {
 		log.Info("initialiing auth db with", "i", caffNodeInitArgs.InitializeCaffNodeTags)
 		// if we need to initialize caff node tags, then we will disable auth reads
 		db, err = authdb.NewAuthDB(chainDb, caffNodeInitArgs.TeeHMAC, caffNodeInitArgs.InitializeCaffNodeTags)
@@ -249,14 +241,14 @@ func NewEspressoCaffNode(
 	// hotshot transactions using SGX quote. Therefore we create a SGX TEE verifier here.
 	sgxVerifier, err := espressotee.NewEspressoSGXVerifier(
 		l1Reader.Client(),
-		common.HexToAddress(configFetcher().EspressoSGXVerifierAddr),
+		common.HexToAddress(configFetcher().SGXVerifierAddr),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create espressoTEEVerifier: %w", err)
 	}
 	client := espressoClient.NewClient(configFetcher().HotShotUrl)
 
-	fromBlock := configFetcher().FromBlock
+	fromBlock := streamerConfigFetcher().AddressMonitorStartL1
 
 	if !configFetcher().Dangerous.IgnoreDatabaseFromBlock {
 		fromBlock, err = authdb.ReadFromBlock(&db)
@@ -265,7 +257,7 @@ func NewEspressoCaffNode(
 		}
 	}
 	if fromBlock == 0 {
-		fromBlock = configFetcher().FromBlock
+		fromBlock = streamerConfigFetcher().AddressMonitorStartL1
 		if fromBlock == 0 {
 			return nil, fmt.Errorf("fromBlock is 0, please provide a valid block number")
 		}
@@ -278,16 +270,16 @@ func NewEspressoCaffNode(
 		sequencerInbox.address,
 		delayedBridge.fromBlock,
 		fromBlock,
-		configFetcher().AddressMonitorStep,
+		streamerConfigFetcher().AddressMonitorStep,
 	)
 	espressoStreamer := espressostreamer.NewEspressoStreamer(configFetcher().Namespace,
-		configFetcher().NextHotshotBlock,
+		streamerConfigFetcher().HotShotBlock,
 		sgxVerifier,
 		client,
 		recordPerformance,
 		batcherAddrMonitor.GetValidAddresses,
-		configFetcher().RetryTime,
-		configFetcher().Dangerous.MinimumHotshotBlockNum,
+		streamerConfigFetcher().TxnsPollingInterval,
+		streamerConfigFetcher().Dangerous.MinimumHotshotBlockNum,
 	)
 
 	delayedMessageFetcher := NewDelayedMessageFetcher(delayedBridge, l1Reader, blocksToRead,
@@ -314,7 +306,7 @@ func NewEspressoCaffNode(
 
 	// Create a new EspressoKeyManager
 	// Get the EspressoTEEVerifier address from SequencerInbox contract
-	configAddress := configFetcher().EspressoTEEVerifierAddr
+	configAddress := configFetcher().TEEVerifierAddr
 	var espressoTEEVerifierAddress common.Address
 	// parse the espresso tee verifier address from config if it exists, otherwise read from the sequencerInbox
 	// Eventually we should only read from the SequencerInbox
@@ -375,7 +367,7 @@ func NewEspressoCaffNode(
 			return nil, fmt.Errorf("failed to create data poster: %w", err)
 		}
 
-		keyManager = espresso_key_manager.NewEspressoKeyManager(verifier, nitroVerifier, dataPoster, nil, teeType, espressotee.CaffNode, configFetcher().EspressoRegisterServiceConfig, caffNodeInitArgs.CaffNodePrivateKey, configFetcher().UserDataAttestationFile, configFetcher().QuoteFile, configFetcher().AttestationServiceURL)
+		keyManager = espresso_key_manager.NewEspressoKeyManager(verifier, nitroVerifier, dataPoster, nil, teeType, espressotee.CaffNode, configFetcher().RegisterServiceConfig, caffNodeInitArgs.CaffNodePrivateKey, configFetcher().UserDataAttestationFile, configFetcher().QuoteFile, configFetcher().AttestationServiceURL)
 
 	}
 
@@ -395,6 +387,7 @@ func NewEspressoCaffNode(
 		keyManager:            keyManager,
 		dataPoster:            dataPoster,
 		caffNodePrivateKey:    caffNodeInitArgs.CaffNodePrivateKey,
+		streamerConfigFetcher: streamerConfigFetcher,
 	}, nil
 }
 
@@ -527,7 +520,7 @@ func (n *EspressoCaffNode) GetEspressoStreamer() espressostreamer.EspressoStream
 func (n *EspressoCaffNode) Start(ctx context.Context) error {
 	n.StopWaiter.Start(ctx, n)
 
-	if n.configFetcher().EspressoTeeType == "" && n.configFetcher().SnapshotChecksum != "" {
+	if n.configFetcher().TeeType == "" && n.configFetcher().SnapshotChecksum != "" {
 		return fmt.Errorf("espresso tee type is required when trying to verify a snapshot checksum")
 	}
 
@@ -587,7 +580,7 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 	}
 	if nextHotshotBlock == 0 {
 		// No next hotshot block found, so we need to start from config.CaffNodeConfig.NextHotshotBlock
-		nextHotshotBlock = n.configFetcher().NextHotshotBlock
+		nextHotshotBlock = n.streamerConfigFetcher().HotShotBlock
 		if nextHotshotBlock == 0 {
 			return errors.New("no next hotshot block found in database or dangerous.ignore-database-hotshot-block is set to true, please set config.CaffNodeConfig.NextHotshotBlock")
 		}
@@ -622,7 +615,7 @@ func (n *EspressoCaffNode) Start(ctx context.Context) error {
 		if madeBlock {
 			return n.configFetcher().HotshotPollingInterval
 		}
-		return n.configFetcher().RetryTime
+		return n.streamerConfigFetcher().TxnsPollingInterval
 	})
 	if err != nil {
 		return fmt.Errorf("failed to start node, error in createBlock: %w", err)

--- a/arbnode/espresso_transaction_streamer_helpers.go
+++ b/arbnode/espresso_transaction_streamer_helpers.go
@@ -15,6 +15,7 @@ import (
 
 	key_manager "github.com/offchainlabs/nitro/espresso/key-manager"
 	"github.com/offchainlabs/nitro/espresso/submitter"
+	"github.com/offchainlabs/nitro/espressostreamer"
 )
 
 // TransactionStreamerEspressoConfig is a configuration struct for the
@@ -218,13 +219,12 @@ func ConfigureEspressoFields(
 ) (submitter.EspressoSubmitter, error) {
 	config := TransactionStreamerEspressoConfig{
 		InitialFinalizedSequencerMessageCount: big.NewInt(0),
-		TxnsPollingInterval:                   DefaultBatchPosterConfig.EspressoTxnsPollingInterval,
-		TxnsSendingInterval:                   DefaultBatchPosterConfig.EspressoTxnsSendingInterval,
-		TxnsResubmissionInterval:              DefaultBatchPosterConfig.EspressoTxnsResubmissionInterval,
-		MaxTransactionSize:                    DefaultBatchPosterConfig.EspressoTxSizeLimit,
-		ResubmitEspressoTxDeadline:            DefaultBatchPosterConfig.ResubmitEspressoTxDeadline,
-
-		SubmitterCreator: submitter.NewPollingEspressoSubmitter,
+		TxnsPollingInterval:                   espressostreamer.DefaultEspressoStreamerConfig.TxnsPollingInterval,
+		TxnsSendingInterval:                   DefaultEspressoBatchPosterConfig.TxnsSendingInterval,
+		TxnsResubmissionInterval:              DefaultEspressoBatchPosterConfig.TxnsResubmissionInterval,
+		MaxTransactionSize:                    DefaultEspressoBatchPosterConfig.TxSizeLimit,
+		ResubmitEspressoTxDeadline:            DefaultEspressoBatchPosterConfig.ResubmitEspressoTxDeadline,
+		SubmitterCreator:                      submitter.NewPollingEspressoSubmitter,
 	}
 
 	applyEspressoOptions(&config, options...)

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -36,12 +36,14 @@ import (
 	"github.com/offchainlabs/nitro/broadcaster"
 	"github.com/offchainlabs/nitro/cmd/chaininfo"
 	"github.com/offchainlabs/nitro/das"
+	"github.com/offchainlabs/nitro/espressostreamer"
 	"github.com/offchainlabs/nitro/execution"
 	"github.com/offchainlabs/nitro/execution/gethexec"
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
 	"github.com/offchainlabs/nitro/solgen/go/precompilesgen"
 	"github.com/offchainlabs/nitro/solgen/go/rollupgen"
 	"github.com/offchainlabs/nitro/staker"
+	"github.com/offchainlabs/nitro/staker/bold"
 	boldstaker "github.com/offchainlabs/nitro/staker/bold"
 	legacystaker "github.com/offchainlabs/nitro/staker/legacy"
 	multiprotocolstaker "github.com/offchainlabs/nitro/staker/multi_protocol"
@@ -82,6 +84,12 @@ func GenerateRollupConfig(prod bool, wasmModuleRoot common.Hash, rollupOwner com
 	}
 }
 
+type EspressoConfig struct {
+	CaffNode    EspressoCaffNodeConfig                  `koanf:"caff-node"`
+	BatchPoster EspressoBatchPosterConfig               `koanf:"batch-poster"`
+	Streamer    espressostreamer.EspressoStreamerConfig `koanf:"streamer"`
+}
+
 type Config struct {
 	Sequencer            bool                           `koanf:"sequencer"`
 	ParentChainReader    headerreader.Config            `koanf:"parent-chain-reader" reload:"hot"`
@@ -104,7 +112,7 @@ type Config struct {
 	// SnapSyncConfig is only used for testing purposes, these should not be configured in production.
 	SnapSyncTest SnapSyncConfig
 
-	EspressoCaffNode EspressoCaffNodeConfig `koanf:"espresso-caff-node"`
+	Espresso EspressoConfig `koanf:"espresso" reload:"hot"`
 }
 
 func (c *Config) Validate() error {
@@ -121,7 +129,7 @@ func (c *Config) Validate() error {
 		c.Feed.Output.Enable = false
 		c.Feed.Input.URL = []string{}
 	}
-	if c.EspressoCaffNode.Enable && (c.Sequencer || c.DelayedSequencer.Enable || c.SeqCoordinator.Enable) {
+	if c.Espresso.CaffNode.Enable && (c.Sequencer || c.DelayedSequencer.Enable || c.SeqCoordinator.Enable) {
 		return errors.New("cannot start a Caff node with any sequencer enabled")
 	}
 	if err := c.BlockValidator.Validate(); err != nil {
@@ -176,30 +184,39 @@ func ConfigAddOptions(prefix string, f *flag.FlagSet, feedInputEnable bool, feed
 	TransactionStreamerConfigAddOptions(prefix+".transaction-streamer", f)
 	MaintenanceConfigAddOptions(prefix+".maintenance", f)
 	BlockMetadataFetcherConfigAddOptions(prefix+".block-metadata-fetcher", f)
-	EspressoCaffNodeConfigAddOptions(prefix+".espresso-caff-node", f)
+	EspressoCaffNodeConfigAddOptions(prefix+".espresso.espresso-caff-node", f)
+	EspressoBatchPosterConfigAddOptions(prefix+".espresso.espresso-batch-poster", f)
+	espressostreamer.EspressoStreamerConfigAddOptions(prefix+".espresso.espresso-streamer", f)
+}
+
+var EspressoConfigDefault = EspressoConfig{
+	CaffNode:    DefaultEspressoCaffNodeConfig,
+	BatchPoster: DefaultEspressoBatchPosterConfig,
+	Streamer:    espressostreamer.DefaultEspressoStreamerConfig,
 }
 
 var ConfigDefault = Config{
-	Sequencer:            false,
-	ParentChainReader:    headerreader.DefaultConfig,
-	InboxReader:          DefaultInboxReaderConfig,
-	DelayedSequencer:     DefaultDelayedSequencerConfig,
-	BatchPoster:          DefaultBatchPosterConfig,
-	MessagePruner:        DefaultMessagePrunerConfig,
-	BlockValidator:       staker.DefaultBlockValidatorConfig,
-	Feed:                 broadcastclient.FeedConfigDefault,
-	Staker:               legacystaker.DefaultL1ValidatorConfig,
-	Bold:                 boldstaker.DefaultBoldConfig,
-	SeqCoordinator:       DefaultSeqCoordinatorConfig,
-	DataAvailability:     das.DefaultDataAvailabilityConfig,
-	SyncMonitor:          DefaultSyncMonitorConfig,
-	Dangerous:            DefaultDangerousConfig,
-	TransactionStreamer:  DefaultTransactionStreamerConfig,
-	ResourceMgmt:         resourcemanager.DefaultConfig,
-	Maintenance:          DefaultMaintenanceConfig,
-	BlockMetadataFetcher: DefaultBlockMetadataFetcherConfig,
-	SnapSyncTest:         DefaultSnapSyncConfig,
-	EspressoCaffNode:     DefaultEspressoCaffNodeConfig,
+	Sequencer:                false,
+	ParentChainReader:        headerreader.DefaultConfig,
+	InboxReader:              DefaultInboxReaderConfig,
+	DelayedSequencer:         DefaultDelayedSequencerConfig,
+	BatchPoster:              DefaultBatchPosterConfig,
+	MessagePruner:            DefaultMessagePrunerConfig,
+	BlockValidator:           staker.DefaultBlockValidatorConfig,
+	Feed:                     broadcastclient.FeedConfigDefault,
+	Staker:                   legacystaker.DefaultL1ValidatorConfig,
+	Bold:                     bold.DefaultBoldConfig,
+	SeqCoordinator:           DefaultSeqCoordinatorConfig,
+	DataAvailability:         das.DefaultDataAvailabilityConfig,
+	SyncMonitor:              DefaultSyncMonitorConfig,
+	Dangerous:                DefaultDangerousConfig,
+	TransactionStreamer:      DefaultTransactionStreamerConfig,
+	ResourceMgmt:             resourcemanager.DefaultConfig,
+	BlockMetadataFetcher:     DefaultBlockMetadataFetcherConfig,
+	Maintenance:              DefaultMaintenanceConfig,
+	SnapSyncTest:             DefaultSnapSyncConfig,
+
+	Espresso: EspressoConfigDefault,
 }
 
 func ConfigDefaultL1Test() *Config {
@@ -584,17 +601,17 @@ func createNodeImpl(
 		return nil, err
 	}
 
-	if config.EspressoCaffNode.Enable {
+	if config.Espresso.CaffNode.Enable {
 		if exec, ok := exec.(*gethexec.ExecutionNode); ok {
 			espressoCaffNode, err := NewEspressoCaffNode(
 				ctx,
-				func() *EspressoCaffNodeConfig { return &config.EspressoCaffNode },
+				func() *EspressoCaffNodeConfig { return &config.Espresso.CaffNode },
 				exec.ChainDB,
 				exec.ExecEngine,
 				delayedBridge,
 				l1Reader,
-				config.EspressoCaffNode.RecordPerformance,
-				config.EspressoCaffNode.BlocksToRead,
+				config.Espresso.CaffNode.RecordPerformance,
+				config.Espresso.CaffNode.BlocksToRead,
 				sequencerInbox,
 				fatalErrChan,
 				stack,
@@ -839,6 +856,10 @@ func createNodeImpl(
 			DAPReaders:    dapReaders,
 
 			DataSigner: dataSigner,
+
+			EspressoConfigFetcher: func() *EspressoConfig {
+				return &configFetcher.Get().Espresso
+			},
 		})
 		if err != nil {
 			return nil, err

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -274,18 +274,18 @@ func mainImpl() int {
 	defaultBatchPosterL1WalletConfig := arbnode.DefaultBatchPosterL1WalletConfig
 	defaultBatchPosterL1WalletConfig.ResolveDirectoryNames(nodeConfig.Persistent.Chain)
 
-	nodeConfig.Node.EspressoCaffNode.ResolveDirectoryNames(nodeConfig.Persistent.Chain)
+	nodeConfig.Node.Espresso.CaffNode.ResolveDirectoryNames(nodeConfig.Persistent.Chain)
 
 	var espressoCaffNodeInitArgs *arbnode.EspressoCaffNodeInitArgs
 
-	if nodeConfig.Node.EspressoCaffNode.Enable && nodeConfig.Node.EspressoCaffNode.EspressoTeeType != "" {
-		caffNodePrivateKey, err := espresso_tee_utils.ReadEnclavePrivateKey(nodeConfig.Node.EspressoCaffNode.KeyPairAttestationsPath, nodeConfig.Chain.ID)
+	if nodeConfig.Node.Espresso.CaffNode.Enable && nodeConfig.Node.Espresso.CaffNode.TeeType != "" {
+		caffNodePrivateKey, err := espresso_tee_utils.ReadEnclavePrivateKey(nodeConfig.Node.Espresso.CaffNode.KeyPairAttestationsPath, nodeConfig.Chain.ID)
 		if err != nil {
 			flag.Usage()
-			log.Crit("error reading enclave private key for Espresso Caff node", "path", nodeConfig.Node.EspressoCaffNode.KeyPairAttestationsPath, "err", err)
+			log.Crit("error reading enclave private key for Espresso Caff node", "path", nodeConfig.Node.Espresso.CaffNode.KeyPairAttestationsPath, "err", err)
 		}
 
-		teeHMAC, err = espresso_tee_utils.DeriveHmac(nodeConfig.Node.EspressoCaffNode.KeyPairAttestationsPath, nodeConfig.Chain.ID)
+		teeHMAC, err = espresso_tee_utils.DeriveHmac(nodeConfig.Node.Espresso.CaffNode.KeyPairAttestationsPath, nodeConfig.Chain.ID)
 		if err != nil {
 			flag.Usage()
 			log.Crit("error generating HMAC key for Espresso Caff node", "err", err)
@@ -498,14 +498,14 @@ func mainImpl() int {
 
 	var initializeCaffNodeTags bool
 	// If snapshot mode is enabled, verify the extracted snapshot hash matches the config
-	if nodeConfig.Node.EspressoCaffNode.Enable && nodeConfig.Node.EspressoCaffNode.SnapshotChecksum != "" {
+	if nodeConfig.Node.Espresso.CaffNode.Enable && nodeConfig.Node.Espresso.CaffNode.SnapshotChecksum != "" {
 		// Check that TEE is enabled
-		if nodeConfig.Node.EspressoCaffNode.EspressoTeeType == "" {
+		if nodeConfig.Node.Espresso.CaffNode.TeeType == "" {
 			log.Error("snapshot verification requires TEE, but no TEE type was specified")
 			return 1
 		}
-		log.Info("Verifying the snapshot", "snapshot checksum", nodeConfig.Node.EspressoCaffNode.SnapshotChecksum)
-		initializeCaffNodeTags, err = arbutil.VerifySnapshot(nodeConfig.Node.EspressoCaffNode.SnapshotChecksum, stack.InstanceDir(), stack.ResolvePath("l2chaindata"), stack.ResolveAncient("l2chaindata", nodeConfig.Persistent.Ancient), espressoCaffNodeInitArgs.CaffNodePrivateKey)
+		log.Info("Verifying the snapshot", "snapshot checksum", nodeConfig.Node.Espresso.CaffNode.SnapshotChecksum)
+		initializeCaffNodeTags, err = arbutil.VerifySnapshot(nodeConfig.Node.Espresso.CaffNode.SnapshotChecksum, stack.InstanceDir(), stack.ResolvePath("l2chaindata"), stack.ResolveAncient("l2chaindata", nodeConfig.Persistent.Ancient), espressoCaffNodeInitArgs.CaffNodePrivateKey)
 		if err != nil {
 			log.Error("failed to verify snapshot", "err", err)
 			return 1

--- a/espressostreamer/espresso_streamer.go
+++ b/espressostreamer/espresso_streamer.go
@@ -12,6 +12,7 @@ import (
 	espressoClient "github.com/EspressoSystems/espresso-network/sdks/go/client"
 	espressoTypes "github.com/EspressoSystems/espresso-network/sdks/go/types"
 	"github.com/ccoveille/go-safecast"
+	"github.com/spf13/pflag"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -57,6 +58,41 @@ type MessageWithMetadataAndPos struct {
 	MessageWithMeta arbostypes.MessageWithMetadata
 	Pos             uint64
 	HotshotHeight   uint64
+}
+
+type DangerousEspressoStreamerConfig struct {
+	MinimumHotshotBlockNum uint64 `koanf:"minimum-hotshot-block-num"`
+}
+
+var DefaultDangerousEspressoStreamerConfig = DangerousEspressoStreamerConfig{
+	MinimumHotshotBlockNum: 0,
+}
+
+type EspressoStreamerConfig struct {
+	HotShotBlock          uint64                          `koanf:"hotshot-block"`
+	TxnsPollingInterval   time.Duration                   `koanf:"txns-polling-interval"`
+	AddressMonitorStartL1 uint64                          `koanf:"address-monitor-start-l1"`
+	AddressMonitorStep    uint64                          `koanf:"address-monitor-step"`
+	Dangerous             DangerousEspressoStreamerConfig `koanf:"dangerous"`
+}
+
+var DefaultEspressoStreamerConfig = EspressoStreamerConfig{
+	HotShotBlock: 1,
+	// By default, no minimum hotshot block number is enforced
+	Dangerous: DefaultDangerousEspressoStreamerConfig,
+	// Hotshot currently produces blocks at average of 2 seconds
+	// We set it to 1 second to get updates more often than blocks are produced
+	TxnsPollingInterval:   time.Second,
+	AddressMonitorStartL1: 1,
+	AddressMonitorStep:    100,
+}
+
+func EspressoStreamerConfigAddOptions(prefix string, f *pflag.FlagSet) {
+	f.Uint64(prefix+".hotshot-block", DefaultEspressoStreamerConfig.HotShotBlock, "specifies the hotshot block number to start the espresso streamer on")
+	f.Uint64(prefix+".minimum-hotshot-block-num", DefaultEspressoStreamerConfig.Dangerous.MinimumHotshotBlockNum, "minimum hotshot block number")
+	f.Uint64(prefix+".address-monitor-step", DefaultEspressoStreamerConfig.AddressMonitorStep, "specifies the number of blocks at a time to query when searching for logs emitted for updating valid batcher addresses.")
+	f.Uint64(prefix+".address-monitor-start-l1", DefaultEspressoStreamerConfig.AddressMonitorStartL1, "specifies the l1 block number when this rollup started posting to monitor addresses")
+	f.Duration(prefix+".txns-polling-interval", DefaultEspressoStreamerConfig.TxnsPollingInterval, "interval between polling for transactions to be included in the block")
 }
 
 type EspressoStreamer struct {

--- a/scripts/migrate-config-file.py
+++ b/scripts/migrate-config-file.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+import json
+import copy
+import sys
+from pathlib import Path
+    # old_key: (espresso_section, new_key)
+ESPRESSO_FIELD_MAP = {
+    "hotshot-block": ("streamer", "hotshot-block"),
+    "espresso-txns-polling-interval": ("streamer", "txns-polling-interval"),
+    "address-monitor-step": ("streamer", "address-monitor-step"),
+    "address-monitor-start-l1": ("streamer", "address-monitor-start-l1"),
+
+    # [espresso][batch-poster]
+    "espresso-tee-type": ("batch-poster", "tee-type"),
+    "espresso-register-service-config": ("batch-poster", "register-service-config"),
+    "hotshot-url": ("batch-poster", "hotshot-url"),
+    "espresso-txns-sending-interval": ("batch-poster", "txns-sending-interval"),
+    "espresso-txns-resubmission-interval": ("batch-poster", "txns-resubmission-interval"),
+    "resubmit-espresso-tx-deadline": ("batch-poster", "resubmit-espresso-tx-deadline"),
+    "espresso-tx-size-limit": ("batch-poster", "tx-size-limit"),
+    "user-data-attestation-file": ("batch-poster", "user-data-attestation-file"),
+    "quote-file": ("batch-poster", "quote-file"),
+    "attestation-service-url": ("batch-poster", "attestation-service-url"),
+    "espresso-event-polling-step": ("batch-poster", "event-polling-step"),
+    "hotshot-first-posting-block": ("batch-poster", "hotshot-first-posting-block"),
+    "init-batcher-addresses": ("batch-poster", "init-batcher-addresses"),
+    "address-valid-ranges": ("batch-poster", "address-valid-ranges"),
+
+    # "address-monitor-step": ("batch-poster", "address-monitor-step"),
+    # "address-monitor-start-l1": ("batch-poster", "address-monitor-start-l1"),
+}
+
+OLD_CAFF_NODE_KEY = "espresso-caff-node"
+NEW_CAFF_NODE_PATH = ("espresso", "caff-node")
+STREAMER_KEY = "streamer"
+DANGEROUS_KEY = "dangerous"
+MIN_BLOCK_KEY = "minimum-hotshot-block-num"
+TX_POLLING_INTERVAL_KEY = "txns-polling-interval"
+ADDRESS_MONITOR_STEP_KEY = "address-monitor-step"
+ADDRESS_MONITOR_START_L1_KEY = "address-monitor-start-l1"
+
+def migrate_config(cfg: dict) -> dict:
+    cfg = copy.deepcopy(cfg)
+
+    node = cfg.get("node")
+    if not node:
+        return cfg
+
+    espresso = cfg.setdefault("espresso", {})
+
+    # ---- Migrate batch-poster ----
+    batch_poster = node.get("batch-poster")
+    if not batch_poster:
+        return cfg
+
+
+    for old_key, (section, new_key) in ESPRESSO_FIELD_MAP.items():
+        if old_key in batch_poster:
+            section_cfg = espresso.setdefault(section, {})
+            section_cfg.setdefault(new_key, batch_poster[old_key])
+            batch_poster.pop(old_key, None)
+
+    if not batch_poster:
+        node.pop("batch-poster", None)
+
+
+    # ---- Migrate caff-node  ----
+    if OLD_CAFF_NODE_KEY in node:
+        old_caff_data = node.pop(OLD_CAFF_NODE_KEY)
+        
+        clean_caff = {}
+        for k, v in old_caff_data.items():
+            new_k = k.replace("espresso-", "") if k.startswith("espresso-") else k
+            clean_caff[new_k] = v
+            
+        espresso["caff-node"] = clean_caff
+    
+    caff = espresso.get("caff-node")
+    if not caff:
+        return
+
+    streamer = espresso.setdefault("streamer", {})
+
+    if ADDRESS_MONITOR_STEP_KEY in caff:
+        streamer.setdefault(
+            ADDRESS_MONITOR_STEP_KEY,
+            caff[ADDRESS_MONITOR_STEP_KEY],
+        )
+        caff.pop(ADDRESS_MONITOR_STEP_KEY, None)
+    
+    if ADDRESS_MONITOR_START_L1_KEY in caff:
+        streamer.setdefault(
+            ADDRESS_MONITOR_START_L1_KEY,
+            caff[ADDRESS_MONITOR_START_L1_KEY],
+        )
+        caff.pop(ADDRESS_MONITOR_START_L1_KEY, None)
+
+    dangerous = caff.get("dangerous")
+    if not dangerous:
+        return
+
+    if MIN_BLOCK_KEY not in dangerous:
+        return
+
+    #  ---- Migrate streamer  ----
+   
+    streamer_dangerous = streamer.setdefault("dangerous", {})
+
+    streamer_dangerous.setdefault(
+        MIN_BLOCK_KEY,
+        dangerous[MIN_BLOCK_KEY],
+    )
+
+    dangerous.pop(MIN_BLOCK_KEY, None)
+
+    if not dangerous:
+        caff.pop("dangerous", None)
+
+    if not node:
+        cfg.pop("node", None)
+
+    return cfg
+
+
+
+if len(sys.argv) < 3:
+    print("Usage: python3 migrate-config-file.py <old_config.json> <new_config.json>")
+    sys.exit(1)
+
+old_config = sys.argv[1]
+new_config = sys.argv[2]
+
+with open(old_config, 'r') as f:
+    cfg = json.load(f)
+
+new_cfg = migrate_config(cfg)
+
+with open(new_config, "w") as f:
+    json.dump(new_cfg, f, indent=2, sort_keys=True)
+
+print(f"Converted config written to {new_config}")

--- a/system_tests/batch_poster_test.go
+++ b/system_tests/batch_poster_test.go
@@ -136,6 +136,8 @@ func testBatchPosterParallel(t *testing.T, useRedis bool) {
 	for i := 0; i < parallelBatchPosters; i++ {
 		// Make a copy of the batch poster config so NewBatchPoster calling Validate() on it doesn't race
 		batchPosterConfig := builder.nodeConfig.BatchPoster
+		espressoConfig := builder.nodeConfig.Espresso
+
 		batchPoster, err := arbnode.NewBatchPoster(ctx,
 			&arbnode.BatchPosterOpts{
 				DataPosterDB:  nil,
@@ -149,6 +151,8 @@ func testBatchPosterParallel(t *testing.T, useRedis bool) {
 				TransactOpts:  &seqTxOpts,
 				DAPWriter:     nil,
 				ParentChainID: parentChainID,
+
+				EspressoConfigFetcher: func() *arbnode.EspressoConfig { return &espressoConfig },
 			},
 		)
 		Require(t, err)

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -52,29 +52,28 @@ func createCaffNode(
 	execConfig.Sequencer.Enable = false
 	execConfig.ForwardingTarget = existing.l2StackConfig.IPCPath
 	execConfig.SecondaryForwardingTarget = []string{}
-	nodeConfig.EspressoCaffNode.Enable = true
-	nodeConfig.EspressoCaffNode.Namespace = builder.chainConfig.ChainID.Uint64()
-	nodeConfig.EspressoCaffNode.NextHotshotBlock = 1
-	nodeConfig.EspressoCaffNode.EspressoSGXVerifierAddr = existing.L1Info.GetAddress("EspressoTEEVerifierMock").Hex()
+	nodeConfig.Espresso.CaffNode.Enable = true
+	nodeConfig.Espresso.CaffNode.Namespace = builder.chainConfig.ChainID.Uint64()
+	nodeConfig.Espresso.Streamer.HotShotBlock = 1
+	nodeConfig.Espresso.CaffNode.SGXVerifierAddr = existing.L1Info.GetAddress("EspressoTEEVerifierMock").Hex()
 
 	// reuse the caff node settings so we can set them outside this function.
-	nodeConfig.EspressoCaffNode.WaitForFinalization = existing.nodeConfig.EspressoCaffNode.WaitForFinalization
-	nodeConfig.EspressoCaffNode.WaitForConfirmations = existing.nodeConfig.EspressoCaffNode.WaitForConfirmations
-	nodeConfig.EspressoCaffNode.RequiredBlockDepth = existing.nodeConfig.EspressoCaffNode.RequiredBlockDepth
-	nodeConfig.EspressoCaffNode.BatchPosterAddr = "0xb386a74Dcab67b66F8AC07B4f08365d37495Dd23"
-	nodeConfig.EspressoCaffNode.FromBlock = 1
-	nodeConfig.EspressoCaffNode.EspressoTeeType = ""
-	nodeConfig.EspressoCaffNode.DataPoster = dataposter.DefaultDataPosterConfig
-	nodeConfig.EspressoCaffNode.EspressoRegisterServiceConfig = espressotee.DefaultEspressoRegisterServiceConfig
-	nodeConfig.EspressoCaffNode.EspressoRegisterServiceConfig.MaxRetries = 5
+	nodeConfig.Espresso.CaffNode.WaitForFinalization = existing.nodeConfig.Espresso.CaffNode.WaitForFinalization
+	nodeConfig.Espresso.CaffNode.WaitForConfirmations = existing.nodeConfig.Espresso.CaffNode.WaitForConfirmations
+	nodeConfig.Espresso.CaffNode.RequiredBlockDepth = existing.nodeConfig.Espresso.CaffNode.RequiredBlockDepth
+	nodeConfig.Espresso.CaffNode.BatchPosterAddr = "0xb386a74Dcab67b66F8AC07B4f08365d37495Dd23"
+	nodeConfig.Espresso.Streamer.AddressMonitorStartL1 = 1
+	nodeConfig.Espresso.CaffNode.TeeType = ""
+	nodeConfig.Espresso.CaffNode.DataPoster = dataposter.DefaultDataPosterConfig
+	nodeConfig.Espresso.CaffNode.RegisterServiceConfig = espressotee.DefaultEspressoRegisterServiceConfig
 
-	nodeConfig.EspressoCaffNode.StateChecker = arbnode.StateCheckerConfig{
+	nodeConfig.Espresso.CaffNode.StateChecker = arbnode.StateCheckerConfig{
 		PollingInterval:        time.Second * 100,
 		ErrorToleranceDuration: time.Hour * 1, // Set it to a larger value. That makes the state checker not shut down
 		TrustedNodeUrl:         fmt.Sprintf("http://bad-url:%d", 8945),
 	}
 
-	nodeConfig.EspressoCaffNode.ForceInclusionChecker = arbnode.ForceInclusionCheckerConfig{
+	nodeConfig.Espresso.CaffNode.ForceInclusionChecker = arbnode.ForceInclusionCheckerConfig{
 		RetryTime:                time.Second * 2,
 		PollingInterval:          time.Second * 100,
 		BlockThresholdTolerance:  20,
@@ -83,25 +82,25 @@ func createCaffNode(
 	}
 
 	// for testing, we can use the same hotshot url for both
-	nodeConfig.EspressoCaffNode.HotShotUrl = hotShotUrl
-	nodeConfig.EspressoCaffNode.RetryTime = time.Second * 1
-	nodeConfig.EspressoCaffNode.HotshotPollingInterval = time.Millisecond * 100
+	nodeConfig.Espresso.CaffNode.HotShotUrl = hotShotUrl
+	nodeConfig.Espresso.Streamer.TxnsPollingInterval = time.Second * 1
+	nodeConfig.Espresso.CaffNode.HotshotPollingInterval = time.Millisecond * 100
 	nodeConfig.ParentChainReader.Enable = true
-	nodeConfig.EspressoCaffNode.BlocksToRead = 10000
+	nodeConfig.Espresso.CaffNode.BlocksToRead = 10000
 
 	builder.l2StackConfig.HTTPPort = getRandomPort(t)
 	builder.l2StackConfig.HTTPHost = "0.0.0.0"
 	builder.useL2StackConfig = true
 
 	if dangerous {
-		nodeConfig.EspressoCaffNode.Dangerous.IgnoreDatabaseHotshotBlock = true
-		nodeConfig.EspressoCaffNode.NextHotshotBlock = 0
+		nodeConfig.Espresso.CaffNode.Dangerous.IgnoreDatabaseHotshotBlock = true
+		nodeConfig.Espresso.Streamer.HotShotBlock = 0
 	}
 
-	nodeConfig.EspressoCaffNode.EspressoTeeType = existing.nodeConfig.EspressoCaffNode.EspressoTeeType
-	nodeConfig.EspressoCaffNode.SnapshotChecksum = existing.nodeConfig.EspressoCaffNode.SnapshotChecksum
-	nodeConfig.EspressoCaffNode.GenerateSnapshot = existing.nodeConfig.EspressoCaffNode.GenerateSnapshot
-	nodeConfig.EspressoCaffNode.EspressoTEEVerifierAddr = existing.nodeConfig.EspressoCaffNode.EspressoTEEVerifierAddr
+	nodeConfig.Espresso.CaffNode.TeeType = existing.nodeConfig.Espresso.CaffNode.TeeType
+	nodeConfig.Espresso.CaffNode.SnapshotChecksum = existing.nodeConfig.Espresso.CaffNode.SnapshotChecksum
+	nodeConfig.Espresso.CaffNode.GenerateSnapshot = existing.nodeConfig.Espresso.CaffNode.GenerateSnapshot
+	nodeConfig.Espresso.CaffNode.TEEVerifierAddr = existing.nodeConfig.Espresso.CaffNode.TEEVerifierAddr
 
 	cleanup, err := builder.BuildEspressoCaffNode(t, existing)
 	builder.L1 = existing.L1
@@ -122,16 +121,16 @@ func createCaffNodeConfig(ctx context.Context, t *testing.T) *NodeBuilder {
 	nodeConfig.Dangerous.NoSequencerCoordinator = true
 	execConfig.Sequencer.Enable = false
 	execConfig.SecondaryForwardingTarget = []string{}
-	nodeConfig.EspressoCaffNode.Enable = true
-	nodeConfig.EspressoCaffNode.Namespace = builder.chainConfig.ChainID.Uint64()
-	nodeConfig.EspressoCaffNode.NextHotshotBlock = 1
-	nodeConfig.EspressoCaffNode.BatchPosterAddr = "0xb386a74Dcab67b66F8AC07B4f08365d37495Dd23"
+	nodeConfig.Espresso.CaffNode.Enable = true
+	nodeConfig.Espresso.CaffNode.Namespace = builder.chainConfig.ChainID.Uint64()
+	nodeConfig.Espresso.Streamer.HotShotBlock = 1
+	nodeConfig.Espresso.CaffNode.BatchPosterAddr = "0xb386a74Dcab67b66F8AC07B4f08365d37495Dd23"
 
 	// for testing, we can use the same hotshot url for both
-	nodeConfig.EspressoCaffNode.HotShotUrl = hotShotUrl
-	nodeConfig.EspressoCaffNode.RetryTime = time.Second * 1
-	nodeConfig.EspressoCaffNode.HotshotPollingInterval = time.Millisecond * 100
-	nodeConfig.EspressoCaffNode.FromBlock = 1
+	nodeConfig.Espresso.CaffNode.HotShotUrl = hotShotUrl
+	nodeConfig.Espresso.Streamer.TxnsPollingInterval = time.Second * 1
+	nodeConfig.Espresso.CaffNode.HotshotPollingInterval = time.Millisecond * 100
+	nodeConfig.Espresso.Streamer.AddressMonitorStartL1 = 1
 	nodeConfig.ParentChainReader.Enable = true
 
 	return builder
@@ -234,7 +233,7 @@ func TestEspressoCaffNode(t *testing.T) {
 	Require(t, err)
 
 	// don't make the caff node wait for finalization during the default test.
-	builder.nodeConfig.EspressoCaffNode.WaitForFinalization = false
+	builder.nodeConfig.Espresso.CaffNode.WaitForFinalization = false
 	builder.nodeConfig.EspressoCaffNode.WaitForConfirmations = false
 	// start the node
 	builder, _, err = createCaffNode(ctx, t, builder, arbnode.TestBatchPosterConfig.DisableDapFallbackStoreDataOnChain)
@@ -377,9 +376,9 @@ func TestEspressoCaffNodeDelayedMessagesConfirmations(t *testing.T) {
 	defer cleanEspresso()
 
 	// Set caff node config variables
-	builder.nodeConfig.EspressoCaffNode.WaitForConfirmations = true
-	builder.nodeConfig.EspressoCaffNode.RequiredBlockDepth = 6
-	builder.nodeConfig.EspressoCaffNode.WaitForFinalization = false
+	builder.nodeConfig.Espresso.CaffNode.WaitForConfirmations = true
+	builder.nodeConfig.Espresso.CaffNode.RequiredBlockDepth = 6
+	builder.nodeConfig.Espresso.CaffNode.WaitForFinalization = false
 
 	// start the node
 	log.Info("Starting the caff node")
@@ -404,7 +403,7 @@ func TestEspressoCaffNodeDelayedMessagesConfirmations(t *testing.T) {
 		err := waitForWith(ctx, 240*time.Second, 1*time.Second, func() bool {
 			header, err := builder.L1.Client.HeaderByNumber(ctx, nil) // get the latest header to check tx block depth
 			Require(t, err)
-			return header.Number.Uint64() >= tx[0].BlockNumber.Uint64()+builder.nodeConfig.EspressoCaffNode.RequiredBlockDepth // check that the tx is at least RequiredBlockDepth blocks deep in the parent chains state.
+			return header.Number.Uint64() >= tx[0].BlockNumber.Uint64()+builder.nodeConfig.Espresso.CaffNode.RequiredBlockDepth // check that the tx is at least RequiredBlockDepth blocks deep in the parent chains state.
 		})
 		return err
 	}
@@ -436,9 +435,9 @@ func TestEspressoCaffNodeDelayedMessagesFinalized(t *testing.T) {
 	Require(t, err)
 
 	// Set caff node config vars
-	builder.nodeConfig.EspressoCaffNode.WaitForConfirmations = false
-	builder.nodeConfig.EspressoCaffNode.RequiredBlockDepth = 6
-	builder.nodeConfig.EspressoCaffNode.WaitForFinalization = true
+	builder.nodeConfig.Espresso.CaffNode.WaitForConfirmations = false
+	builder.nodeConfig.Espresso.CaffNode.RequiredBlockDepth = 6
+	builder.nodeConfig.Espresso.CaffNode.WaitForFinalization = true
 	// start the node
 	log.Info("Starting the caff node")
 	builder2, cleanupCaffNode, err := createCaffNode(ctx, t, builder, false)
@@ -487,9 +486,9 @@ func TestEspressoCaffNodeUnfinalizedDelayedMessages(t *testing.T) {
 	defer cleanup()
 	defer cleanEspresso()
 	// set caff node config vars
-	builder.nodeConfig.EspressoCaffNode.WaitForConfirmations = false
-	builder.nodeConfig.EspressoCaffNode.RequiredBlockDepth = 6
-	builder.nodeConfig.EspressoCaffNode.WaitForFinalization = false
+	builder.nodeConfig.Espresso.CaffNode.WaitForConfirmations = false
+	builder.nodeConfig.Espresso.CaffNode.RequiredBlockDepth = 6
+	builder.nodeConfig.Espresso.CaffNode.WaitForFinalization = false
 
 	// start the node
 	log.Info("Starting the caff node")
@@ -530,10 +529,10 @@ func TestEspressoCaffNodeSnapshot(t *testing.T) {
 	defer cleanEspresso()
 
 	// Set caff node config variables
-	builder.nodeConfig.EspressoCaffNode.WaitForConfirmations = true
-	builder.nodeConfig.EspressoCaffNode.RequiredBlockDepth = 6
-	builder.nodeConfig.EspressoCaffNode.WaitForFinalization = false
-	builder.nodeConfig.EspressoCaffNode.GenerateSnapshot = true
+	builder.nodeConfig.Espresso.CaffNode.WaitForConfirmations = true
+	builder.nodeConfig.Espresso.CaffNode.RequiredBlockDepth = 6
+	builder.nodeConfig.Espresso.CaffNode.WaitForFinalization = false
+	builder.nodeConfig.Espresso.CaffNode.GenerateSnapshot = true
 
 	// start the node
 	log.Info("Starting the caff node initially")
@@ -571,14 +570,14 @@ func TestEspressoCaffNodeSnapshot(t *testing.T) {
 
 	// now we need to restart the caff node in Snapshot mode such and it will use this snapshot,
 	// verify it and re-initialize the tags with tmac
-	builderCaffNode.nodeConfig.EspressoCaffNode.SnapshotChecksum = base64SnapshotFileContent
-	builderCaffNode.nodeConfig.EspressoCaffNode.EspressoTeeType = "TESTS"
-	builderCaffNode.nodeConfig.EspressoCaffNode.GenerateSnapshot = false
+	builderCaffNode.nodeConfig.Espresso.CaffNode.SnapshotChecksum = base64SnapshotFileContent
+	builderCaffNode.nodeConfig.Espresso.CaffNode.TeeType = "TESTS"
+	builderCaffNode.nodeConfig.Espresso.CaffNode.GenerateSnapshot = false
 
 	parentChainTransactionOpts := builder.L1Info.GetDefaultTransactOpts("Faucet", ctx)
 	espressoTEEVerifierAddress, _, _, err := espressogen.DeployEspressoTEEVerifierMock(&parentChainTransactionOpts, builder.L1.Client)
 	Require(t, err)
-	builderCaffNode.nodeConfig.EspressoCaffNode.EspressoTEEVerifierAddr = espressoTEEVerifierAddress.Hex()
+	builderCaffNode.nodeConfig.Espresso.CaffNode.TEEVerifierAddr = espressoTEEVerifierAddress.Hex()
 
 	logHandler := testhelpers.InitTestLog(t, log.LevelInfo)
 	_ = logHandler

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -709,7 +709,7 @@ func (b *NodeBuilder) BuildEspressoCaffNode(t *testing.T, existing *NodeBuilder)
 
 	fatalErrChan := make(chan error, 10)
 
-	if existing.nodeConfig.EspressoCaffNode.EspressoTeeType != "" {
+	if existing.nodeConfig.Espresso.CaffNode.TeeType != "" {
 		initializeTags := false
 		if os.Getenv("INITIALIZE_TAGS") != "" {
 			initializeTags = true
@@ -795,7 +795,7 @@ func (b *NodeBuilder) RestartCaffNode(t *testing.T) {
 	feedErrChan := make(chan error, 10)
 
 	var currentNode *arbnode.Node
-	if b.nodeConfig.EspressoCaffNode.EspressoTeeType != "" {
+	if b.nodeConfig.Espresso.CaffNode.TeeType != "" {
 		teeHMAC, err := espresso_tee_utils.HmacForTest()
 		caffNodeTxopts := b.L1Info.GetDefaultTransactOpts("User", context.Background())
 		Require(t, err)
@@ -1657,9 +1657,9 @@ func createNonL1BlockChainWithStackConfig(
 
 	var chainData ethdb.Database
 	// If snapshot mode is enabled, check if the snapshot hash matches the one in the config before opening the database in write mode
-	if nodeConfig != nil && nodeConfig.EspressoCaffNode.SnapshotChecksum != "" {
+	if nodeConfig != nil && nodeConfig.Espresso.CaffNode.SnapshotChecksum != "" {
 		log.Info("Snapshot mode enabled in Caff node")
-		if nodeConfig.EspressoCaffNode.SnapshotChecksum == "" {
+		if nodeConfig.Espresso.CaffNode.SnapshotChecksum == "" {
 			Fatal(t, "snapshot checksum should not be empty when snapshot mode is enabled")
 		}
 		privKey := os.Getenv("CAFF_NODE_PRIV_KEY")
@@ -1672,7 +1672,7 @@ func createNonL1BlockChainWithStackConfig(
 			Fatal(t, "Invalid CAFF_NODE_PRIV_KEY format")
 		}
 		t.Setenv("INITIALIZE_TAGS", "")
-		initializeTags, err := arbutil.VerifySnapshot(nodeConfig.EspressoCaffNode.SnapshotChecksum, stack.InstanceDir(), stack.ResolvePath("l2chaindata"), stack.ResolveAncient("l2chaindata", conf.PersistentConfigDefault.Ancient), caffPrivKey)
+		initializeTags, err := arbutil.VerifySnapshot(nodeConfig.Espresso.CaffNode.SnapshotChecksum, stack.InstanceDir(), stack.ResolvePath("l2chaindata"), stack.ResolveAncient("l2chaindata", conf.PersistentConfigDefault.Ancient), caffPrivKey)
 		Require(t, err)
 		if initializeTags {
 			t.Setenv("INITIALIZE_TAGS", "true")

--- a/system_tests/espresso/config/espresso_config_parsing_test.go
+++ b/system_tests/espresso/config/espresso_config_parsing_test.go
@@ -1,0 +1,105 @@
+package config_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/knadh/koanf"
+	"github.com/knadh/koanf/parsers/json"
+	"github.com/knadh/koanf/providers/confmap"
+	"github.com/knadh/koanf/providers/rawbytes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/offchainlabs/nitro/arbnode"
+)
+
+func TestEspressoConfigParsing(t *testing.T) {
+	inputSource := map[string]interface{}{
+		"sequencer": true,
+		"espresso": map[string]interface{}{
+			"caff-node": map[string]interface{}{
+				"enable": true,
+			},
+			"batch-poster": map[string]interface{}{
+				"tee-type":      "NITRO",
+				"hotshot-url":   "http://localhost:8080",
+				"tx-size-limit": int64(900000),
+			},
+			"streamer": map[string]interface{}{
+				"hotshot-block": uint64(100),
+				"dangerous": map[string]interface{}{
+					"minimum-hotshot-block-num": int64(50),
+				},
+				"txns-polling-interval": "3s",
+				"address-monitor-step":  uint64(100),
+			},
+		},
+	}
+
+	k := koanf.New(".")
+	err := k.Load(confmap.Provider(inputSource, "."), nil)
+	require.NoError(t, err)
+
+	var parsedConfig arbnode.Config
+	err = k.UnmarshalWithConf("", &parsedConfig, koanf.UnmarshalConf{Tag: "koanf"})
+	require.NoError(t, err)
+
+	assert.Equal(t, true, parsedConfig.Sequencer)
+	assert.Equal(t, true, parsedConfig.Espresso.CaffNode.Enable)
+	assert.Equal(t, "NITRO", parsedConfig.Espresso.BatchPoster.TeeType)
+	assert.Equal(t, "http://localhost:8080", parsedConfig.Espresso.BatchPoster.HotShotUrl)
+	assert.Equal(t, int64(900000), parsedConfig.Espresso.BatchPoster.TxSizeLimit)
+	assert.Equal(t, uint64(100), parsedConfig.Espresso.Streamer.HotShotBlock)
+	assert.Equal(t, uint64(50), parsedConfig.Espresso.Streamer.Dangerous.MinimumHotshotBlockNum)
+	assert.Equal(t, 3*time.Second, parsedConfig.Espresso.Streamer.TxnsPollingInterval)
+	assert.Equal(t, uint64(100), parsedConfig.Espresso.Streamer.AddressMonitorStep)
+}
+
+func TestEspressoConfigMigration(t *testing.T) {
+	const oldConfigJSONPath = "./testdata/migrated_config.json"
+
+	oldConfigJSON, err := os.ReadFile(oldConfigJSONPath)
+	require.NoError(t, err)
+
+	k := koanf.New(".")
+
+	err = k.Load(
+		rawbytes.Provider([]byte(oldConfigJSON)),
+		json.Parser(),
+	)
+	require.NoError(t, err)
+
+	var cfg arbnode.Config
+	err = k.Unmarshal("", &cfg)
+	require.NoError(t, err)
+
+	// streamer
+	require.Equal(t, uint64(10), cfg.Espresso.Streamer.HotShotBlock)
+	require.Equal(
+		t,
+		uint64(56),
+		cfg.Espresso.Streamer.Dangerous.MinimumHotshotBlockNum,
+	)
+
+	// caff-node
+	require.True(
+		t,
+		cfg.Espresso.CaffNode.Dangerous.IgnoreDatabaseHotshotBlock,
+	)
+	require.False(
+		t,
+		cfg.Espresso.CaffNode.Dangerous.IgnoreDatabaseFromBlock,
+	)
+
+	require.Equal(t,
+		time.Duration(2*time.Second),
+		cfg.Espresso.Streamer.TxnsPollingInterval,
+	)
+
+	require.Equal(t,
+		uint64(100),
+		cfg.Espresso.Streamer.AddressMonitorStep,
+	)
+}

--- a/system_tests/espresso/config/testdata/migrated_config.json
+++ b/system_tests/espresso/config/testdata/migrated_config.json
@@ -1,0 +1,161 @@
+{
+  "chain": {
+    "info-files": [
+      "/config/l2_chain_info.json"
+    ]
+  },
+  "espresso": {
+    "batch-poster": {
+      "address-valid-ranges": [
+        {
+          "address": "${address1}",
+          "from": 1,
+          "to": 99
+        },
+        {
+          "address": "${address2}",
+          "from": 99,
+          "to": 199
+        }
+      ],
+      "hotshot-first-posting-block": 1,
+      "hotshot-url": "https://localhost:9090",
+      "register-service-config": {
+        "max-base-fee": 10,
+        "max-retries": 5
+      },
+      "resubmit-espresso-tx-deadline": "2m",
+      "tee-type": "${espresso_tee_type}"
+    },
+    "caff-node": {
+      "dangerous": {
+        "ignore-database-from-block": false,
+        "ignore-database-hotshot-block": true
+      },
+      "enable": false,
+      "from-block": 5,
+      "namespace": 23,
+      "tee-type": "${espresso_tee_type}"
+    },
+    "streamer": {
+      "address-monitor-start-l1": 1,
+      "address-monitor-step": 100,
+      "dangerous": {
+        "minimum-hotshot-block-num": 56
+      },
+      "hotshot-block": 10,
+      "txns-polling-interval": "2s"
+    }
+  },
+  "execution": {
+    "forwarding-target": "null",
+    "sequencer": {
+      "enable": true
+    }
+  },
+  "http": {
+    "addr": "0.0.0.0",
+    "api": [
+      "eth",
+      "net",
+      "web3",
+      "arb",
+      "debug",
+      "txpool"
+    ],
+    "corsdomain": "*",
+    "vhosts": "*"
+  },
+  "node": {
+    "batch-poster": {
+      "data-poster": {
+        "max-base-fee": 10
+      },
+      "enable": true,
+      "l1-block-bound": "ignore",
+      "light-client-address": "${light_client_address}",
+      "max-delay": "1h0m0s",
+      "max-empty-batch-delay": "1h0m0s",
+      "parent-chain-wallet": {
+        "private-key": "${batch_poster_secret_arn}"
+      },
+      "poll-interval": "10s",
+      "post-4844-blobs": false,
+      "redis-url": "",
+      "wait-for-max-delay": true
+    },
+    "block-validator": {
+      "enable": true,
+      "validation-server": {
+        "jwtsecret": "/config/val_jwt.hex",
+        "url": "${validation_server_url}"
+      }
+    },
+    "dangerous": {
+      "disable-blob-reader": true,
+      "no-sequencer-coordinator": true
+    },
+    "data-availability": {
+      "enable": false
+    },
+    "delayed-sequencer": {
+      "enable": true,
+      "finalize-distance": 6,
+      "use-merge-finality": false
+    },
+    "feed": {
+      "input": {
+        "url": ""
+      },
+      "output": {
+        "enable": true,
+        "signed": false
+      }
+    },
+    "parent-chain-reader": {
+      "poll-interval": "60s",
+      "poll-only": true
+    },
+    "seq-coordinator": {
+      "enable": false,
+      "lockout-duration": "30s",
+      "lockout-spare": "1s",
+      "my-url": "",
+      "redis-url": "redis://redis:6379",
+      "retry-interval": "0.5s",
+      "seq-num-duration": "24h0m0s",
+      "update-interval": "3s"
+    },
+    "sequencer": true,
+    "staker": {
+      "disable-challenge": false,
+      "enable": true,
+      "make-assertion-interval": "120s",
+      "parent-chain-wallet": {
+        "private-key": "${staker_secret_arn}"
+      },
+      "staker-interval": "120s",
+      "strategy": "MakeNodes"
+    }
+  },
+  "parent-chain": {
+    "connection": {
+      "url": "${parent_chain_url_secret_arn}"
+    }
+  },
+  "persistent": {
+    "chain": "local",
+    "db-engine": "leveldb"
+  },
+  "ws": {
+    "addr": "0.0.0.0",
+    "api": [
+      "eth",
+      "net",
+      "web3",
+      "arb",
+      "debug",
+      "txpool"
+    ]
+  }
+}

--- a/system_tests/espresso_setup_test.go
+++ b/system_tests/espresso_setup_test.go
@@ -6,6 +6,8 @@ import (
 	"math/big"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func createL1AndL2Node(
@@ -29,14 +31,13 @@ func createL1AndL2Node(
 
 	// poster config
 	builder.nodeConfig.BatchPoster.Enable = true
-	builder.nodeConfig.BatchPoster.EspressoTxnsPollingInterval = 2 * time.Second
+	builder.nodeConfig.Espresso.Streamer.TxnsPollingInterval = 2 * time.Second
 	builder.nodeConfig.BatchPoster.ErrorDelay = 5 * time.Second
 	builder.nodeConfig.BatchPoster.MaxSize = 1000
 	builder.nodeConfig.BatchPoster.PollInterval = 10 * time.Second
 	builder.nodeConfig.BatchPoster.MaxDelay = -1000 * time.Hour
-	builder.nodeConfig.BatchPoster.HotShotUrl = hotShotUrl
-	builder.nodeConfig.BatchPoster.HotShotUrl = hotShotUrl
-	builder.nodeConfig.BatchPoster.EspressoTeeType = "SGX"
+	builder.nodeConfig.Espresso.BatchPoster.HotShotUrl = hotShotUrl
+	builder.nodeConfig.Espresso.BatchPoster.TeeType = "SGX"
 	builder.nodeConfig.BatchPoster.MaxEmptyBatchDelay = 10 * time.Second
 
 	// validator config
@@ -75,4 +76,14 @@ func createL1AndL2Node(
 	builder.L1.TransferBalance(t, "Faucet", "CommitmentTask", new(big.Int).Mul(big.NewInt(9e18), big.NewInt(1000)), builder.L1Info)
 
 	return builder, cleanup
+}
+
+func TestCreateEspressoCaffNode(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	valNodeCleanup := createValidationNode(ctx, t, true)
+	defer valNodeCleanup()
+	builder, cleanup := createL1AndL2Node(ctx, t, true, false)
+	defer cleanup()
+	require.Greater(t, builder.nodeConfig.Espresso.BatchPoster.TxSizeLimit, int64(0), "EspressoTxSizeLimit should be greater than 0")
 }


### PR DESCRIPTION
Backport of [916](https://github.com/EspressoSystems/nitro-espresso-integration/pull/916) to integration-v3.5.6

(cherry picked from commit db6a95d4ef5082eb7872b2c45fc1846f4b740c62)

