### PR TITLE
fix: stop parsing if sig verification fails

### DIFF
--- a/espressostreamer/espresso_streamer.go
+++ b/espressostreamer/espresso_streamer.go
@@ -361,6 +361,11 @@ func (s *EspressoStreamer) parseEspressoTransaction(tx espressoTypes.Bytes, l1He
 		}
 	}
 
+	// do not proceed with message parsing if the all signature verification paths failed
+	if !success {
+		return fmt.Errorf("all signature verification paths failed for HotShot payload")
+	}
+
 	s.messageLock.Lock()
 	defer s.messageLock.Unlock()
 	for i, message := range messages {

--- a/espressostreamer/espresso_streamer.go
+++ b/espressostreamer/espresso_streamer.go
@@ -359,6 +359,7 @@ func (s *EspressoStreamer) parseEspressoTransaction(tx espressoTypes.Bytes, l1He
 			log.Warn("failed to verify attestation quote", "err", err)
 			return err
 		}
+		success = true
 	}
 
 	// do not proceed with message parsing if the all signature verification paths failed


### PR DESCRIPTION
[Asana Task](https://app.asana.com/1/1208976916964769/project/1209976130071762/task/1213739697090132?focus=true)

Previously, the code would continue parsing messages even if all signature verification paths fail...this adds a check such that it will only parse messages if sig verification passes.