### PR TITLE
fix: add underflow guard in delayed message fetcher

### DIFF
--- a/arbnode/espresso_delayed_message_fetcher.go
+++ b/arbnode/espresso_delayed_message_fetcher.go
@@ -211,6 +211,10 @@ func (d *DelayedMessageFetcher) getL1BlockNumber(ctx context.Context) (uint64, e
 		if err != nil {
 			return 0, err
 		}
+		if latestBlockNumber < d.requiredBlockDepth {
+			// chain is too young, start from genesis
+			return 0, nil
+		}
 		// Get the latest block - requiredBlockDepth
 		return latestBlockNumber - d.requiredBlockDepth, nil
 	}


### PR DESCRIPTION
[Asana Task](https://github.com/EspressoSystems/nitro-espresso-integration/pull/new/vd/underflow-check)

This adds an underflow check in delayed message fetcher 
In production, this will probably never be an issue but it is possible for brand new chains or devnets so its good to have this check in place