### PR TITLE
[Backport/integration-v3.5.6]: Registering the signer should have a limit (#931)

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -81,8 +81,9 @@ var (
 
 	batchPosterFailureCounter = metrics.NewRegisteredCounter("arb/batchPoster/action/failure", nil)
 
-	usableBytesInBlob    = big.NewInt(int64(len(kzg4844.Blob{}) * 31 / 32))
-	blobTxBlobGasPerBlob = big.NewInt(params.BlobTxBlobGasPerBlob)
+	usableBytesInBlob              = big.NewInt(int64(len(kzg4844.Blob{}) * 31 / 32))
+	blobTxBlobGasPerBlob           = big.NewInt(params.BlobTxBlobGasPerBlob)
+	FatalErrUnableToRegisterSigner = errors.New("unable to register signer")
 )
 
 const (
@@ -1653,7 +1654,7 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 			log.Warn("ephemeral keys are not yet registered in Espresso TEE Contract")
 			err := espressoSubmitter.RegisterService()
 			if err != nil {
-				return false, fmt.Errorf("unable to register signer: %w", err)
+				return false, fmt.Errorf("%w: %w", FatalErrUnableToRegisterSigner, err)
 			}
 		}
 	}
@@ -2289,6 +2290,7 @@ func (b *BatchPoster) Start(ctxIn context.Context) {
 		accumulatorNotFoundEphemeralErrorHandler.Reset()
 		espressoEphemeralErrorHandler.Reset()
 	}
+	registrationFailCount := 0
 	b.CallIteratively(func(ctx context.Context) time.Duration {
 		var err error
 		if common.HexToAddress(b.config().GasRefunderAddress) != (common.Address{}) {
@@ -2328,6 +2330,16 @@ func (b *BatchPoster) Start(ctxIn context.Context) {
 				// Shutting down. No need to print the context canceled error.
 				return 0
 			}
+			if errors.Is(err, FatalErrUnableToRegisterSigner) {
+				registrationFailCount++
+				if registrationFailCount > int(b.espressoConfig.BatchPoster.RegisterServiceConfig.MaxRegisterRetries) {
+					log.Crit("Espresso signer registration failed 5 times consecutively. Panicking.", "err", err)
+					panic(err)
+				}
+				log.Warn("Espresso signer registration failed", "attempt", registrationFailCount, "err", err)
+				return b.espressoConfig.BatchPoster.RegisterServiceConfig.RegisterRetryDelay
+			}
+
 			b.building = nil
 			logLevel := log.Error
 			// Likely the inbox tracker just isn't caught up.

--- a/espressotee/espresso_tee_helpers.go
+++ b/espressotee/espresso_tee_helpers.go
@@ -97,6 +97,8 @@ type EspressoRegisterServiceConfig struct {
 	MaxTxnWaitTime                time.Duration `koanf:"max-txn-wait-time"`
 	RetryReadContractDelay        time.Duration `koanf:"retry-read-contract-delay"`
 	MaxRetries                    uint8         `koanf:"max-retries"`
+	MaxRegisterRetries            uint8         `koanf:"max-register-retries"`
+	RegisterRetryDelay            time.Duration `koanf:"register-retry-delay"`
 	GasLimitBufferIncreasePercent uint64        `koanf:"gas-limit-buffer-increase-percent"`
 }
 
@@ -104,6 +106,8 @@ var DefaultEspressoRegisterServiceConfig = EspressoRegisterServiceConfig{
 	MaxTxnWaitTime:                3 * time.Minute,
 	RetryReadContractDelay:        5 * time.Second,
 	MaxRetries:                    5,
+	MaxRegisterRetries:            5,
+	RegisterRetryDelay:            time.Millisecond * 10,
 	GasLimitBufferIncreasePercent: 20,
 }
 
@@ -111,6 +115,8 @@ type EspressoRegisterServiceOpts struct {
 	MaxTxnWaitTime                time.Duration
 	RetryReadContractDelay        time.Duration
 	MaxRetries                    int
+	MaxRegisterRetries            int
+	RegisterRetryDelay            time.Duration
 	GasLimitBufferIncreasePercent uint64
 }
 
@@ -119,4 +125,6 @@ func AddEspressoRegisterServiceConfigOptions(prefix string, f *pflag.FlagSet) {
 	f.Duration(prefix+".retry-read-contract-delay", DefaultEspressoRegisterServiceConfig.RetryReadContractDelay, "delay in calls to read from contract for verification")
 	f.Int(prefix+".max-retries", int(DefaultEspressoRegisterServiceConfig.MaxRetries), "how many times to check if we have data in our espresso tee contracts")
 	f.Uint64(prefix+".gas-limit-buffer-increase-percent", DefaultEspressoRegisterServiceConfig.GasLimitBufferIncreasePercent, "buffer increase to gas limit in espresso tee contracts")
+	f.Int(prefix+".max-register-retries", int(DefaultEspressoRegisterServiceConfig.MaxRegisterRetries), "maximum number of retries for registering with the Espresso Network")
+	f.Duration(prefix+".register-retry-delay", DefaultEspressoRegisterServiceConfig.RegisterRetryDelay, "delay between retries for registering with the Espresso Network")
 }

--- a/system_tests/espresso/config/espresso_config_parsing_test.go
+++ b/system_tests/espresso/config/espresso_config_parsing_test.go
@@ -26,6 +26,10 @@ func TestEspressoConfigParsing(t *testing.T) {
 				"tee-type":      "NITRO",
 				"hotshot-url":   "http://localhost:8080",
 				"tx-size-limit": int64(900000),
+				"register-service-config": map[string]interface{}{
+					"max-register-retries": 5,
+					"register-retry-delay": "10ms",
+				},
 			},
 			"streamer": map[string]interface{}{
 				"hotshot-block": uint64(100),
@@ -55,6 +59,8 @@ func TestEspressoConfigParsing(t *testing.T) {
 	assert.Equal(t, uint64(50), parsedConfig.Espresso.Streamer.Dangerous.MinimumHotshotBlockNum)
 	assert.Equal(t, 3*time.Second, parsedConfig.Espresso.Streamer.TxnsPollingInterval)
 	assert.Equal(t, uint64(100), parsedConfig.Espresso.Streamer.AddressMonitorStep)
+	assert.Equal(t, uint8(5), parsedConfig.Espresso.BatchPoster.RegisterServiceConfig.MaxRegisterRetries)
+	assert.Equal(t, 10*time.Millisecond, parsedConfig.Espresso.BatchPoster.RegisterServiceConfig.RegisterRetryDelay)
 }
 
 func TestEspressoConfigMigration(t *testing.T) {


### PR DESCRIPTION
Backport of https://github.com/EspressoSystems/nitro-espresso-integration/pull/931 to `integration-v3.5.6`