### PR TITLE
Add persistent key storage to the Batch Poster

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -6,7 +6,6 @@ package arbnode
 import (
 	"bytes"
 	"context"
-	"crypto/ecdsa"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
@@ -27,7 +26,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
@@ -633,19 +631,11 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 			panic("TransactOpts is nil")
 		}
 		// to support tests, we can give the batch poster a "persistent key" via the config, This variable WILL be nil if the configured tee type is not TESTS
-		var testsPersistentKey *ecdsa.PrivateKey
-		if teeType == espressotee.TESTS {
-			testsPersistentKey, err = crypto.HexToECDSA(opts.Config().ParentChainWallet.PrivateKey)
-			if err != nil {
-				log.Error("Unable to convert config private key string to type for mocking during tests")
-				return nil, err
-			}
-		}
 		submitterOptions = append(
 			submitterOptions,
 			// TODO: pass the persistent private key to the key manager in future
 			submitter.WithKeyManager(
-				espresso_key_manager.NewEspressoKeyManager(verifier, b.dataPoster, opts.DataSigner, teeType, espressotee.BatchPoster, testsPersistentKey, opts.EspressoConfigFetcher().BatchPoster.AttestationServiceURL, opts.EspressoConfigFetcher().BatchPoster.KeyPairAttestationsPath, opts.ChainID),
+				espresso_key_manager.NewEspressoKeyManager(verifier, b.dataPoster, opts.DataSigner, teeType, espressotee.BatchPoster, nil, opts.EspressoConfigFetcher().BatchPoster.AttestationServiceURL, opts.EspressoConfigFetcher().BatchPoster.KeyPairAttestationsPath, opts.ChainID),
 			),
 		)
 

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -6,6 +6,7 @@ package arbnode
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
@@ -26,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
@@ -630,11 +632,20 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 		if b.dataPoster.Auth() == nil {
 			panic("TransactOpts is nil")
 		}
+		// to support tests, we can give the batch poster a "persistent key" via the config, This variable WILL be nil if the configured tee type is not TESTS
+		var testsPersistentKey *ecdsa.PrivateKey
+		if teeType == espressotee.TESTS {
+			testsPersistentKey, err = crypto.HexToECDSA(opts.Config().ParentChainWallet.PrivateKey)
+			if err != nil {
+				log.Error("Unable to convert config private key string to type for mocking during tests")
+				return nil, err
+			}
+		}
 		submitterOptions = append(
 			submitterOptions,
 			// TODO: pass the persistent private key to the key manager in future
 			submitter.WithKeyManager(
-				espresso_key_manager.NewEspressoKeyManager(verifier, b.dataPoster, opts.DataSigner, teeType, espressotee.BatchPoster, nil, opts.EspressoConfigFetcher().BatchPoster.AttestationServiceURL, opts.EspressoConfigFetcher().BatchPoster.KeyPairAttestationsPath, opts.ChainID),
+				espresso_key_manager.NewEspressoKeyManager(verifier, b.dataPoster, opts.DataSigner, teeType, espressotee.BatchPoster, testsPersistentKey, opts.EspressoConfigFetcher().BatchPoster.AttestationServiceURL, opts.EspressoConfigFetcher().BatchPoster.KeyPairAttestationsPath, opts.ChainID),
 			),
 		)
 

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -634,7 +634,7 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 			submitterOptions,
 			// TODO: pass the persistent private key to the key manager in future
 			submitter.WithKeyManager(
-				espresso_key_manager.NewEspressoKeyManager(verifier, b.dataPoster, opts.DataSigner, teeType, espressotee.BatchPoster, nil, opts.EspressoConfigFetcher().BatchPoster.AttestationServiceURL),
+				espresso_key_manager.NewEspressoKeyManager(verifier, b.dataPoster, opts.DataSigner, teeType, espressotee.BatchPoster, nil, opts.EspressoConfigFetcher().BatchPoster.AttestationServiceURL, opts.EspressoConfigFetcher().BatchPoster.KeyPairAttestationsPath, opts.ChainID),
 			),
 		)
 

--- a/arbnode/espresso_batch_poster_config.go
+++ b/arbnode/espresso_batch_poster_config.go
@@ -16,6 +16,7 @@ type EspressoBatchPosterConfig struct {
 	TxnsResubmissionInterval   time.Duration `koanf:"txns-resubmission-interval"`
 	ResubmitEspressoTxDeadline time.Duration `koanf:"resubmit-espresso-tx-deadline"`
 	AttestationServiceURL      string        `koanf:"attestation-service-url"`
+	KeyPairAttestationsPath    string        `koanf:"key-pair-attestations-path"`
 
 	EventPollingStep         uint64 `koanf:"event-polling-step"`
 	HotShotFirstPostingBlock uint64 `koanf:"hotshot-first-posting-block"`
@@ -34,6 +35,7 @@ func EspressoBatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Duration(prefix+".resubmit-espresso-tx-deadline", DefaultEspressoBatchPosterConfig.ResubmitEspressoTxDeadline, "time threshold after which a transaction will be automatically resubmitted if no response is received")
 	f.Duration(prefix+".txns-monitoring-interval", DefaultEspressoBatchPosterConfig.TxnsMonitoringInterval, "interval for sending and polling transactions to and from espresso")
 	f.String(prefix+".attestation-service-url", DefaultEspressoBatchPosterConfig.AttestationServiceURL, "URL of the attestation service to use for obtaining zk proof over  attestation")
+	f.String(prefix+".key-pair-attestations-path", DefaultEspressoBatchPosterConfig.KeyPairAttestationsPath, "path to attestation documents with KMSKeyID, EncryptedPrivateKey attestations")
 	f.StringSlice(prefix+".init-batcher-addresses", DefaultEspressoBatchPosterConfig.InitBatcherAddresses, "specifies the init batcher addresses")
 }
 

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -338,7 +338,7 @@ func NewEspressoCaffNode(
 			return nil, fmt.Errorf("failed to create data poster: %w", err)
 		}
 
-		keyManager = espresso_key_manager.NewEspressoKeyManager(verifier, dataPoster, nil, teeType, espressotee.CaffNode, caffNodeInitArgs.CaffNodePrivateKey, configFetcher().AttestationServiceURL)
+		keyManager = espresso_key_manager.NewEspressoKeyManager(verifier, dataPoster, nil, teeType, espressotee.CaffNode, caffNodeInitArgs.CaffNodePrivateKey, configFetcher().AttestationServiceURL, "", 0)
 
 	}
 	initializeCaffNodeTags := false

--- a/espresso/key-manager/key_manager.go
+++ b/espresso/key-manager/key_manager.go
@@ -17,7 +17,6 @@ import (
 	"github.com/offchainlabs/nitro/arbnode/dataposter"
 	"github.com/offchainlabs/nitro/arbutil"
 	espresso_tee_utils "github.com/offchainlabs/nitro/cmd/util/espresso-tee-utils"
-	"github.com/offchainlabs/nitro/espresso-tee-contracts/espressogen"
 	attestationverifierclient "github.com/offchainlabs/nitro/espresso/attestation_verifier_client"
 	"github.com/offchainlabs/nitro/espressotee"
 	"github.com/offchainlabs/nitro/util/signature"
@@ -83,13 +82,8 @@ func NewEspressoKeyManager(
 			log.Crit("error reading enclave private key for Espresso Key Manager", "path", keyPairAttestationsPath, "err", err)
 		}
 
-		pubKey, ok = privKey.Public().(*ecdsa.PublicKey)
-		if !ok {
-			panic("failed to get public key")
-		}
 	} else if servicePersistentPrivateKey != nil {
 		privKey = servicePersistentPrivateKey
-		pubKey = &servicePersistentPrivateKey.PublicKey
 	} else {
 		panic("either keyPairAttestationsPath and chainID must be provided, or servicePersistentPrivateKey must be non-nil")
 	}
@@ -186,7 +180,7 @@ func (k *EspressoKeyManager) PrepareRegisterService(getAttestationFunc func([]by
 		log.Info("successfully generated zk proof from nitro attestation")
 		return journalBytes, onchainProofBytes, nil
 	case TESTS:
-		pubKey := crypto.FromECDSAPub(k.pubKey)
+		pubKey := crypto.FromECDSAPub(&k.privKey.PublicKey)
 		log.Info("TESTS signing address", "addr", signerAddr)
 
 		attestationQuote, err := getAttestationFunc(pubKey)

--- a/espresso/key-manager/key_manager.go
+++ b/espresso/key-manager/key_manager.go
@@ -3,7 +3,6 @@ package keymanager
 import (
 	"context"
 	"crypto/ecdsa"
-	"crypto/rand"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -17,6 +16,8 @@ import (
 
 	"github.com/offchainlabs/nitro/arbnode/dataposter"
 	"github.com/offchainlabs/nitro/arbutil"
+	espresso_tee_utils "github.com/offchainlabs/nitro/cmd/util/espresso-tee-utils"
+	"github.com/offchainlabs/nitro/espresso-tee-contracts/espressogen"
 	attestationverifierclient "github.com/offchainlabs/nitro/espresso/attestation_verifier_client"
 	"github.com/offchainlabs/nitro/espressotee"
 	"github.com/offchainlabs/nitro/util/signature"
@@ -65,20 +66,32 @@ func NewEspressoKeyManager(
 	serviceType espressotee.ServiceType,
 	servicePersistentPrivateKey *ecdsa.PrivateKey,
 	zkAttestationServiceURL string,
+	keyPairAttestationsPath string,
+	chainID uint64,
 ) *EspressoKeyManager {
 	var err error
 	var privKey *ecdsa.PrivateKey
 
-	// If the node supports persistent private key, we use that one otherwise we generate a
-	// new ephemeral key. Currently only the cafff node supports persistent private key.
-	if servicePersistentPrivateKey == nil {
-		// ephemeral key
-		privKey, err = ecdsa.GenerateKey(crypto.S256(), rand.Reader)
+	// Both the caff node and batch poster support persistent private keys. If an existing private key
+	// is provided, we use that one. Otherwise, we read the enclave private key from the attestation path.
+	// Note: The current implementation only supports reading the key during key manager construction
+	// for the batch poster. Support for reading the caff node key will be added in a later PR.
+	if keyPairAttestationsPath != "" && chainID != 0 {
+		// Read enclave private key
+		privKey, err = espresso_tee_utils.ReadEnclavePrivateKey(keyPairAttestationsPath, chainID)
 		if err != nil {
-			panic(err)
+			log.Crit("error reading enclave private key for Espresso Key Manager", "path", keyPairAttestationsPath, "err", err)
 		}
-	} else {
+
+		pubKey, ok = privKey.Public().(*ecdsa.PublicKey)
+		if !ok {
+			panic("failed to get public key")
+		}
+	} else if servicePersistentPrivateKey != nil {
 		privKey = servicePersistentPrivateKey
+		pubKey = &servicePersistentPrivateKey.PublicKey
+	} else {
+		panic("either keyPairAttestationsPath and chainID must be provided, or servicePersistentPrivateKey must be non-nil")
 	}
 
 	// Currently the caff node will not need to sign any payloads, so we check if the service type is a caff node
@@ -88,7 +101,11 @@ func NewEspressoKeyManager(
 	}
 
 	if teeType == NITRO && zkAttestationServiceURL == "" {
-		panic("zk attestation service URL must be provided for nitro TEE type")
+		if serviceType != espressotee.Test {
+			panic("zk attestation service URL must be provided for nitro TEE type")
+		} else {
+			log.Info("Allowing nitro key manager creation without zkAttestationServiceURL for tests")
+		}
 	}
 
 	espressoNitroAttestationVerifierClient := attestationverifierclient.NewEspressoAttestationVerifierClient(zkAttestationServiceURL)
@@ -169,14 +186,14 @@ func (k *EspressoKeyManager) PrepareRegisterService(getAttestationFunc func([]by
 		log.Info("successfully generated zk proof from nitro attestation")
 		return journalBytes, onchainProofBytes, nil
 	case TESTS:
-		addr := signerAddr.Bytes()
+		pubKey := crypto.FromECDSAPub(k.pubKey)
 		log.Info("TESTS signing address", "addr", signerAddr)
 
-		attestationQuote, err := getAttestationFunc(addr)
+		attestationQuote, err := getAttestationFunc(pubKey)
 		if err != nil {
 			return nil, nil, fmt.Errorf("TESTS signing failed: %w", err)
 		}
-		return attestationQuote, addr, nil
+		return attestationQuote, pubKey, nil
 	default:
 		return nil, nil, fmt.Errorf("unsupported TEE type: %v", k.teeType)
 	}

--- a/espresso/key-manager/key_manager.go
+++ b/espresso/key-manager/key_manager.go
@@ -29,6 +29,9 @@ const (
 	EMPTY = espressotee.EMPTY
 )
 
+// This is a private key derived from the test test test ... test junk BIP-39 mnemonic. It is a well known private key, so it should be fine to hardcode for tests.
+// I found it here: https://ethereum.stackexchange.com/questions/147078/hardhat-which-file-is-initial-state-in-such-as-the-mnemonic-and-20-accounts
+const TEST_PERSISTENT_KEY = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 const quoteFile = "/dev/attestation/quote"
 const userDataAttestationFile = "/dev/attestation/user_report_data"
 
@@ -84,6 +87,11 @@ func NewEspressoKeyManager(
 
 	} else if servicePersistentPrivateKey != nil {
 		privKey = servicePersistentPrivateKey
+	} else if teeType == espressotee.TESTS {
+		privKey, err = crypto.HexToECDSA(TEST_PERSISTENT_KEY)
+		if err != nil {
+			log.Crit("Failed to create persistent private key for tests", "err", err)
+		}
 	} else {
 		panic("either keyPairAttestationsPath and chainID must be provided, or servicePersistentPrivateKey must be non-nil")
 	}

--- a/espresso/key-manager/key_manager.go
+++ b/espresso/key-manager/key_manager.go
@@ -187,7 +187,7 @@ func (k *EspressoKeyManager) PrepareRegisterService(getAttestationFunc func([]by
 		if err != nil {
 			return nil, nil, fmt.Errorf("TESTS signing failed: %w", err)
 		}
-		return attestationQuote, pubKey, nil
+		return attestationQuote, signerAddr.Bytes(), nil
 	default:
 		return nil, nil, fmt.Errorf("unsupported TEE type: %v", k.teeType)
 	}
@@ -215,7 +215,6 @@ func (k *EspressoKeyManager) Register(getAttestationFunc func([]byte) ([]byte, e
 	if err != nil {
 		return err
 	}
-
 	err = k.espressoTEEVerifierCaller.RegisterService(k.dataPoster, attestation, data, uint8(k.teeType), k.serviceType)
 	if err != nil {
 		return err

--- a/espresso/key-manager/key_manager_test.go
+++ b/espresso/key-manager/key_manager_test.go
@@ -3,9 +3,11 @@ package keymanager_test
 import (
 	"crypto/ecdsa"
 	"encoding/hex"
+	"fmt"
 	"math/big"
 	"testing"
 
+	hdwallet "github.com/miguelmota/go-ethereum-hdwallet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -52,12 +54,16 @@ func TestEspressoKeyManager(t *testing.T) {
 	mockEspressoNitroTEEVerifier := new(mockNitroEspressoTEEVerifier)
 	mockEspressoNitroTEEVerifier.On("IsPCR0HashRegistered", mock.Anything).Return(true, nil)
 
+	// Generate persistent private key from test mnemonic for tests that need it
+	testMnemonic := "test test test test test test test test test test test junk"
+	persistentPrivKey := GeneratePrivateKeyFromMnemonic(t, testMnemonic, 0)
+
 	// Test initialization
 	t.Run("SGX NewEspressoKeyManager", func(t *testing.T) {
 		mockEspressoTEEVerifierClient := new(mockEspressoTEEVerifier)
 		mockEspressoTEEVerifierClient.On("RegisterService", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockEspressoTEEVerifierClient.On("RegisteredServices", mock.Anything, mock.Anything, mock.Anything).Return(false, nil).Once()
-		km := espresso_key_manager.NewEspressoKeyManager(mockEspressoTEEVerifierClient, dataposter, dataSigner, espresso_key_manager.SGX, espressotee.Test, nil, "")
+		km := espresso_key_manager.NewEspressoKeyManager(mockEspressoTEEVerifierClient, dataposter, dataSigner, espresso_key_manager.SGX, espressotee.Test, persistentPrivKey, "", "", 0)
 		require.NotNil(t, km, "Key manager should not be nil")
 		assert.NotEmpty(t, km.GetCurrentKey(), "Public key should be set")
 		// assert.NotNil(t, km.privKey, "Private key should be set")
@@ -69,10 +75,9 @@ func TestEspressoKeyManager(t *testing.T) {
 	t.Run("SGX Registry", func(t *testing.T) {
 		mockEspressoTEEVerifierClient := new(mockEspressoTEEVerifier)
 		mockEspressoTEEVerifierClient.On("RegisterService", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		// First call: not registered, Second call: registered
 		mockEspressoTEEVerifierClient.On("RegisteredServices", mock.Anything, mock.Anything, mock.Anything).Return(false, nil).Once()
 		mockEspressoTEEVerifierClient.On("RegisteredServices", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Once()
-		km := espresso_key_manager.NewEspressoKeyManager(mockEspressoTEEVerifierClient, dataposter, dataSigner, espresso_key_manager.SGX, espressotee.Test, nil, "")
+		km := espresso_key_manager.NewEspressoKeyManager(mockEspressoTEEVerifierClient, dataposter, dataSigner, espresso_key_manager.SGX, espressotee.Test, persistentPrivKey, "", "", 0)
 		registered := km.HasRegistered()
 		assert.False(t, registered, "Should start unregistered")
 
@@ -105,7 +110,7 @@ func TestEspressoKeyManager(t *testing.T) {
 		mockEspressoTEEVerifierClient := new(mockEspressoTEEVerifier)
 		mockEspressoTEEVerifierClient.On("RegisterService", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockEspressoTEEVerifierClient.On("RegisteredServices", mock.Anything, mock.Anything, mock.Anything).Return(false, nil).Once()
-		km := espresso_key_manager.NewEspressoKeyManager(mockEspressoTEEVerifierClient, dataposter, dataSigner, espresso_key_manager.SGX, espressotee.Test, nil, "")
+		km := espresso_key_manager.NewEspressoKeyManager(mockEspressoTEEVerifierClient, dataposter, dataSigner, espresso_key_manager.SGX, espressotee.Test, persistentPrivKey, "", "", 0)
 		pubKey := km.GetCurrentKey()
 		assert.NotEmpty(t, pubKey, "Public key should not be empty")
 	})
@@ -115,7 +120,7 @@ func TestEspressoKeyManager(t *testing.T) {
 		mockEspressoTEEVerifierClient := new(mockEspressoTEEVerifier)
 		mockEspressoTEEVerifierClient.On("RegisterService", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockEspressoTEEVerifierClient.On("RegisteredServices", mock.Anything, mock.Anything, mock.Anything).Return(false, nil).Once()
-		km := espresso_key_manager.NewEspressoKeyManager(mockEspressoTEEVerifierClient, dataposter, dataSigner, espresso_key_manager.SGX, espressotee.Test, nil, "")
+		km := espresso_key_manager.NewEspressoKeyManager(mockEspressoTEEVerifierClient, dataposter, dataSigner, espresso_key_manager.SGX, espressotee.Test, persistentPrivKey, "", "", 0)
 		message := []byte("test-message")
 		signature, err := km.SignMessage(message)
 		require.NoError(t, err, "Sign should succeed")
@@ -131,7 +136,7 @@ func TestEspressoKeyManager(t *testing.T) {
 		mockEspressoTEEVerifierClient := new(mockEspressoTEEVerifier)
 		mockEspressoTEEVerifierClient.On("RegisterService", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockEspressoTEEVerifierClient.On("RegisteredServices", mock.Anything, mock.Anything, mock.Anything).Return(false, nil).Once()
-		km := espresso_key_manager.NewEspressoKeyManager(mockEspressoTEEVerifierClient, dataposter, dataSigner, espresso_key_manager.SGX, espressotee.Test, nil, "")
+		km := espresso_key_manager.NewEspressoKeyManager(mockEspressoTEEVerifierClient, dataposter, dataSigner, espresso_key_manager.SGX, espressotee.Test, persistentPrivKey, "", "", 0)
 		message := []byte("test-message")
 		signature, err := km.SignPayload(message)
 		require.NoError(t, err, "Sign should succeed")
@@ -151,10 +156,9 @@ func TestEspressoKeyManager(t *testing.T) {
 	t.Run("Nitro Registry", func(t *testing.T) {
 		mockEspressoTEEVerifierClient := new(mockEspressoTEEVerifier)
 		mockEspressoTEEVerifierClient.On("RegisterService", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		// First call: not registered, Second call: registered
 		mockEspressoTEEVerifierClient.On("RegisteredServices", mock.Anything, mock.Anything, mock.Anything).Return(false, nil).Once()
 		mockEspressoTEEVerifierClient.On("RegisteredServices", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Once()
-		km := espresso_key_manager.NewEspressoKeyManager(mockEspressoTEEVerifierClient, dataposter, dataSigner, espresso_key_manager.NITRO, espressotee.Test, nil, "http:/127.0.0.1")
+		km := espresso_key_manager.NewEspressoKeyManager(mockEspressoTEEVerifierClient, dataposter, dataSigner, espresso_key_manager.TESTS, espressotee.Test, persistentPrivKey, "", "", 0)
 		registered := km.HasRegistered()
 		assert.False(t, registered, "Should start unregistered")
 
@@ -164,7 +168,7 @@ func TestEspressoKeyManager(t *testing.T) {
 			called = true
 			pubKeyBytes := crypto.FromECDSAPub(km.GetCurrentKey())
 			assert.Equal(t, pubKeyBytes, data, "Sign function should receive public key")
-			return []byte("mock-signature"), nil
+			return []byte{}, nil
 		}
 
 		// First registration
@@ -188,7 +192,7 @@ func TestEspressoKeyManager(t *testing.T) {
 		mockEspressoTEEVerifierClient := new(mockEspressoTEEVerifier)
 		mockEspressoTEEVerifierClient.On("RegisterService", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockEspressoTEEVerifierClient.On("RegisteredServices", mock.Anything, mock.Anything, mock.Anything).Return(false, nil).Once()
-		km := espresso_key_manager.NewEspressoKeyManager(mockEspressoTEEVerifierClient, dataposter, dataSigner, espresso_key_manager.NITRO, espressotee.Test, nil, "http:/127.0.0.1")
+		km := espresso_key_manager.NewEspressoKeyManager(mockEspressoTEEVerifierClient, dataposter, dataSigner, espresso_key_manager.NITRO, espressotee.Test, persistentPrivKey, "", "", 0)
 		message := []byte("test-message")
 		signature, err := km.SignMessage(message)
 		require.NoError(t, err, "Sign should succeed")
@@ -204,7 +208,7 @@ func TestEspressoKeyManager(t *testing.T) {
 		mockEspressoTEEVerifierClient := new(mockEspressoTEEVerifier)
 		mockEspressoTEEVerifierClient.On("RegisterService", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockEspressoTEEVerifierClient.On("RegisteredServices", mock.Anything, mock.Anything, mock.Anything).Return(false, nil).Once()
-		km := espresso_key_manager.NewEspressoKeyManager(mockEspressoTEEVerifierClient, dataposter, dataSigner, espresso_key_manager.NITRO, espressotee.Test, nil, "http:/127.0.0.1")
+		km := espresso_key_manager.NewEspressoKeyManager(mockEspressoTEEVerifierClient, dataposter, dataSigner, espresso_key_manager.NITRO, espressotee.Test, persistentPrivKey, "", "", 0)
 		message := []byte("test-message")
 		signature, err := km.SignPayload(message)
 		require.NoError(t, err, "Sign should succeed")
@@ -254,3 +258,18 @@ func GetTransactOptsAndSigner(priKey string, chainId *big.Int) (*bind.TransactOp
 }
 
 type DataSignerFunc func([]byte) ([]byte, error)
+
+// GeneratePrivateKeyFromMnemonic generates a private key from a mnemonic phrase
+func GeneratePrivateKeyFromMnemonic(t *testing.T, mnemonic string, index uint) *ecdsa.PrivateKey {
+	wallet, err := hdwallet.NewFromMnemonic(mnemonic)
+	require.NoError(t, err, "Should create wallet from mnemonic")
+
+	path := hdwallet.MustParseDerivationPath(fmt.Sprintf("m/44'/60'/0'/0/%d", index))
+	account, err := wallet.Derive(path, false)
+	require.NoError(t, err, "Should derive account from path")
+
+	privateKey, err := wallet.PrivateKey(account)
+	require.NoError(t, err, "Should get private key from wallet")
+
+	return privateKey
+}

--- a/system_tests/espresso_setup_test.go
+++ b/system_tests/espresso_setup_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/offchainlabs/nitro/cmd/genericconf"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,6 +40,11 @@ func createL1AndL2Node(
 	builder.nodeConfig.BatchPoster.MaxDelay = -1000 * time.Hour
 	builder.nodeConfig.Espresso.BatchPoster.HotShotUrl = hotShotUrl
 	builder.nodeConfig.Espresso.BatchPoster.TeeType = "TESTS"
+	// This is a private key derived from the test test test ... test junk BIP-39 mnemonic. It is a well known private key, so it should be fine to hardcode for tests.
+	// I found it here: https://ethereum.stackexchange.com/questions/147078/hardhat-which-file-is-initial-state-in-such-as-the-mnemonic-and-20-accounts
+	builder.nodeConfig.BatchPoster.ParentChainWallet = genericconf.WalletConfig{
+		PrivateKey: "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+	}
 
 	// validator config
 	builder.nodeConfig.BlockValidator.Enable = true

--- a/system_tests/espresso_setup_test.go
+++ b/system_tests/espresso_setup_test.go
@@ -7,8 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/offchainlabs/nitro/cmd/genericconf"
 	"github.com/stretchr/testify/require"
+
+	"github.com/offchainlabs/nitro/cmd/genericconf"
 )
 
 func createL1AndL2Node(

--- a/system_tests/espresso_setup_test.go
+++ b/system_tests/espresso_setup_test.go
@@ -8,8 +8,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/offchainlabs/nitro/cmd/genericconf"
 )
 
 func createL1AndL2Node(
@@ -41,11 +39,6 @@ func createL1AndL2Node(
 	builder.nodeConfig.BatchPoster.MaxDelay = -1000 * time.Hour
 	builder.nodeConfig.Espresso.BatchPoster.HotShotUrl = hotShotUrl
 	builder.nodeConfig.Espresso.BatchPoster.TeeType = "TESTS"
-	// This is a private key derived from the test test test ... test junk BIP-39 mnemonic. It is a well known private key, so it should be fine to hardcode for tests.
-	// I found it here: https://ethereum.stackexchange.com/questions/147078/hardhat-which-file-is-initial-state-in-such-as-the-mnemonic-and-20-accounts
-	builder.nodeConfig.BatchPoster.ParentChainWallet = genericconf.WalletConfig{
-		PrivateKey: "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
-	}
 
 	// validator config
 	builder.nodeConfig.BlockValidator.Enable = true


### PR DESCRIPTION
Closes Asana Ticket: [Add persistent key storage to batch poster. ](https://app.asana.com/0/home/1209393650288774/1212979769535806)


### This PR:
Adapts the persistant key storage mechanism made for the TEE Caff node to be used by the batch poster via the `EspressoKeyManager`

### This PR does not:

- Add any new tests. This work is not really unit testable as we don't want our CI to be creating things in an AWS KMS. However, I have fixed, the behavior of some tests that were seemingly broken.

- Change the register on startup approach that the batcher takes to registering it's persistent key. This will not affect the batchers behavior, as this code section already has checks (via the key manager) to determine if it has already registered, so nothing weird will happen on any startup after the initial registration.

### Key places to review:

- Private key generation in the key manager tests vs e2e tests. I ended up with 2 different solutions, the one done in the key manager tests was written by claude code, and produces the exact same account as the one I produced for the batch poster, but only because hooking into the batch posters config was the only reasonable way I could see to give it a private key during tests. It's a little "hacky" in the batchers constructor, but it seemed like the easiest way to accomplish something specific to tests.

- All of the changes in `espresso/key-manager/key_manager.go` 

- Construction of the key manager in `arbnode/batch_poster.go` and `arbnode/espresso_caff_node.go`

- Changes to the E2E test to provide the batch poster with a dummy persistent key.

- Changes to `espresso/key-manager/key_manager_test.go`

- Changes to the EspressoTEEVerifierMock contract in espresso-tee-contracts-legacy. I believe this may fix some changes @lukeiannucci was having recently.

### How to test this PR:
Run the E2E test.

### Things tested:

- E2E test is passing locally.

- I will also be testing this against some internal devnet, or against a testnet.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212979769535806