### PR TITLE
fix: reject TESTS tee type with production service type

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -623,12 +623,15 @@ func NewBatchPoster(ctx context.Context, opts *BatchPosterOpts) (*BatchPoster, e
 		if b.dataPoster.Auth() == nil {
 			panic("TransactOpts is nil")
 		}
-		// to support tests, we can give the batch poster a "persistent key" via the config, This variable WILL be nil if the configured tee type is not TESTS
+		batchPosterServiceType := espressotee.BatchPoster
+		if teeType == espressotee.TESTS {
+			batchPosterServiceType = espressotee.Test
+		}
 		submitterOptions = append(
 			submitterOptions,
 			// TODO: pass the persistent private key to the key manager in future
 			submitter.WithKeyManager(
-				espresso_key_manager.NewEspressoKeyManager(verifier, b.dataPoster, opts.DataSigner, teeType, espressotee.BatchPoster, nil, opts.EspressoConfigFetcher().BatchPoster.AttestationServiceURL, opts.EspressoConfigFetcher().BatchPoster.KeyPairAttestationsPath, opts.ChainID),
+				espresso_key_manager.NewEspressoKeyManager(verifier, b.dataPoster, opts.DataSigner, teeType, batchPosterServiceType, nil, opts.EspressoConfigFetcher().BatchPoster.AttestationServiceURL, opts.EspressoConfigFetcher().BatchPoster.KeyPairAttestationsPath, opts.ChainID),
 			),
 		)
 

--- a/arbnode/espresso_caff_node.go
+++ b/arbnode/espresso_caff_node.go
@@ -338,7 +338,11 @@ func NewEspressoCaffNode(
 			return nil, fmt.Errorf("failed to create data poster: %w", err)
 		}
 
-		keyManager = espresso_key_manager.NewEspressoKeyManager(verifier, dataPoster, nil, teeType, espressotee.CaffNode, caffNodeInitArgs.CaffNodePrivateKey, configFetcher().AttestationServiceURL, "", 0)
+		caffNodeServiceType := espressotee.CaffNode
+		if teeType == espressotee.TESTS {
+			caffNodeServiceType = espressotee.Test
+		}
+		keyManager = espresso_key_manager.NewEspressoKeyManager(verifier, dataPoster, nil, teeType, caffNodeServiceType, caffNodeInitArgs.CaffNodePrivateKey, configFetcher().AttestationServiceURL, "", 0)
 
 	}
 	initializeCaffNodeTags := false

--- a/espresso/key-manager/key_manager.go
+++ b/espresso/key-manager/key_manager.go
@@ -300,10 +300,32 @@ func (k *EspressoKeyManager) prepareRegisterService(getAttestationFunc func([]by
 		if err != nil {
 			return nil, nil, fmt.Errorf("TESTS signing failed: %w", err)
 		}
-		return attestationQuote, signerAddr.Bytes(), nil
+		// TESTS maps to NITRO on-chain; Nitro mock expects `output` to be an
+		// ABI-encoded VerifierJournal containing the signer public key.
+		journalBytes, err := k.encodeNitroMockJournalByService(attestationQuote)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to encode Nitro mock VerifierJournal for TESTS registration: %w", err)
+		}
+		// Proof bytes are ignored by the Nitro mock.
+		return journalBytes, []byte{}, nil
 	default:
 		return nil, nil, fmt.Errorf("unsupported TEE type: %v", k.teeType)
 	}
+}
+
+func (k *EspressoKeyManager) encodeNitroMockJournalByService(publicKey []byte) ([]byte, error) {
+	if k.onChainServiceType() == espressotee.BatchPoster {
+		return encodeNitroMockBatchPosterVerifierJournalPublicKey(publicKey)
+	}
+	return encodeNitroMockCaffNodeVerifierJournalPublicKey(publicKey)
+}
+
+func encodeNitroMockBatchPosterVerifierJournalPublicKey(publicKey []byte) ([]byte, error) {
+	return espressotee.EncodeNitroMockVerifierJournalPublicKey(publicKey)
+}
+
+func encodeNitroMockCaffNodeVerifierJournalPublicKey(publicKey []byte) ([]byte, error) {
+	return espressotee.EncodeNitroMockVerifierJournalPublicKey(publicKey)
 }
 
 func (k *EspressoKeyManager) initRegistration(getAttestationFunc func([]byte) ([]byte, error)) (*state, error) {

--- a/espresso/key-manager/key_manager.go
+++ b/espresso/key-manager/key_manager.go
@@ -83,8 +83,6 @@ type EspressoKeyManager struct {
 	dataPoster  *dataposter.DataPoster
 	teeType     espressotee.TEE
 	serviceType espressotee.ServiceType
-	// contractServiceType is what we send on-chain; the contract rejects Test (255).
-	contractServiceType espressotee.ServiceType
 
 	espressoNitroAttestationVerifierClient *attestationverifierclient.EspressoAttestationVerifierClient
 	parentChainId                          uint64
@@ -135,17 +133,6 @@ func NewEspressoKeyManager(
 		panic(fmt.Sprintf("fatal misconfiguration: TeeType=TESTS requires serviceType=Test, got serviceType=%v", serviceType))
 	}
 
-	// The contract rejects Test (255). Infer the production service type from
-	// the signer: batch posters have one, caff nodes don't.
-	contractServiceType := serviceType
-	if teeType == TESTS {
-		if signerFunc != nil {
-			contractServiceType = espressotee.BatchPoster
-		} else {
-			contractServiceType = espressotee.CaffNode
-		}
-	}
-
 	if signerFunc == nil && serviceType != espressotee.CaffNode && serviceType != espressotee.Test {
 		panic("DataSigner is nil")
 	}
@@ -171,7 +158,6 @@ func NewEspressoKeyManager(
 		dataPoster:                             dataPoster,
 		teeType:                                teeType,
 		serviceType:                            serviceType,
-		contractServiceType:                    contractServiceType,
 		espressoNitroAttestationVerifierClient: espressoNitroAttestationVerifierClient,
 		parentChainId:                          parentChainId,
 		state: state{
@@ -180,6 +166,28 @@ func NewEspressoKeyManager(
 			data:         []byte{},
 		},
 	}
+}
+
+// onChainTeeType is the tee type we send to the on-chain contract, which
+// only accepts SGX or NITRO. TESTS is mapped to SGX.
+func (k *EspressoKeyManager) onChainTeeType() espressotee.TEE {
+	if k.teeType == TESTS {
+		return SGX
+	}
+	return k.teeType
+}
+
+// onChainServiceType is the service type we send to the on-chain contract,
+// which only accepts BatchPoster or CaffNode. When in TESTS mode we infer
+// the production type from whether a data signer was provided.
+func (k *EspressoKeyManager) onChainServiceType() espressotee.ServiceType {
+	if k.teeType == TESTS {
+		if k.signer != nil {
+			return espressotee.BatchPoster
+		}
+		return espressotee.CaffNode
+	}
+	return k.serviceType
 }
 
 func (k *EspressoKeyManager) hasRegistered() bool {
@@ -199,7 +207,7 @@ func (k *EspressoKeyManager) verifyRegistrationOnChain() (bool, error) {
 		panic("failed to get public key")
 	}
 	signerAddr := crypto.PubkeyToAddress(*pubKey)
-	ok, err := k.espressoTEEVerifierCaller.RegisteredServices(signerAddr, k.teeType, k.contractServiceType)
+	ok, err := k.espressoTEEVerifierCaller.RegisteredServices(signerAddr, k.onChainTeeType(), k.onChainServiceType())
 	if err != nil {
 		return false, err
 	}
@@ -288,17 +296,21 @@ func (k *EspressoKeyManager) prepareRegisterService(getAttestationFunc func([]by
 
 		log.Info("successfully generated zk proof from nitro attestation")
 		return journalBytes, onchainProofBytes, nil
+	case TESTS:
+		pubKey := crypto.FromECDSAPub(&k.privKey.PublicKey)
+		log.Info("TESTS signing address", "addr", signerAddr)
+
+		attestationQuote, err := getAttestationFunc(pubKey)
+		if err != nil {
+			return nil, nil, fmt.Errorf("TESTS signing failed: %w", err)
+		}
+		return attestationQuote, signerAddr.Bytes(), nil
 	default:
 		return nil, nil, fmt.Errorf("unsupported TEE type: %v", k.teeType)
 	}
 }
 
 func (k *EspressoKeyManager) initRegistration(getAttestationFunc func([]byte) ([]byte, error)) (*state, error) {
-	// The on-chain contract only accepts SGX or NITRO.
-	if k.teeType == TESTS {
-		k.teeType = SGX
-	}
-
 	hasRegistered, err := k.verifyRegistrationOnChain()
 	if err != nil {
 		return nil, err
@@ -341,7 +353,7 @@ func (k *EspressoKeyManager) registerService() error {
 	if currentState != PendingRegistration {
 		return fmt.Errorf("invalid state to register signer: got %v, want PendingRegistration", currentState)
 	}
-	err := k.espressoTEEVerifierCaller.RegisterService(k.dataPoster, k.state.attestation, k.state.data, uint8(k.teeType), k.contractServiceType)
+	err := k.espressoTEEVerifierCaller.RegisterService(k.dataPoster, k.state.attestation, k.state.data, uint8(k.onChainTeeType()), k.onChainServiceType())
 	if err != nil {
 		return err
 	}
@@ -366,8 +378,10 @@ func (k *EspressoKeyManager) GetCurrentKey() *ecdsa.PublicKey {
 	return &k.privKey.PublicKey
 }
 
+// TeeType returns the tee type registered on-chain. Callers (e.g. the batch
+// poster building its on-chain payload) need to match what the contract saw.
 func (k *EspressoKeyManager) TeeType() espressotee.TEE {
-	return k.teeType
+	return k.onChainTeeType()
 }
 
 func (k *EspressoKeyManager) SignPayload(message []byte) ([]byte, error) {
@@ -380,8 +394,9 @@ func (k *EspressoKeyManager) SignMessage(message []byte) ([]byte, error) {
 }
 
 func (k *EspressoKeyManager) init() (*state, error) {
-	teeType := k.TeeType()
-	switch teeType {
+	// Dispatch on the configured tee type, not the on-chain one: TESTS must
+	// use noOpSignerFunc even though it registers on-chain as SGX.
+	switch k.teeType {
 	case SGX:
 		return k.initRegistration(k.getAttestationQuote)
 	case NITRO:
@@ -389,7 +404,7 @@ func (k *EspressoKeyManager) init() (*state, error) {
 	case TESTS:
 		return k.initRegistration(k.noOpSignerFunc)
 	default:
-		return nil, fmt.Errorf("unsupported tee Type: %d", teeType)
+		return nil, fmt.Errorf("unsupported tee Type: %d", k.teeType)
 	}
 }
 

--- a/espresso/key-manager/key_manager.go
+++ b/espresso/key-manager/key_manager.go
@@ -169,10 +169,10 @@ func NewEspressoKeyManager(
 }
 
 // onChainTeeType is the tee type we send to the on-chain contract, which
-// only accepts SGX or NITRO. TESTS is mapped to SGX.
+// only accepts SGX or NITRO. TESTS is mapped to NITRO.
 func (k *EspressoKeyManager) onChainTeeType() espressotee.TEE {
 	if k.teeType == TESTS {
-		return SGX
+		return NITRO
 	}
 	return k.teeType
 }

--- a/espresso/key-manager/key_manager.go
+++ b/espresso/key-manager/key_manager.go
@@ -83,6 +83,8 @@ type EspressoKeyManager struct {
 	dataPoster  *dataposter.DataPoster
 	teeType     espressotee.TEE
 	serviceType espressotee.ServiceType
+	// contractServiceType is what we send on-chain; the contract rejects Test (255).
+	contractServiceType espressotee.ServiceType
 
 	espressoNitroAttestationVerifierClient *attestationverifierclient.EspressoAttestationVerifierClient
 	parentChainId                          uint64
@@ -127,9 +129,24 @@ func NewEspressoKeyManager(
 		panic("either keyPairAttestationsPath and chainID must be provided, or servicePersistentPrivateKey must be non-nil")
 	}
 
-	// Currently the caff node will not need to sign any payloads, so we check if the service type is a caff node
-	// and if it is we can safely ignore a nil data signer.
-	if signerFunc == nil && serviceType != espressotee.CaffNode {
+	// Guard against a production node with TeeType=TESTS: it would register the
+	// well-known test key on-chain as SGX-attested with no real attestation.
+	if teeType == TESTS && serviceType != espressotee.Test {
+		panic(fmt.Sprintf("fatal misconfiguration: TeeType=TESTS requires serviceType=Test, got serviceType=%v", serviceType))
+	}
+
+	// The contract rejects Test (255). Infer the production service type from
+	// the signer: batch posters have one, caff nodes don't.
+	contractServiceType := serviceType
+	if teeType == TESTS {
+		if signerFunc != nil {
+			contractServiceType = espressotee.BatchPoster
+		} else {
+			contractServiceType = espressotee.CaffNode
+		}
+	}
+
+	if signerFunc == nil && serviceType != espressotee.CaffNode && serviceType != espressotee.Test {
 		panic("DataSigner is nil")
 	}
 
@@ -154,6 +171,7 @@ func NewEspressoKeyManager(
 		dataPoster:                             dataPoster,
 		teeType:                                teeType,
 		serviceType:                            serviceType,
+		contractServiceType:                    contractServiceType,
 		espressoNitroAttestationVerifierClient: espressoNitroAttestationVerifierClient,
 		parentChainId:                          parentChainId,
 		state: state{
@@ -181,7 +199,7 @@ func (k *EspressoKeyManager) verifyRegistrationOnChain() (bool, error) {
 		panic("failed to get public key")
 	}
 	signerAddr := crypto.PubkeyToAddress(*pubKey)
-	ok, err := k.espressoTEEVerifierCaller.RegisteredServices(signerAddr, k.teeType, k.serviceType)
+	ok, err := k.espressoTEEVerifierCaller.RegisteredServices(signerAddr, k.teeType, k.contractServiceType)
 	if err != nil {
 		return false, err
 	}
@@ -270,23 +288,14 @@ func (k *EspressoKeyManager) prepareRegisterService(getAttestationFunc func([]by
 
 		log.Info("successfully generated zk proof from nitro attestation")
 		return journalBytes, onchainProofBytes, nil
-	case TESTS:
-		pubKey := crypto.FromECDSAPub(&k.privKey.PublicKey)
-		log.Info("TESTS signing address", "addr", signerAddr)
-
-		attestationQuote, err := getAttestationFunc(pubKey)
-		if err != nil {
-			return nil, nil, fmt.Errorf("TESTS signing failed: %w", err)
-		}
-		return attestationQuote, signerAddr.Bytes(), nil
 	default:
 		return nil, nil, fmt.Errorf("unsupported TEE type: %v", k.teeType)
 	}
 }
 
 func (k *EspressoKeyManager) initRegistration(getAttestationFunc func([]byte) ([]byte, error)) (*state, error) {
-	// In tests we use TESTS tee type but the contract only accepts SGX tee type
-	if k.teeType == TESTS && k.serviceType != espressotee.Test {
+	// The on-chain contract only accepts SGX or NITRO.
+	if k.teeType == TESTS {
 		k.teeType = SGX
 	}
 
@@ -332,7 +341,7 @@ func (k *EspressoKeyManager) registerService() error {
 	if currentState != PendingRegistration {
 		return fmt.Errorf("invalid state to register signer: got %v, want PendingRegistration", currentState)
 	}
-	err := k.espressoTEEVerifierCaller.RegisterService(k.dataPoster, k.state.attestation, k.state.data, uint8(k.teeType), k.serviceType)
+	err := k.espressoTEEVerifierCaller.RegisterService(k.dataPoster, k.state.attestation, k.state.data, uint8(k.teeType), k.contractServiceType)
 	if err != nil {
 		return err
 	}

--- a/espresso/key-manager/key_manager.go
+++ b/espresso/key-manager/key_manager.go
@@ -127,8 +127,7 @@ func NewEspressoKeyManager(
 		panic("either keyPairAttestationsPath and chainID must be provided, or servicePersistentPrivateKey must be non-nil")
 	}
 
-	// Guard against a production node with TeeType=TESTS: it would register the
-	// well-known test key on-chain as SGX-attested with no real attestation.
+	// Production guard: TESTS with a non-Test serviceType would register the test key unattested.
 	if teeType == TESTS && serviceType != espressotee.Test {
 		panic(fmt.Sprintf("fatal misconfiguration: TeeType=TESTS requires serviceType=Test, got serviceType=%v", serviceType))
 	}
@@ -168,8 +167,7 @@ func NewEspressoKeyManager(
 	}
 }
 
-// onChainTeeType is the tee type we send to the on-chain contract, which
-// only accepts SGX or NITRO. TESTS is mapped to NITRO.
+// Contract only accepts SGX/NITRO; TESTS → NITRO.
 func (k *EspressoKeyManager) onChainTeeType() espressotee.TEE {
 	if k.teeType == TESTS {
 		return NITRO
@@ -177,9 +175,7 @@ func (k *EspressoKeyManager) onChainTeeType() espressotee.TEE {
 	return k.teeType
 }
 
-// onChainServiceType is the service type we send to the on-chain contract,
-// which only accepts BatchPoster or CaffNode. When in TESTS mode we infer
-// the production type from whether a data signer was provided.
+// Contract only accepts BatchPoster/CaffNode; infer from signer presence when in TESTS.
 func (k *EspressoKeyManager) onChainServiceType() espressotee.ServiceType {
 	if k.teeType == TESTS {
 		if k.signer != nil {
@@ -378,8 +374,7 @@ func (k *EspressoKeyManager) GetCurrentKey() *ecdsa.PublicKey {
 	return &k.privKey.PublicKey
 }
 
-// TeeType returns the tee type registered on-chain. Callers (e.g. the batch
-// poster building its on-chain payload) need to match what the contract saw.
+// Returns the on-chain tee type (callers building payloads need to match the contract).
 func (k *EspressoKeyManager) TeeType() espressotee.TEE {
 	return k.onChainTeeType()
 }
@@ -394,8 +389,7 @@ func (k *EspressoKeyManager) SignMessage(message []byte) ([]byte, error) {
 }
 
 func (k *EspressoKeyManager) init() (*state, error) {
-	// Dispatch on the configured tee type, not the on-chain one: TESTS must
-	// use noOpSignerFunc even though it registers on-chain as SGX.
+	// Dispatch on configured tee type, not on-chain: TESTS needs noOpSignerFunc.
 	switch k.teeType {
 	case SGX:
 		return k.initRegistration(k.getAttestationQuote)

--- a/espresso/key-manager/key_manager_test.go
+++ b/espresso/key-manager/key_manager_test.go
@@ -252,7 +252,7 @@ func TestEspressoKeyManager(t *testing.T) {
 	})
 }
 
-func TestEspressoKeyManagerTestsTeeTypeWithProductionServiceTypePanics(t *testing.T) {
+func TestEspressoKeyManagerTestsTeeTypeServiceTypeValidation(t *testing.T) {
 	mockClient := new(mockEspressoTEEVerifier)
 	mockClient.On("ParentChainId").Return(uint64(1), nil)
 	mockClient.On("EspressoTEEAddress").Return(common.Address{})
@@ -261,47 +261,21 @@ func TestEspressoKeyManagerTestsTeeTypeWithProductionServiceTypePanics(t *testin
 	require.NoError(t, err)
 	dataSigner := func(data []byte) ([]byte, error) { return signer(data) }
 
-	require.Panics(t, func() {
+	newKM := func(sig func([]byte) ([]byte, error), svc espressotee.ServiceType) {
 		espresso_key_manager.NewEspressoKeyManager(
-			mockClient, &dataposter.DataPoster{}, dataSigner,
-			espresso_key_manager.TESTS, espressotee.BatchPoster,
+			mockClient, &dataposter.DataPoster{}, sig,
+			espresso_key_manager.TESTS, svc,
 			nil, "", "", 0,
 		)
-	})
+	}
 
-	require.Panics(t, func() {
-		espresso_key_manager.NewEspressoKeyManager(
-			mockClient, &dataposter.DataPoster{}, nil,
-			espresso_key_manager.TESTS, espressotee.CaffNode,
-			nil, "", "", 0,
-		)
-	})
-}
+	// TESTS paired with a production service type is a fatal misconfiguration.
+	require.Panics(t, func() { newKM(dataSigner, espressotee.BatchPoster) })
+	require.Panics(t, func() { newKM(nil, espressotee.CaffNode) })
 
-func TestEspressoKeyManagerTestsTeeTypeWithTestServiceTypeSucceeds(t *testing.T) {
-	mockClient := new(mockEspressoTEEVerifier)
-	mockClient.On("ParentChainId").Return(uint64(1), nil)
-	mockClient.On("EspressoTEEAddress").Return(common.Address{})
-
-	_, signer, err := GetTransactOptsAndSigner("1234567890abcdef1234567890abcdef12345678000000000000000000000000", big.NewInt(1))
-	require.NoError(t, err)
-	dataSigner := func(data []byte) ([]byte, error) { return signer(data) }
-
-	require.NotPanics(t, func() {
-		espresso_key_manager.NewEspressoKeyManager(
-			mockClient, &dataposter.DataPoster{}, dataSigner,
-			espresso_key_manager.TESTS, espressotee.Test,
-			nil, "", "", 0,
-		)
-	})
-
-	require.NotPanics(t, func() {
-		espresso_key_manager.NewEspressoKeyManager(
-			mockClient, &dataposter.DataPoster{}, nil,
-			espresso_key_manager.TESTS, espressotee.Test,
-			nil, "", "", 0,
-		)
-	})
+	// TESTS + Test is the only valid test configuration (either signer flavor).
+	require.NotPanics(t, func() { newKM(dataSigner, espressotee.Test) })
+	require.NotPanics(t, func() { newKM(nil, espressotee.Test) })
 }
 
 func VerifySignatureWithPublicKey(publicKey *ecdsa.PublicKey, data []byte, signature []byte) (bool, error) {

--- a/espresso/key-manager/key_manager_test.go
+++ b/espresso/key-manager/key_manager_test.go
@@ -252,6 +252,58 @@ func TestEspressoKeyManager(t *testing.T) {
 	})
 }
 
+func TestEspressoKeyManagerTestsTeeTypeWithProductionServiceTypePanics(t *testing.T) {
+	mockClient := new(mockEspressoTEEVerifier)
+	mockClient.On("ParentChainId").Return(uint64(1), nil)
+	mockClient.On("EspressoTEEAddress").Return(common.Address{})
+
+	_, signer, err := GetTransactOptsAndSigner("1234567890abcdef1234567890abcdef12345678000000000000000000000000", big.NewInt(1))
+	require.NoError(t, err)
+	dataSigner := func(data []byte) ([]byte, error) { return signer(data) }
+
+	require.Panics(t, func() {
+		espresso_key_manager.NewEspressoKeyManager(
+			mockClient, &dataposter.DataPoster{}, dataSigner,
+			espresso_key_manager.TESTS, espressotee.BatchPoster,
+			nil, "", "", 0,
+		)
+	})
+
+	require.Panics(t, func() {
+		espresso_key_manager.NewEspressoKeyManager(
+			mockClient, &dataposter.DataPoster{}, nil,
+			espresso_key_manager.TESTS, espressotee.CaffNode,
+			nil, "", "", 0,
+		)
+	})
+}
+
+func TestEspressoKeyManagerTestsTeeTypeWithTestServiceTypeSucceeds(t *testing.T) {
+	mockClient := new(mockEspressoTEEVerifier)
+	mockClient.On("ParentChainId").Return(uint64(1), nil)
+	mockClient.On("EspressoTEEAddress").Return(common.Address{})
+
+	_, signer, err := GetTransactOptsAndSigner("1234567890abcdef1234567890abcdef12345678000000000000000000000000", big.NewInt(1))
+	require.NoError(t, err)
+	dataSigner := func(data []byte) ([]byte, error) { return signer(data) }
+
+	require.NotPanics(t, func() {
+		espresso_key_manager.NewEspressoKeyManager(
+			mockClient, &dataposter.DataPoster{}, dataSigner,
+			espresso_key_manager.TESTS, espressotee.Test,
+			nil, "", "", 0,
+		)
+	})
+
+	require.NotPanics(t, func() {
+		espresso_key_manager.NewEspressoKeyManager(
+			mockClient, &dataposter.DataPoster{}, nil,
+			espresso_key_manager.TESTS, espressotee.Test,
+			nil, "", "", 0,
+		)
+	})
+}
+
 func VerifySignatureWithPublicKey(publicKey *ecdsa.PublicKey, data []byte, signature []byte) (bool, error) {
 	hash := crypto.Keccak256Hash(data)
 

--- a/espressotee/espresso_tee_helpers.go
+++ b/espressotee/espresso_tee_helpers.go
@@ -6,10 +6,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/offchainlabs/nitro/arbnode/dataposter"
+	"github.com/offchainlabs/nitro/espresso-tee-contracts/espressogen"
 )
 
 type TEE uint8
@@ -93,4 +95,37 @@ func NonceValidation(context context.Context, l1Client *ethclient.Client, dataPo
 		return fmt.Errorf("dataposter nonce %d does not match on-chain nonce %d", dataPosterNonce, nonce)
 	}
 	return nil
+}
+
+// EncodeNitroMockVerifierJournalPublicKey returns ABI-encoded VerifierJournal bytes
+// with only PublicKey set; Nitro mock ignores the rest of the fields.
+func EncodeNitroMockVerifierJournalPublicKey(publicKey []byte) ([]byte, error) {
+	journalType, err := abi.NewType("tuple", "VerifierJournal", []abi.ArgumentMarshaling{
+		{Name: "result", Type: "uint8"},
+		{Name: "trustedCertsPrefixLen", Type: "uint8"},
+		{Name: "timestamp", Type: "uint64"},
+		{Name: "certs", Type: "bytes32[]"},
+		{Name: "userData", Type: "bytes"},
+		{Name: "nonce", Type: "bytes"},
+		{Name: "publicKey", Type: "bytes"},
+		{Name: "pcrs", Type: "tuple[]", Components: []abi.ArgumentMarshaling{
+			{Name: "index", Type: "uint64"},
+			{Name: "value", Type: "tuple", Components: []abi.ArgumentMarshaling{
+				{Name: "first", Type: "bytes32"},
+				{Name: "second", Type: "bytes16"},
+			}},
+		}},
+		{Name: "moduleId", Type: "string"},
+	})
+	if err != nil {
+		return nil, err
+	}
+	args := abi.Arguments{{Type: journalType}}
+	return args.Pack(espressogen.VerifierJournal{
+		Certs:     [][32]byte{},
+		UserData:  []byte{},
+		Nonce:     []byte{},
+		PublicKey: publicKey,
+		Pcrs:      []espressogen.Pcr{},
+	})
 }

--- a/system_tests/espresso_utils.go
+++ b/system_tests/espresso_utils.go
@@ -8,6 +8,7 @@ import (
 
 	hdwallet "github.com/miguelmota/go-ethereum-hdwallet"
 
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -81,10 +82,60 @@ func deployMockTEEContracts(t *testing.T, transactionOpts *bind.TransactOpts, cl
 		return common.Address{}, nil, nil, fmt.Errorf("failed to register Nitro test key: %w", err)
 	}
 
-	nitro, _, _, err := espressogen.DeployEspressoNitroTEEVerifierMock(transactionOpts, client)
+	nitro, nitroTx, nitroMock, err := espressogen.DeployEspressoNitroTEEVerifierMock(transactionOpts, client)
 	if err != nil {
 		return common.Address{}, nil, nil, fmt.Errorf("failed to deploy EspressoNitroTEEVerifierMock: %w", err)
 	}
+	_, err = bind.WaitDeployed(ctx, client, nitroTx)
+	if err != nil {
+		return common.Address{}, nil, nil, fmt.Errorf("failed to confirm EspressoNitroTEEVerifierMock deployment: %w", err)
+	}
+
+	// Pre-register for TESTS→NITRO key-manager mode.
+	journalBytes, err := encodeVerifierJournalPublicKey(crypto.FromECDSAPub(&privKey.PublicKey))
+	if err != nil {
+		return common.Address{}, nil, nil, fmt.Errorf("failed to encode VerifierJournal: %w", err)
+	}
+	_, err = nitroMock.RegisterService(transactionOpts, journalBytes, []byte{}, 0)
+	if err != nil {
+		return common.Address{}, nil, nil, fmt.Errorf("failed to register Nitro BatchPoster test key: %w", err)
+	}
+	_, err = nitroMock.RegisterService(transactionOpts, journalBytes, []byte{}, 1)
+	if err != nil {
+		return common.Address{}, nil, nil, fmt.Errorf("failed to register Nitro CaffNode test key: %w", err)
+	}
 
 	return espressogen.DeployEspressoTEEVerifierMock(transactionOpts, client, sgx, nitro)
+}
+
+// ABI-encoded VerifierJournal with only PublicKey set; NITRO mock ignores the rest.
+func encodeVerifierJournalPublicKey(publicKey []byte) ([]byte, error) {
+	journalType, err := abi.NewType("tuple", "VerifierJournal", []abi.ArgumentMarshaling{
+		{Name: "result", Type: "uint8"},
+		{Name: "trustedCertsPrefixLen", Type: "uint8"},
+		{Name: "timestamp", Type: "uint64"},
+		{Name: "certs", Type: "bytes32[]"},
+		{Name: "userData", Type: "bytes"},
+		{Name: "nonce", Type: "bytes"},
+		{Name: "publicKey", Type: "bytes"},
+		{Name: "pcrs", Type: "tuple[]", Components: []abi.ArgumentMarshaling{
+			{Name: "index", Type: "uint64"},
+			{Name: "value", Type: "tuple", Components: []abi.ArgumentMarshaling{
+				{Name: "first", Type: "bytes32"},
+				{Name: "second", Type: "bytes16"},
+			}},
+		}},
+		{Name: "moduleId", Type: "string"},
+	})
+	if err != nil {
+		return nil, err
+	}
+	args := abi.Arguments{{Type: journalType}}
+	return args.Pack(espressogen.VerifierJournal{
+		Certs:     [][32]byte{},
+		UserData:  []byte{},
+		Nonce:     []byte{},
+		PublicKey: publicKey,
+		Pcrs:      []espressogen.Pcr{},
+	})
 }

--- a/system_tests/espresso_utils.go
+++ b/system_tests/espresso_utils.go
@@ -2,13 +2,13 @@ package arbtest
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"fmt"
 	"sync/atomic"
 	"testing"
 
 	hdwallet "github.com/miguelmota/go-ethereum-hdwallet"
 
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -19,6 +19,7 @@ import (
 	"github.com/offchainlabs/nitro/arbnode"
 	"github.com/offchainlabs/nitro/espresso-tee-contracts/espressogen"
 	testutils "github.com/offchainlabs/nitro/espresso/test-utils"
+	"github.com/offchainlabs/nitro/espressotee"
 )
 
 func (b *BlockchainTestInfo) GenerateAccountWithMnemonic(name string, mnemonic string, idx uint) error {
@@ -91,51 +92,54 @@ func deployMockTEEContracts(t *testing.T, transactionOpts *bind.TransactOpts, cl
 		return common.Address{}, nil, nil, fmt.Errorf("failed to confirm EspressoNitroTEEVerifierMock deployment: %w", err)
 	}
 
-	// Pre-register for TESTS→NITRO key-manager mode.
-	journalBytes, err := encodeVerifierJournalPublicKey(crypto.FromECDSAPub(&privKey.PublicKey))
+	err = registerNitroMockBatchPosterTestKey(transactionOpts, nitroMock, privKey)
 	if err != nil {
-		return common.Address{}, nil, nil, fmt.Errorf("failed to encode VerifierJournal: %w", err)
+		return common.Address{}, nil, nil, err
 	}
-	_, err = nitroMock.RegisterService(transactionOpts, journalBytes, []byte{}, 0)
+	err = registerNitroMockCaffNodeTestKey(transactionOpts, nitroMock, privKey)
 	if err != nil {
-		return common.Address{}, nil, nil, fmt.Errorf("failed to register Nitro BatchPoster test key: %w", err)
-	}
-	_, err = nitroMock.RegisterService(transactionOpts, journalBytes, []byte{}, 1)
-	if err != nil {
-		return common.Address{}, nil, nil, fmt.Errorf("failed to register Nitro CaffNode test key: %w", err)
+		return common.Address{}, nil, nil, err
 	}
 
 	return espressogen.DeployEspressoTEEVerifierMock(transactionOpts, client, sgx, nitro)
 }
 
-// ABI-encoded VerifierJournal with only PublicKey set; NITRO mock ignores the rest.
-func encodeVerifierJournalPublicKey(publicKey []byte) ([]byte, error) {
-	journalType, err := abi.NewType("tuple", "VerifierJournal", []abi.ArgumentMarshaling{
-		{Name: "result", Type: "uint8"},
-		{Name: "trustedCertsPrefixLen", Type: "uint8"},
-		{Name: "timestamp", Type: "uint64"},
-		{Name: "certs", Type: "bytes32[]"},
-		{Name: "userData", Type: "bytes"},
-		{Name: "nonce", Type: "bytes"},
-		{Name: "publicKey", Type: "bytes"},
-		{Name: "pcrs", Type: "tuple[]", Components: []abi.ArgumentMarshaling{
-			{Name: "index", Type: "uint64"},
-			{Name: "value", Type: "tuple", Components: []abi.ArgumentMarshaling{
-				{Name: "first", Type: "bytes32"},
-				{Name: "second", Type: "bytes16"},
-			}},
-		}},
-		{Name: "moduleId", Type: "string"},
-	})
+func registerNitroMockBatchPosterTestKey(
+	transactionOpts *bind.TransactOpts,
+	nitroMock *espressogen.EspressoNitroTEEVerifierMock,
+	privKey *ecdsa.PrivateKey,
+) error {
+	journalBytes, err := encodeNitroMockBatchPosterVerifierJournalPublicKey(crypto.FromECDSAPub(&privKey.PublicKey))
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("failed to encode Nitro mock VerifierJournal for batch poster: %w", err)
 	}
-	args := abi.Arguments{{Type: journalType}}
-	return args.Pack(espressogen.VerifierJournal{
-		Certs:     [][32]byte{},
-		UserData:  []byte{},
-		Nonce:     []byte{},
-		PublicKey: publicKey,
-		Pcrs:      []espressogen.Pcr{},
-	})
+	_, err = nitroMock.RegisterService(transactionOpts, journalBytes, []byte{}, uint8(espressotee.BatchPoster))
+	if err != nil {
+		return fmt.Errorf("failed to register Nitro mock batch poster test key: %w", err)
+	}
+	return nil
+}
+
+func registerNitroMockCaffNodeTestKey(
+	transactionOpts *bind.TransactOpts,
+	nitroMock *espressogen.EspressoNitroTEEVerifierMock,
+	privKey *ecdsa.PrivateKey,
+) error {
+	journalBytes, err := encodeNitroMockCaffNodeVerifierJournalPublicKey(crypto.FromECDSAPub(&privKey.PublicKey))
+	if err != nil {
+		return fmt.Errorf("failed to encode Nitro mock VerifierJournal for caff node: %w", err)
+	}
+	_, err = nitroMock.RegisterService(transactionOpts, journalBytes, []byte{}, uint8(espressotee.CaffNode))
+	if err != nil {
+		return fmt.Errorf("failed to register Nitro mock caff node test key: %w", err)
+	}
+	return nil
+}
+
+func encodeNitroMockBatchPosterVerifierJournalPublicKey(publicKey []byte) ([]byte, error) {
+	return espressotee.EncodeNitroMockVerifierJournalPublicKey(publicKey)
+}
+
+func encodeNitroMockCaffNodeVerifierJournalPublicKey(publicKey []byte) ([]byte, error) {
+	return espressotee.EncodeNitroMockVerifierJournalPublicKey(publicKey)
 }


### PR DESCRIPTION
## Summary
Address audit finding where a production node misconfigured with `TeeType: "TESTS"` would silently register the well-known test private key on-chain as SGX-attested with no real attestation.

## Why not the literal audit recommendation?
The audit recommended aborting startup on the combination `TESTS + non-Test serviceType`. We couldn't take that literally because:

- The on-chain `EspressoTEEVerifier` only accepts `serviceType` values `BatchPoster` (0) and `CaffNode` (1). It rejects `Test` (255). So we can't simply pass `Test` to the contract in place of the production service type.
- E2E tests intentionally run with `TeeType="TESTS"` and exercise the real batch poster / caff node code paths, which must issue valid on-chain registration calls.

## Design
- Callers (`batch_poster.go`, `espresso_caff_node.go`) convert `TESTS → Test` before constructing the key manager, making the test intent explicit.
- The constructor panics on `TESTS + non-Test serviceType` which is the audit guard.
- Two computed helpers `onChainTeeType()` and `onChainServiceType()` translate `TESTS → SGX` and infer the production service type (batch posters have a signer, caff nodes don't).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213739697090140