### PR TITLE
Registering the signer should have a limit

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -82,8 +82,9 @@ var (
 
 	batchPosterFailureCounter = metrics.NewRegisteredCounter("arb/batchPoster/action/failure", nil)
 
-	usableBytesInBlob    = big.NewInt(int64(len(kzg4844.Blob{}) * 31 / 32))
-	blobTxBlobGasPerBlob = big.NewInt(params.BlobTxBlobGasPerBlob)
+	usableBytesInBlob              = big.NewInt(int64(len(kzg4844.Blob{}) * 31 / 32))
+	blobTxBlobGasPerBlob           = big.NewInt(params.BlobTxBlobGasPerBlob)
+	FatalErrUnableToRegisterSigner = errors.New("unable to register signer")
 )
 
 const (
@@ -1833,7 +1834,7 @@ func (b *BatchPoster) MaybePostSequencerBatch(ctx context.Context) (bool, error)
 			log.Warn("ephemeral keys are not yet registered in Espresso TEE Contract")
 			err := espressoSubmitter.RegisterService()
 			if err != nil {
-				return false, fmt.Errorf("unable to register signer: %w", err)
+				return false, fmt.Errorf("%w: %w", FatalErrUnableToRegisterSigner, err)
 			}
 		}
 	}
@@ -2599,13 +2600,14 @@ func (b *BatchPoster) Start(ctxIn context.Context) {
 				// Shutting down. No need to print the context canceled error.
 				return 0
 			}
-			if strings.Contains(err.Error(), "unable to register signer") {
+			if errors.Is(err, FatalErrUnableToRegisterSigner) {
 				registrationFailCount++
-				if registrationFailCount > 5 {
+				if registrationFailCount > int(b.espressoConfig.BatchPoster.RegisterServiceConfig.MaxRegisterRetries) {
 					log.Crit("Espresso signer registration failed 5 times consecutively. Panicking.", "err", err)
 					panic(err)
 				}
 				log.Warn("Espresso signer registration failed", "attempt", registrationFailCount, "err", err)
+				return b.espressoConfig.BatchPoster.RegisterServiceConfig.RegisterRetryDelay
 			}
 
 			b.building = nil

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -2559,6 +2559,7 @@ func (b *BatchPoster) Start(ctxIn context.Context) {
 		nonceTooHighEphemeralErrorHandler.Reset()
 		espressoEphemeralErrorHandler.Reset()
 	}
+	registrationFailCount := 0
 	b.CallIteratively(func(ctx context.Context) time.Duration {
 		var err error
 		if common.HexToAddress(b.config().GasRefunderAddress) != (common.Address{}) {
@@ -2598,6 +2599,15 @@ func (b *BatchPoster) Start(ctxIn context.Context) {
 				// Shutting down. No need to print the context canceled error.
 				return 0
 			}
+			if strings.Contains(err.Error(), "unable to register signer") {
+				registrationFailCount++
+				if registrationFailCount > 5 {
+					log.Crit("Espresso signer registration failed 5 times consecutively. Panicking.", "err", err)
+					panic(err)
+				}
+				log.Warn("Espresso signer registration failed", "attempt", registrationFailCount, "err", err)
+			}
+
 			b.building = nil
 			logLevel := log.Error
 			// Likely the inbox tracker just isn't caught up.

--- a/espressotee/espresso_tee_helpers.go
+++ b/espressotee/espresso_tee_helpers.go
@@ -97,6 +97,8 @@ type EspressoRegisterServiceConfig struct {
 	MaxTxnWaitTime                time.Duration `koanf:"max-txn-wait-time"`
 	RetryReadContractDelay        time.Duration `koanf:"retry-read-contract-delay"`
 	MaxRetries                    uint8         `koanf:"max-retries"`
+	MaxRegisterRetries            uint8         `koanf:"max-register-retries"`
+	RegisterRetryDelay            time.Duration `koanf:"register-retry-delay"`
 	GasLimitBufferIncreasePercent uint64        `koanf:"gas-limit-buffer-increase-percent"`
 }
 
@@ -104,6 +106,8 @@ var DefaultEspressoRegisterServiceConfig = EspressoRegisterServiceConfig{
 	MaxTxnWaitTime:                3 * time.Minute,
 	RetryReadContractDelay:        5 * time.Second,
 	MaxRetries:                    5,
+	MaxRegisterRetries:            5,
+	RegisterRetryDelay:            time.Millisecond * 10,
 	GasLimitBufferIncreasePercent: 20,
 }
 
@@ -111,6 +115,8 @@ type EspressoRegisterServiceOpts struct {
 	MaxTxnWaitTime                time.Duration
 	RetryReadContractDelay        time.Duration
 	MaxRetries                    int
+	MaxRegisterRetries            int
+	RegisterRetryDelay            time.Duration
 	GasLimitBufferIncreasePercent uint64
 }
 
@@ -119,4 +125,6 @@ func AddEspressoRegisterServiceConfigOptions(prefix string, f *pflag.FlagSet) {
 	f.Duration(prefix+".retry-read-contract-delay", DefaultEspressoRegisterServiceConfig.RetryReadContractDelay, "delay in calls to read from contract for verification")
 	f.Int(prefix+".max-retries", int(DefaultEspressoRegisterServiceConfig.MaxRetries), "how many times to check if we have data in our espresso tee contracts")
 	f.Uint64(prefix+".gas-limit-buffer-increase-percent", DefaultEspressoRegisterServiceConfig.GasLimitBufferIncreasePercent, "buffer increase to gas limit in espresso tee contracts")
+	f.Int(prefix+".max-register-retries", int(DefaultEspressoRegisterServiceConfig.MaxRegisterRetries), "maximum number of retries for registering with the Espresso Network")
+	f.Duration(prefix+".register-retry-delay", DefaultEspressoRegisterServiceConfig.RegisterRetryDelay, "delay between retries for registering with the Espresso Network")
 }

--- a/system_tests/espresso/config/espresso_config_parsing_test.go
+++ b/system_tests/espresso/config/espresso_config_parsing_test.go
@@ -26,6 +26,10 @@ func TestEspressoConfigParsing(t *testing.T) {
 				"tee-type":      "NITRO",
 				"hotshot-url":   "http://localhost:8080",
 				"tx-size-limit": int64(900000),
+				"register-service-config": map[string]interface{}{
+					"max-register-retries": 5,
+					"register-retry-delay": "10ms",
+				},
 			},
 			"streamer": map[string]interface{}{
 				"hotshot-block": uint64(100),
@@ -55,6 +59,8 @@ func TestEspressoConfigParsing(t *testing.T) {
 	assert.Equal(t, uint64(50), parsedConfig.Espresso.Streamer.Dangerous.MinimumHotshotBlockNum)
 	assert.Equal(t, 3*time.Second, parsedConfig.Espresso.Streamer.TxnsPollingInterval)
 	assert.Equal(t, uint64(100), parsedConfig.Espresso.Streamer.AddressMonitorStep)
+	assert.Equal(t, uint8(5), parsedConfig.Espresso.BatchPoster.RegisterServiceConfig.MaxRegisterRetries)
+	assert.Equal(t, 10*time.Millisecond, parsedConfig.Espresso.BatchPoster.RegisterServiceConfig.RegisterRetryDelay)
 }
 
 func TestEspressoConfigMigration(t *testing.T) {


### PR DESCRIPTION
Closes [Asana Task](https://app.asana.com/1/1208976916964769/project/1212536007593685/task/1212718128030180?focus=true)


### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->
Previously, failing singer registration would go on forever and in the process draining all the zk funds.
This PR fixes that by using a limit defined by `registrationFailCount` currently hardcoded to 5.
If the signer registration is not successful even after 5 tries, the process will fail and panic.


### Key places to review:
`arbnode/batch_poster.go`

### How to test this PR:  
I've tested this naively by forcing signer registration to always fail and this new mechanism is working and kicked in after 5 tries. Here are the logs from the test:
```
WARN [01-19|14:57:12.905] Espresso signer registration failed      attempt=1 err="unable to register signer"
WARN [01-19|14:57:12.905] error posting batch                      err="unable to register signer"
WARN [01-19|14:57:12.915] Espresso signer registration failed      attempt=2 err="unable to register signer"
WARN [01-19|14:57:12.915] error posting batch                      err="unable to register signer"
WARN [01-19|14:57:12.925] Espresso signer registration failed      attempt=3 err="unable to register signer"
WARN [01-19|14:57:12.925] error posting batch                      err="unable to register signer"
WARN [01-19|14:57:12.936] Espresso signer registration failed      attempt=4 err="unable to register signer"
WARN [01-19|14:57:12.936] error posting batch                      err="unable to register signer"
WARN [01-19|14:57:12.946] Espresso signer registration failed      attempt=5 err="unable to register signer"
WARN [01-19|14:57:12.946] error posting batch                      err="unable to register signer"
CRIT [01-19|14:57:12.957] Espresso signer registration failed 5 times consecutively. Panicking. err="unable to register signer"
```

### Possible improvements:
- I don't specifically like the hardcoded value and think its better if we allow this value to be set by the user in the `batch_config.json` file essentially putting the value as an optional inside `EspressoBatchPosterConfig`. I'll wait for review incase there is a better approach or if we don't want this to be user-configurable


