### PR TITLE
fix: rm use of EspressoRollupSequencerManager

### DIFF
--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -1793,9 +1793,6 @@ func deployOnParentChain(
 	_, err = parentChainReader.WaitForTxApproval(ctx, tx)
 	Require(t, err)
 
-	_, err = parentChainReader.WaitForTxApproval(ctx, tx)
-	Require(t, err)
-
 	var addresses *chaininfo.RollupAddresses
 	if deployBold {
 		stakeToken, tx, _, err := localgen.DeployTestWETH9(

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -72,7 +72,6 @@ import (
 	"github.com/offchainlabs/nitro/daprovider/das/dastree"
 	"github.com/offchainlabs/nitro/daprovider/das/dasutil"
 	"github.com/offchainlabs/nitro/deploy"
-	"github.com/offchainlabs/nitro/espresso-tee-contracts/espressogen"
 	"github.com/offchainlabs/nitro/espresso/authdb"
 	"github.com/offchainlabs/nitro/execution/gethexec"
 	_ "github.com/offchainlabs/nitro/execution/nodeInterface"
@@ -1794,11 +1793,6 @@ func deployOnParentChain(
 	_, err = parentChainReader.WaitForTxApproval(ctx, tx)
 	Require(t, err)
 
-	rollupSequencerManagerAddress, tx, _, err := espressogen.DeployEspressoRollupSequencerManager(&parentChainTransactionOpts, parentChainClient, []common.Address{
-		parentChainInfo.GetAddress("Sequencer"),
-	})
-	Require(t, err)
-
 	_, err = parentChainReader.WaitForTxApproval(ctx, tx)
 	Require(t, err)
 
@@ -1902,7 +1896,6 @@ func deployOnParentChain(
 	parentChainInfo.SetContract("Inbox", addresses.Inbox)
 	parentChainInfo.SetContract("UpgradeExecutor", addresses.UpgradeExecutor)
 	parentChainInfo.SetContract("EspressoTEEVerifierMock", espressoTEEVerifierAddress)
-	parentChainInfo.SetContract("RollupSequencerManager", rollupSequencerManagerAddress)
 	initMessage := getInitMessage(ctx, t, parentChainClient, addresses)
 	return addresses, initMessage
 }


### PR DESCRIPTION
Part of [Asana Task](https://app.asana.com/1/1208976916964769/project/1209976130071762/task/1213738299556180?focus=true)

`EspressoRollupSequencerManager` is no longer being used and should be removed from this repository.
Parent PR to remove the contract from the `tee-contracts` repo is [here](https://github.com/EspressoSystems/espresso-tee-contracts/pull/61)