### PR TITLE
feat: move signer registration loop to the verifier

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -2584,7 +2584,7 @@ func (b *BatchPoster) Start(ctxIn context.Context) {
 				return 0
 			}
 			if errors.Is(err, FatalErrUnableToRegisterSigner) {
-				log.Crit(
+				log.Warn(
 					"Espresso signer registration failed consecutively. Stopping.",
 					"retries", espressotee.EspressoMaxRetries,
 					"err", err,

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -2543,7 +2543,7 @@ func (b *BatchPoster) Start(ctxIn context.Context) {
 		nonceTooHighEphemeralErrorHandler.Reset()
 		espressoEphemeralErrorHandler.Reset()
 	}
-	registrationFailCount := 0
+
 	b.CallIteratively(func(ctx context.Context) time.Duration {
 		var err error
 		if common.HexToAddress(b.config().GasRefunderAddress) != (common.Address{}) {
@@ -2584,12 +2584,13 @@ func (b *BatchPoster) Start(ctxIn context.Context) {
 				return 0
 			}
 			if errors.Is(err, FatalErrUnableToRegisterSigner) {
-				registrationFailCount++
-				if registrationFailCount > espressotee.EspressoMaxRetries {
-					log.Crit("Espresso signer registration failed 5 times consecutively. Stopping.", "err", err)
-					b.fatalErrChan <- err
-				}
-				log.Warn("Espresso signer registration failed", "attempt", registrationFailCount, "err", err)
+				log.Crit(
+					"Espresso signer registration failed consecutively. Stopping.",
+					"retries", espressotee.EspressoMaxRetries,
+					"err", err,
+				)
+
+				b.fatalErrChan <- err
 			}
 
 			b.building = nil

--- a/espressotee/espresso_verifier.go
+++ b/espressotee/espresso_verifier.go
@@ -79,13 +79,12 @@ func (e *EspressoTEEVerifier) RegisterService(
 			return nil
 		}
 
-		if attempt < EspressoMaxRetries {
-			log.Warn(
-				"service registration failed",
-				"err", registrationErr,
-				"attempt", attempt+1,
-				"retry_delay", EspressoRetryReadContractDelay,
-			)
+		log.Warn(
+			"service registration failed",
+			"err", registrationErr,
+			"attempt", attempt+1,
+		)
+		if attempt < EspressoMaxRetries-1 {
 			time.Sleep(EspressoRetryReadContractDelay)
 		}
 	}

--- a/espressotee/espresso_verifier.go
+++ b/espressotee/espresso_verifier.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -42,7 +43,6 @@ func NewEspressoTEEVerifier(espressoTEEVerifierAddress string, l1Client *ethclie
 
 	return &EspressoTEEVerifier{espressoTEEVerifierAddress: espressoTEEVerifierAddress, l1Client: l1Client, address: address}
 }
-
 func (e *EspressoTEEVerifier) RegisterService(
 	dataPoster *dataposter.DataPoster,
 	attestation []byte,
@@ -50,14 +50,51 @@ func (e *EspressoTEEVerifier) RegisterService(
 	teeType uint8,
 	serviceType ServiceType,
 ) error {
-	switch serviceType {
-	case CaffNode:
-		return e.registerService(dataPoster, attestation, data, teeType, serviceType)
-	case BatchPoster:
-		return e.registerSigner(dataPoster, attestation, data, teeType)
+	var registrationErr error
+
+	for attempt := 0; attempt < EspressoMaxRetries; attempt++ {
+		switch serviceType {
+		case CaffNode:
+			registrationErr = e.registerService(
+				dataPoster,
+				attestation,
+				data,
+				teeType,
+				serviceType,
+			)
+
+		case BatchPoster:
+			registrationErr = e.registerSigner(
+				dataPoster,
+				attestation,
+				data,
+				teeType,
+			)
+
+		default:
+			return fmt.Errorf("unsupported service type: %d", serviceType)
+		}
+
+		if registrationErr == nil {
+			return nil
+		}
+
+		if attempt < EspressoMaxRetries {
+			log.Warn(
+				"service registration failed",
+				"err", registrationErr,
+				"attempt", attempt+1,
+				"retry_delay", EspressoRetryReadContractDelay,
+			)
+			time.Sleep(EspressoRetryReadContractDelay)
+		}
 	}
 
-	return fmt.Errorf("unsupported service type: %d", serviceType)
+	return fmt.Errorf(
+		"service registration failed after %d attempts: %w",
+		EspressoMaxRetries,
+		registrationErr,
+	)
 }
 
 func (e *EspressoTEEVerifier) registerService(


### PR DESCRIPTION
Closes [Asana Task](https://app.asana.com/1/1208976916964769/project/1212536007593685/task/1212921478189748?focus=true)
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->
- Moves the signer registration failure loop from the `batch_poster.go` to the `espresso_verifier.go`
- It felt weird that the batch poster code has to monitor the signer registration failing and re-run it if it is below the `MaxRetries` limit. Hence `RegisterService` which is the actual function doing the registration seemed like a more intuitive place for this logic. Similar to the [Contract Verification](https://github.com/EspressoSystems/nitro-espresso-integration/blob/9837028f180efa8e763b6ab3500216cdca3e5ccb/espressotee/espresso_tee_helpers.go#L52) logic
- Now `RegisterService` runs the registration till `MaxRetries` on failure and the `batch_poster` receives `FatalErrUnableToRegisterSigner` if it still fails and immediately calls `fatalErr`

### Key places to review:
`espresso_verifier.go`

