### PR TITLE
fix: espresso caff node test

### DIFF
--- a/.github/workflows/_fast.yml
+++ b/.github/workflows/_fast.yml
@@ -17,10 +17,10 @@ jobs:
         uses: ./.github/actions/ci-setup
 
       - name: Build
-        run: make -j8 build test-go-deps
+        run: make -j4 build test-go-deps
 
       - name: Build all lint dependencies
-        run: make -j8 build-node-deps
+        run: make -j build-node-deps
 
       - name: GolangCI Lint
         uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/_go-tests.yml
+++ b/.github/workflows/_go-tests.yml
@@ -35,7 +35,7 @@ jobs:
           echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> "$GITHUB_ENV"
 
       - name: Build
-        run: make -j8 build test-go-deps
+        run: make -j4 build test-go-deps
 
       - name: Build all lint dependencies
         run: make -j8 build-node-deps

--- a/arbitrator/stylus/tests/.cargo/config.toml
+++ b/arbitrator/stylus/tests/.cargo/config.toml
@@ -1,5 +1,6 @@
 [build]
 target = "wasm32-unknown-unknown"
+jobs = 2
 
 [target.wasm32-unknown-unknown]
 rustflags = [

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -932,8 +932,7 @@ func (b *NodeBuilder) BuildEspressoCaffNode(t *testing.T, existing *NodeBuilder)
 	privKey := existing.L1Info.GetInfoWithPrivKey("User").PrivateKey
 
 	t.Setenv("CAFF_NODE_PRIV_KEY", common.Bytes2Hex(crypto.FromECDSA(privKey)))
-	b.L2Info, b.L2.Stack, chainDb, arbDb, blockchain = createL2BlockChain(
-		t, b.L2Info, b.dataDir, b.chainConfig, b.l2StackConfig, b.execConfig)
+	b.L2Info, b.L2.Stack, chainDb, arbDb, blockchain = createL2BlockChain(t, b.L2Info, b.dataDir, b.chainConfig, existing.initMessage, b.l2StackConfig, b.execConfig)
 
 	Require(t, b.execConfig.Validate())
 	execConfig := b.execConfig
@@ -2453,9 +2452,9 @@ func recordBlock(t *testing.T, block uint64, builder *NodeBuilder, targets ...ra
 }
 
 func createL2BlockChain(
-	t *testing.T, l2info *BlockchainTestInfo, dataDir string, chainConfig *params.ChainConfig, nodeConf *node.Config, execConfig *gethexec.Config,
+	t *testing.T, l2info *BlockchainTestInfo, dataDir string, chainConfig *params.ChainConfig, initMessage *arbostypes.ParsedInitMessage, nodeConf *node.Config, execConfig *gethexec.Config,
 ) (*BlockchainTestInfo, *node.Node, ethdb.Database, ethdb.Database, *core.BlockChain) {
-	return createNonL1BlockChainWithStackConfig(t, l2info, dataDir, chainConfig, nil, nil, nodeConf, execConfig, nil)
+	return createNonL1BlockChainWithStackConfig(t, l2info, dataDir, chainConfig, nil, initMessage, nodeConf, execConfig, nil)
 }
 
 func populateMachineDir(t *testing.T, cr *github.ConsensusRelease) string {

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -945,6 +945,7 @@ func (b *NodeBuilder) BuildEspressoCaffNode(t *testing.T, existing *NodeBuilder)
 	Require(t, err)
 
 	b.L1Info = existing.L1Info
+	b.initMessage = existing.initMessage
 
 	teeHMAC, err := espresso_tee_utils.HmacForTest()
 	Require(t, err)


### PR DESCRIPTION
[Asana Task](https://app.asana.com/1/1208976916964769/project/1212536007593685/task/1214022608054550?focus=true)

Caff node tests are failing in `integration-v3.9.8`. This PR fixes the test.