### PR TITLE
chore: remove tee-verifier-address from caff config

### DIFF
--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -56,9 +56,6 @@ type EspressoCaffNodeConfig struct {
 	Dangerous              DangerousCaffNodeConfig `koanf:"dangerous"`
 	TeeType                string                  `koanf:"tee-type"`
 
-	// SGX specific config, leave empty if not using SGX
-	TEEVerifierAddr string `koanf:"tee-verifier-addr"`
-
 	// AWS Nitro Attestation Service URL
 	AttestationServiceURL string `koanf:"attestation-service-url"`
 
@@ -110,7 +107,6 @@ var DefaultEspressoCaffNodeConfig = EspressoCaffNodeConfig{
 	KeyPairAttestationsPath: "caff_node_key_pair_attestations",
 	TeeType:                 "",
 	AttestationServiceURL:   "",
-	TEEVerifierAddr:         "",
 	DataPoster:              dataposter.DefaultDataPosterConfig,
 	SnapshotChecksum:        "",
 	ParentChainWallet:       DefaultBatchPosterL1WalletConfig,
@@ -136,7 +132,6 @@ func EspressoCaffNodeConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".tee-type", DefaultEspressoCaffNodeConfig.TeeType, "The Trusted Execution Environment (TEE) that Caff node is running in")
 	f.String(prefix+".attestation-service-url", DefaultEspressoBatchPosterConfig.AttestationServiceURL, "URL of the attestation service to use for obtaining zk proof over  attestation")
 	genericconf.WalletConfigAddOptions(prefix+".parent-chain-wallet", f, DefaultBatchPosterConfig.ParentChainWallet.Pathname)
-	f.String(prefix+".tee-verifier-addr", DefaultEspressoCaffNodeConfig.TEEVerifierAddr, "Address of the EspressoTEEVerifier contract utilize for handling cross chain NFT verification")
 	DangerousCaffNodeConfigAddOptions(prefix+".dangerous", f)
 	f.Bool(prefix+".generate-snapshot", DefaultEspressoCaffNodeConfig.GenerateSnapshot, "Configures whether to generate a snapshot")
 	f.Int(prefix+".auth-db-batch-size", DefaultEspressoCaffNodeConfig.AuthDBBatchSize, "Batch size to use when initializing auth tags in the AuthDB")
@@ -227,7 +222,7 @@ func NewEspressoCaffNode(
 		common.HexToAddress(configFetcher().SGXVerifierAddr),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create espressoTEEVerifier: %w", err)
+		return nil, fmt.Errorf("failed to create sgxVerifier: %w", err)
 	}
 	client := espressoClient.NewClient(configFetcher().HotShotUrl)
 
@@ -290,16 +285,9 @@ func NewEspressoCaffNode(
 
 	// Create a new EspressoKeyManager
 	// Get the EspressoTEEVerifier address from SequencerInbox contract
-	configAddress := configFetcher().TEEVerifierAddr
 	var espressoTEEVerifierAddress common.Address
-	// parse the espresso tee verifier address from config if it exists, otherwise read from the sequencerInbox
-	// Eventually we should only read from the SequencerInbox
-	if configAddress != "" && common.IsHexAddress(configAddress) {
-		espressoTEEVerifierAddress = common.HexToAddress(configAddress)
-	} else {
-		espressoTEEVerifierAddress, err = sequencerInbox.con.EspressoTEEVerifier(&bind.CallOpts{})
-	}
-
+	espressoTEEVerifierAddress, err = sequencerInbox.con.EspressoTEEVerifier(&bind.CallOpts{})
+	
 	if err != nil {
 		return nil, fmt.Errorf("failed to get EspressoTEEVerifier address: %w", err)
 	}

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -287,7 +287,7 @@ func NewEspressoCaffNode(
 	// Get the EspressoTEEVerifier address from SequencerInbox contract
 	var espressoTEEVerifierAddress common.Address
 	espressoTEEVerifierAddress, err = sequencerInbox.con.EspressoTEEVerifier(&bind.CallOpts{})
-	
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to get EspressoTEEVerifier address: %w", err)
 	}

--- a/system_tests/caff_node_test.go
+++ b/system_tests/caff_node_test.go
@@ -97,7 +97,6 @@ func createCaffNode(
 	nodeConfig.Espresso.CaffNode.TeeType = existing.nodeConfig.Espresso.CaffNode.TeeType
 	nodeConfig.Espresso.CaffNode.SnapshotChecksum = existing.nodeConfig.Espresso.CaffNode.SnapshotChecksum
 	nodeConfig.Espresso.CaffNode.GenerateSnapshot = existing.nodeConfig.Espresso.CaffNode.GenerateSnapshot
-	nodeConfig.Espresso.CaffNode.TEEVerifierAddr = existing.nodeConfig.Espresso.CaffNode.TEEVerifierAddr
 
 	cleanup, err := builder.BuildEspressoCaffNode(t, existing)
 	builder.L1 = existing.L1
@@ -571,11 +570,6 @@ func TestEspressoCaffNodeSnapshot(t *testing.T) {
 	builderCaffNode.nodeConfig.Espresso.CaffNode.SnapshotChecksum = base64SnapshotFileContent
 	builderCaffNode.nodeConfig.Espresso.CaffNode.TeeType = "TESTS"
 	builderCaffNode.nodeConfig.Espresso.CaffNode.GenerateSnapshot = false
-
-	parentChainTransactionOpts := builderCaffNode.L1Info.GetDefaultTransactOpts("RollupOwner", ctx)
-	espressoTEEVerifierAddress, _, _, err := deployMockTEEContracts(t, &parentChainTransactionOpts, builder.L1.Client)
-	Require(t, err)
-	builderCaffNode.nodeConfig.Espresso.CaffNode.TEEVerifierAddr = espressoTEEVerifierAddress.Hex()
 
 	logHandler := testhelpers.InitTestLog(t, log.LevelInfo)
 	_ = logHandler


### PR DESCRIPTION
While going through the caff node code, I realized we were passing in the `tee-verifier-address` in the config. If this value is nil, we fetch this value from the Sequencer Inbox contract. I think that is the most reliable place to fetch it from. Passing it in config is prone to mistakes. 
Also there was a comment to remove the config value in the future.

optionally, we can remove the `sgx-verifier-address` as well and fetch it from the `SeqInbox -> TeeVerifier -> SGX contract`. Open to suggestions