### PR TITLE
fix: dont count nonce mismatch as registration fail

### DIFF
--- a/espressotee/espresso_tee_helpers.go
+++ b/espressotee/espresso_tee_helpers.go
@@ -2,6 +2,7 @@ package espressotee
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -11,6 +12,10 @@ import (
 
 	"github.com/offchainlabs/nitro/arbnode/dataposter"
 )
+
+// ErrNonceValidation should not increment the signer registration attempt
+// as the database may need time to sync state from l1 and update itself
+var ErrNonceValidation = errors.New("nonce validation error")
 
 type TEE uint8
 
@@ -81,16 +86,16 @@ func NonceValidation(context context.Context, l1Client *ethclient.Client, dataPo
 	nonce, err := l1Client.NonceAt(context, dataPoster.Sender(), nil)
 	if err != nil {
 		log.Warn("could not retrieve on-chain nonce", "err", err)
-		return err
+		return fmt.Errorf("%w: %w", ErrNonceValidation, err)
 	}
 	dataPosterNonce, _, err := dataPoster.GetNextNonceAndMeta(context)
 	if err != nil {
 		log.Warn("error getting dataposter nonce", "err", err)
-		return err
+		return fmt.Errorf("%w: %w", ErrNonceValidation, err)
 	}
 	log.Info("successfully got datapaster next nonce and on-chain nonce", "dataposter nonce", dataPosterNonce, "on-chain nonce", nonce)
 	if dataPosterNonce != nonce {
-		return fmt.Errorf("dataposter nonce %d does not match on-chain nonce %d", dataPosterNonce, nonce)
+		return fmt.Errorf("%w: dataposter nonce %d does not match on-chain nonce %d", ErrNonceValidation, dataPosterNonce, nonce)
 	}
 	return nil
 }

--- a/espressotee/espresso_tee_helpers_test.go
+++ b/espressotee/espresso_tee_helpers_test.go
@@ -92,6 +92,9 @@ func TestEspressoNonceValidationMismatch(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for nonce mismatch, got nil")
 	}
+	if !errors.Is(err, ErrNonceValidation) {
+		t.Fatalf("expected ErrNonceValidation, got: %v", err)
+	}
 }
 
 // Both sides agree on nonce 5 — should pass.

--- a/espressotee/espresso_verifier.go
+++ b/espressotee/espresso_verifier.go
@@ -55,7 +55,7 @@ func (e *EspressoTEEVerifier) RegisterService(
 ) error {
 	var registrationErr error
 
-	for attempt := 0; attempt < EspressoMaxRetries; attempt++ {
+	for attempt := 0; attempt < EspressoMaxRetries; {
 		registrationErr = e.registerService(
 			dataPoster,
 			attestation,
@@ -68,12 +68,22 @@ func (e *EspressoTEEVerifier) RegisterService(
 			return nil
 		}
 
+		if errors.Is(registrationErr, ErrNonceValidation) {
+			log.Warn(
+				"nonce validation error during service registration, retrying without counting as failure",
+				"err", registrationErr,
+			)
+			time.Sleep(EspressoRetryReadContractDelay)
+			continue
+		}
+
+		attempt++
 		log.Warn(
 			"service registration failed",
 			"err", registrationErr,
-			"attempt", attempt+1,
+			"attempt", attempt,
 		)
-		if attempt < EspressoMaxRetries-1 {
+		if attempt < EspressoMaxRetries {
 			time.Sleep(EspressoRetryReadContractDelay)
 		}
 	}

--- a/espressotee/espresso_verifier_test.go
+++ b/espressotee/espresso_verifier_test.go
@@ -1,0 +1,101 @@
+package espressotee
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// registrationAttemptStub drives TestEspressoRegistrationNonceErrorsNotCounted.
+//
+// For the first mismatchFor calls to eth_estimateGas it returns success while
+// responding to eth_getTransactionCount with a nonce that never matches the
+// DataPoster's nonce, so NonceValidation returns ErrNonceValidation.
+// Once mismatchFor is exceeded, eth_estimateGas starts returning an error,
+// producing a non-nonce failure that does count as a registration attempt.
+type registrationAttemptStub struct {
+	estimateGasCalls int
+	mismatchFor      int
+	l1Nonce          uint64 // always returned for eth_getTransactionCount
+}
+
+func (s *registrationAttemptStub) CallContext(_ context.Context, result interface{}, method string, _ ...interface{}) error {
+	switch method {
+	case "eth_estimateGas":
+		s.estimateGasCalls++
+		if s.estimateGasCalls > s.mismatchFor {
+			return errors.New("simulated gas estimation failure")
+		}
+		if ptr, ok := result.(*hexutil.Uint64); ok {
+			*ptr = 0
+		}
+	case "eth_getTransactionCount":
+		if ptr, ok := result.(*hexutil.Uint64); ok {
+			*ptr = hexutil.Uint64(s.l1Nonce)
+		}
+	case "eth_getBlockByNumber":
+		if ptr, ok := result.(**types.Header); ok {
+			*ptr = &types.Header{Number: big.NewInt(1)}
+		}
+	}
+	return nil
+}
+
+func (s *registrationAttemptStub) EthSubscribe(_ context.Context, _ interface{}, _ ...interface{}) (*rpc.ClientSubscription, error) {
+	return nil, nil
+}
+
+func (s *registrationAttemptStub) BatchCallContext(_ context.Context, _ []rpc.BatchElem) error {
+	return nil
+}
+
+func (s *registrationAttemptStub) Close() {}
+
+// TestEspressoRegistrationNonceErrorsNotCounted verifies that ErrNonceValidation
+// errors do not consume registration attempt slots.
+func TestEspressoRegistrationNonceErrorsNotCounted(t *testing.T) {
+	t.Parallel()
+
+	const (
+		dataPosterNonce = uint64(5)
+		l1MismatchNonce = uint64(6) // never matches dataPosterNonce
+		mismatchFor     = 1         // one nonce error before EstimateGas starts failing
+	)
+
+	ctx := context.Background()
+	sender := common.HexToAddress("0xdeadbeef")
+
+	stub := &registrationAttemptStub{
+		mismatchFor: mismatchFor,
+		l1Nonce:     l1MismatchNonce,
+	}
+
+	dp := buildDataPoster(t, ctx, dataPosterNonce, sender)
+	verifier := &EspressoTEEVerifier{
+		l1Client: ethclient.NewClient(stub),
+		address:  common.HexToAddress("0x1234"),
+	}
+
+	err := verifier.RegisterService(dp, []byte("attestation"), []byte("data"), uint8(SGX), Test)
+	if err == nil {
+		t.Fatal("expected RegisterService to fail, got nil")
+	}
+
+	// Nonce errors don't count → loop runs a full EspressoMaxRetries real failures
+	// on top of the mismatchFor nonce-only calls.
+	expected := mismatchFor + EspressoMaxRetries
+	if stub.estimateGasCalls != expected {
+		t.Fatalf(
+			"expected %d EstimateGas calls (%d nonce errors + %d real failures), got %d — "+
+				"nonce errors may be incorrectly counted as registration attempts",
+			expected, mismatchFor, EspressoMaxRetries, stub.estimateGasCalls,
+		)
+	}
+}


### PR DESCRIPTION
[Asana Ticket](https://app.asana.com/1/1208976916964769/project/1209976130071762/task/1213799839230737?focus=true)

This PR makes it so that we don't count Nonce Validation errors as a signer registration fail. 
Test added: TestEspressoRegistrationNonceErrorsNotCounted