### PR TITLE
chore: update nitro test node to latest state

### DIFF
--- a/.github/workflows/espresso-regression.yml
+++ b/.github/workflows/espresso-regression.yml
@@ -76,6 +76,54 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+
+      - name: Install wscat
+        run: npm install -g wscat
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: ./nitro-testnode/rollupcreator
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # Use default branch from test-node.bash
+          build-args: |
+            NITRO_CONTRACTS_BRANCH=develop
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: ./nitro-testnode/scripts
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: ./nitro-testnode/mock-sequencer
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: ./nitro-testnode/tokenbridge
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # Use default branch from test-node.bash
+          build-args: |
+            TOKEN_BRIDGE_BRANCH=v1.2.2
+
       - name: Run regression test
         run: |
           echo "ESPRESSO_VERSION=${{ env.ESPRESSO_VERSION }}"
@@ -86,3 +134,8 @@ jobs:
           fi
           cd nitro-testnode
           ./regression-test.bash
+
+      - name: Dump docker logs on failure
+        if: failure()
+        run: |
+          docker compose logs


### PR DESCRIPTION
Part of [Asana Task](https://app.asana.com/1/1208976916964769/project/1212536007593685/task/1213072202449725?focus=true)
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
- updates the `nitro-testnode` submodule to include the latest config changes (one of the reasons why our regression tests were failing)
- regression tests were failing to call `cast` and `gotestsum`. this also sets up some installation in the CI workflow.



<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->
### Notes
- Regression tests are now running (this was not even starting up previously). See run: https://github.com/EspressoSystems/nitro-espresso-integration/actions/runs/21622118333
- However this will fail in general since `batcher-resubmission.bash` is flaky. Sometimes it catches up and sometimes not. I will make a follow up PR to probably make that test optional to pass in the `nitro-testnode` repo. 

